### PR TITLE
chore: update all repo references to SableClient/Sable

### DIFF
--- a/.changeset/chore-update-repo-references.md
+++ b/.changeset/chore-update-repo-references.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Update all in-app links and references from `7w1/sable` to `SableClient/Sable`.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         ## First of all
-        1. Please search for [existing issues](https://github.com/7w1/sable/issues?q=is%3Aissue) about this problem first.
+        1. Please search for [existing issues](https://github.com/SableClient/Sable/issues?q=is%3Aissue) about this problem first.
         2. Make sure Sable is up to date.
         3. Make sure it's an issue with Sable and not something else you are using.
         4. Remember to be friendly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ All types of contributions are encouraged and valued. Please make sure to read t
 
 ## Bug reports
 
-Bug reports and feature suggestions must use descriptive and concise titles and be submitted to [GitHub Issues](https://github.com/7w1/sable/issues). Please use the search function to make sure that you are not submitting duplicates, and that a similar report or request has not already been resolved or rejected.
+Bug reports and feature suggestions must use descriptive and concise titles and be submitted to [GitHub Issues](https://github.com/SableClient/Sable/issues). Please use the search function to make sure that you are not submitting duplicates, and that a similar report or request has not already been resolved or rejected.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sable
 
-A Matrix client built to enhance the user experience with quality-of-life features, cosmetics, utilities, and sheer usability. See the [changelog](https://github.com/7w1/sable/blob/dev/CHANGELOG.md).
+A Matrix client built to enhance the user experience with quality-of-life features, cosmetics, utilities, and sheer usability. See the [changelog](https://github.com/SableClient/Sable/blob/dev/CHANGELOG.md).
 
 Join our matrix space [here](https://matrix.to/#/#sable:sable.moe) to discuss features, issues, or meowing.
 
@@ -9,7 +9,7 @@ Forked from [Cinny](https://github.com/cinnyapp/cinny/).
 ## Getting started
 The web app is available at [app.sable.moe](https://app.sable.moe/) and gets updated on frequently, as soon as a feature is deemed stable.
 
-You can also download our desktop app for windows and linux from [releases](https://github.com/7w1/sable/releases/latest).
+You can also download our desktop app for windows and linux from [releases](https://github.com/SableClient/Sable/releases/latest).
 
 ## Self-hosting
 You have a few options for self hosting, you can:
@@ -19,7 +19,7 @@ You have a few options for self hosting, you can:
 
 ### Docker
 
-Prebuilt images are published to `ghcr.io/7w1/sable`.
+Prebuilt images are published to `ghcr.io/sableclient/sable`.
 
 - `latest` tracks the current `dev` branch image.
 - `X.Y.Z` tags are versioned releases.
@@ -29,7 +29,7 @@ Prebuilt images are published to `ghcr.io/7w1/sable`.
 Run the latest image with:
 
 ```sh
-docker run --rm -p 8080:8080 ghcr.io/7w1/sable:latest
+docker run --rm -p 8080:8080 ghcr.io/sableclient/sable:latest
 ```
 
 Then open `http://localhost:8080`.
@@ -40,7 +40,7 @@ file at `/app/config.json`:
 ```yaml
 services:
   sable:
-    image: ghcr.io/7w1/sable:latest
+    image: ghcr.io/sableclient/sable:latest
     ports:
       - '8080:8080'
     volumes:

--- a/knope.toml
+++ b/knope.toml
@@ -37,8 +37,8 @@ help_text = "Create a new change file to be included in the next release"
 type = "CreateChangeFile"
 
 [github]
-owner = "7w1"
-repo = "sable"
+owner = "SableClient"
+repo = "Sable"
 
 [bot.releases]
 enabled = true

--- a/src/app/features/settings/about/About.tsx
+++ b/src/app/features/settings/about/About.tsx
@@ -190,7 +190,7 @@ export function About({ requestClose }: AboutProps) {
                   <Box gap="200" wrap="Wrap">
                     <Button
                       as="a"
-                      href="https://github.com/7w1/sable"
+                      href="https://github.com/SableClient/Sable"
                       rel="noreferrer noopener"
                       target="_blank"
                       variant="Secondary"
@@ -203,7 +203,7 @@ export function About({ requestClose }: AboutProps) {
                     </Button>
                     <Button
                       as="a"
-                      href="https://github.com/7w1/sable/pulls"
+                      href="https://github.com/SableClient/Sable/pulls"
                       rel="noreferrer noopener"
                       target="_blank"
                       variant="Critical"

--- a/src/app/pages/auth/AuthFooter.tsx
+++ b/src/app/pages/auth/AuthFooter.tsx
@@ -10,7 +10,7 @@ export function AuthFooter() {
       <Text
         as="a"
         size="T300"
-        href="https://github.com/7w1/sable/"
+        href="https://github.com/SableClient/Sable"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -18,7 +18,11 @@ export function WelcomePage() {
             subTitle={
               <span>
                 Yet another matrix client fork.{' '}
-                <a href="https://github.com/SableClient/Sable" target="_blank" rel="noreferrer noopener">
+                <a
+                  href="https://github.com/SableClient/Sable"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
                   {`v${APP_VERSION}${IS_RELEASE_TAG ? '' : `-dev${BUILD_HASH ? ` (${BUILD_HASH})` : ''}`}`}
                 </a>
               </span>

--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -18,7 +18,7 @@ export function WelcomePage() {
             subTitle={
               <span>
                 Yet another matrix client fork.{' '}
-                <a href="https://github.com/7w1/sable" target="_blank" rel="noreferrer noopener">
+                <a href="https://github.com/SableClient/Sable" target="_blank" rel="noreferrer noopener">
                   {`v${APP_VERSION}${IS_RELEASE_TAG ? '' : `-dev${BUILD_HASH ? ` (${BUILD_HASH})` : ''}`}`}
                 </a>
               </span>
@@ -28,7 +28,7 @@ export function WelcomePage() {
               <Box grow="Yes" style={{ maxWidth: toRem(300) }} direction="Column" gap="300">
                 <Button
                   as="a"
-                  href="https://github.com/7w1/sable"
+                  href="https://github.com/SableClient/Sable"
                   target="_blank"
                   rel="noreferrer noopener"
                   before={<Icon size="200" src={Icons.Code} />}
@@ -40,7 +40,7 @@ export function WelcomePage() {
                 {/*
                 <Button
                   as="a"
-                  href="https://github.com/7w1/sable"
+                  href="https://github.com/SableClient/Sable"
                   target="_blank"
                   rel="noreferrer noopener"
                   fill="Soft"
@@ -56,7 +56,7 @@ export function WelcomePage() {
             <Box direction="Column" gap="200" alignItems="Center">
               <Button
                 as="a"
-                href="https://github.com/7w1/sable/blob/dev/CHANGELOG.md"
+                href="https://github.com/SableClient/Sable/blob/dev/CHANGELOG.md"
                 target="_blank"
                 rel="noreferrer noopener"
                 before={<Icon size="200" src={Icons.Code} />}


### PR DESCRIPTION
The project has moved from `github.com/7w1/sable` to `github.com/SableClient/Sable`. Update all non-historical references throughout the codebase:

- `README.md`: github.com and ghcr.io links
- `CONTRIBUTING.md`: issues link
- `.github/ISSUE_TEMPLATE/bug_report.yml`: existing-issues search link
- `knope.toml`: owner/repo for release automation
- `src/app/features/settings/about/About.tsx`: repo + pulls links
- `src/app/pages/auth/AuthFooter.tsx`: repo link
- `src/app/pages/client/WelcomePage.tsx`: source + changelog links

Historical PR/issue links in `CHANGELOG.md` and issue-specific deep-links (e.g. `github.com/7w1/sable/issues/146`) are intentionally left pointing to the old repo where those items live.

Note: `BugReportModal.tsx` also references the repo URL but that file is introduced in a separate PR — the correct URL will be included there.
