### PR TITLE
Feat: Option for showing a message's edit history

### DIFF
--- a/.changeset/added_message_history.md
+++ b/.changeset/added_message_history.md
@@ -2,4 +2,4 @@
 sable: minor
 ---
 
-Added a pop-up for showing a message's history
+Added a pop-up for showing a message's edit history

--- a/.changeset/added_message_history.md
+++ b/.changeset/added_message_history.md
@@ -1,0 +1,5 @@
+---
+sable: minor
+---
+
+Added a pop-up for showing a message's history

--- a/src/app/components/event-history/EventHistory.css.ts
+++ b/src/app/components/event-history/EventHistory.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { DefaultReset, config } from 'folds';
+import { DefaultReset, color, config } from 'folds';
 
 export const EventHistory = style([
   DefaultReset,
@@ -18,4 +18,16 @@ export const Header = style({
 export const Content = style({
   paddingLeft: config.space.S200,
   paddingBottom: config.space.S400,
+});
+export const EventItem = style({
+  padding: `${config.space.S200} ${config.space.S200}`,
+  height: 'unset',
+  borderRadius: '5px',
+  border: '2px hidden',
+  borderColor: color.Secondary.Main,
+  selectors: {
+    '&:hover': {
+      border: '2px solid',
+    },
+  },
 });

--- a/src/app/components/event-history/EventHistory.css.ts
+++ b/src/app/components/event-history/EventHistory.css.ts
@@ -24,10 +24,10 @@ export const EventItem = style({
   height: 'unset',
   borderRadius: '5px',
   border: '2px hidden',
-  borderColor: color.Secondary.Main,
+  backgroundColor: 'inherit',
   selectors: {
     '&:hover': {
-      border: '2px solid',
+      backgroundColor: color.Surface.ContainerHover,
     },
   },
 });

--- a/src/app/components/event-history/EventHistory.css.ts
+++ b/src/app/components/event-history/EventHistory.css.ts
@@ -1,0 +1,21 @@
+import { style } from '@vanilla-extract/css';
+import { DefaultReset, config } from 'folds';
+
+export const EventHistory = style([
+  DefaultReset,
+  {
+    height: '100%',
+  },
+]);
+
+export const Header = style({
+  paddingLeft: config.space.S400,
+  paddingRight: config.space.S300,
+
+  flexShrink: 0,
+});
+
+export const Content = style({
+  paddingLeft: config.space.S200,
+  paddingBottom: config.space.S400,
+});

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -75,7 +75,8 @@ export const EventHistory = as<'div', EventHistoryProps>(
             style={{
               display: 'flex',
               justifyContent: 'center',
-              padding: `0 ${config.space.S200}`,
+              padding: `${config.space.S200} ${config.space.S200}`,
+              height: 'unset',
             }}
             radii="400"
             onClick={(event) => {
@@ -110,7 +111,10 @@ export const EventHistory = as<'div', EventHistoryProps>(
                 return (
                   <MenuItem
                     key={readerId}
-                    style={{ padding: `0 ${config.space.S200}` }}
+                    style={{
+                      padding: `${config.space.S200} ${config.space.S200}`,
+                      height: 'unset',
+                    }}
                     radii="400"
                     before={
                       <Time

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -10,6 +10,7 @@ import {
   Scroll,
   Text,
   as,
+  color,
   config,
 } from 'folds';
 import { MatrixEvent, Room } from '$types/matrix-sdk';
@@ -125,25 +126,28 @@ export const EventHistory = as<'div', EventHistoryProps>(
                 if (!mEvent.event.sender) return <div />;
                 const EventContent = mEvent.getOriginalContent();
                 return (
-                  <Box className={css.EventItem}>
-                    <Time
-                      ts={mEvent.getTs()}
-                      hour24Clock={hour24Clock}
-                      dateFormatString={dateFormatString}
-                    />
-                    <Text size="T400" style={{ paddingLeft: '10px', wordBreak: 'break-word' }}>
-                      <RenderBody
-                        body={EventContent?.['m.new_content']?.body ?? EventContent?.body ?? ''}
-                        customBody={
-                          EventContent?.['m.new_content']?.formatted_body ??
-                          EventContent?.formatted_body ??
-                          ''
-                        }
-                        htmlReactParserOptions={htmlReactParserOptions}
-                        linkifyOpts={linkifyOpts}
+                  <>
+                    <hr style={{ width: '100%', color: color.Surface.ContainerLine }} />
+                    <Box className={css.EventItem}>
+                      <Time
+                        ts={mEvent.getTs()}
+                        hour24Clock={hour24Clock}
+                        dateFormatString={dateFormatString}
                       />
-                    </Text>
-                  </Box>
+                      <Text size="T400" style={{ paddingLeft: '10px', wordBreak: 'break-word' }}>
+                        <RenderBody
+                          body={EventContent?.['m.new_content']?.body ?? EventContent?.body ?? ''}
+                          customBody={
+                            EventContent?.['m.new_content']?.formatted_body ??
+                            EventContent?.formatted_body ??
+                            ''
+                          }
+                          htmlReactParserOptions={htmlReactParserOptions}
+                          linkifyOpts={linkifyOpts}
+                        />
+                      </Text>
+                    </Box>
+                  </>
                 );
               })}
             </Box>

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -23,9 +23,14 @@ import { getMouseEventCords } from '$utils/dom';
 import { useAtomValue } from 'jotai';
 import { nicknamesAtom } from '$state/nicknames';
 import { UserAvatar } from '$components/user-avatar';
-import { Time } from '$components/message';
+import { RenderBody, Time } from '$components/message';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
+import { useMemo } from 'react';
+import { getReactCustomHtmlParser, LINKIFY_OPTS } from '$plugins/react-custom-html-parser';
+import { Opts as LinkifyOpts } from 'linkifyjs';
+import { HTMLReactParserOptions } from 'html-react-parser';
+import { useSpoilerClickHandler } from '$hooks/useSpoilerClickHandler';
 import * as css from './EventHistory.css';
 
 export type EventHistoryProps = {
@@ -54,6 +59,17 @@ export const EventHistory = as<'div', EventHistoryProps>(
     const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
     const [dateFormatString] = useSetting(settingsAtom, 'dateFormatString');
 
+    const linkifyOpts = useMemo<LinkifyOpts>(() => ({ ...LINKIFY_OPTS }), []);
+    const spoilerClickHandler = useSpoilerClickHandler();
+    const htmlReactParserOptions = useMemo<HTMLReactParserOptions>(
+      () =>
+        getReactCustomHtmlParser(mx, mEvents[0].getRoomId(), {
+          linkifyOpts,
+          useAuthentication,
+          handleSpoilerClick: spoilerClickHandler,
+        }),
+      [linkifyOpts, mEvents, mx, spoilerClickHandler, useAuthentication]
+    );
     return (
       <Box
         className={classNames(css.EventHistory, className)}
@@ -102,7 +118,7 @@ export const EventHistory = as<'div', EventHistoryProps>(
             <Text size="T400">{name}</Text>
           </MenuItem>
         </Header>
-        <Box grow="Yes">
+        <Box grow="Yes" style={{ overflow: 'scroll' }}>
           <Scroll visibility="Hover">
             <Box className={css.Content} direction="Column">
               {mEvents.map((mEvent) => {
@@ -124,10 +140,21 @@ export const EventHistory = as<'div', EventHistoryProps>(
                       />
                     }
                   >
-                    <Text size="T400">
-                      {mEvent?.event?.content?.['m.new_content']?.body ??
-                        mEvent.event?.content?.body ??
-                        ''}
+                    <Text size="T400" style={{ wordBreak: 'break-word' }}>
+                      <RenderBody
+                        body={
+                          mEvent?.event?.content?.['m.new_content']?.body ??
+                          mEvent.event?.content?.body ??
+                          ''
+                        }
+                        customBody={
+                          mEvent?.event?.content?.['m.new_content']?.formatted_body ??
+                          mEvent.event?.content?.formatted_body ??
+                          ''
+                        }
+                        htmlReactParserOptions={htmlReactParserOptions}
+                        linkifyOpts={linkifyOpts}
+                      />
                     </Text>
                   </MenuItem>
                 );

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -123,7 +123,7 @@ export const EventHistory = as<'div', EventHistoryProps>(
             <Box className={css.Content} direction="Column">
               {mEvents.map((mEvent) => {
                 if (!mEvent.event.sender) return <div />;
-
+                const EventContent = mEvent.getOriginalContent();
                 return (
                   <Box className={css.EventItem}>
                     <Time
@@ -133,14 +133,10 @@ export const EventHistory = as<'div', EventHistoryProps>(
                     />
                     <Text size="T400" style={{ paddingLeft: '10px', wordBreak: 'break-word' }}>
                       <RenderBody
-                        body={
-                          mEvent?.event?.content?.['m.new_content']?.body ??
-                          mEvent.event?.content?.body ??
-                          ''
-                        }
+                        body={EventContent?.['m.new_content']?.body ?? EventContent?.body ?? ''}
                         customBody={
-                          mEvent?.event?.content?.['m.new_content']?.formatted_body ??
-                          mEvent.event?.content?.formatted_body ??
+                          EventContent?.['m.new_content']?.formatted_body ??
+                          EventContent?.formatted_body ??
                           ''
                         }
                         htmlReactParserOptions={htmlReactParserOptions}

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -1,0 +1,116 @@
+import classNames from 'classnames';
+import {
+  Avatar,
+  Box,
+  Header,
+  Icon,
+  IconButton,
+  Icons,
+  MenuItem,
+  Scroll,
+  Text,
+  as,
+  config,
+} from 'folds';
+import { MatrixEvent, Room } from '$types/matrix-sdk';
+import { getMemberDisplayName } from '$utils/room';
+import { getMxIdLocalPart } from '$utils/matrix';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import { useOpenUserRoomProfile } from '$state/hooks/userRoomProfile';
+import { useSpaceOptionally } from '$hooks/useSpace';
+import { getMouseEventCords } from '$utils/dom';
+import { useAtomValue } from 'jotai';
+import { nicknamesAtom } from '$state/nicknames';
+import { UserAvatar } from '$components/user-avatar';
+import * as css from './EventHistory.css';
+
+export type EventHistoryProps = {
+  room: Room;
+  mEvents: MatrixEvent[];
+  requestClose: () => void;
+};
+export const EventHistory = as<'div', EventHistoryProps>(
+  ({ className, room, mEvents, requestClose, ...props }, ref) => {
+    const mx = useMatrixClient();
+    const useAuthentication = useMediaAuthentication();
+    const openProfile = useOpenUserRoomProfile();
+    const space = useSpaceOptionally();
+    const nicknames = useAtomValue(nicknamesAtom);
+
+    const getName = (userId: string) =>
+      getMemberDisplayName(room, userId, nicknames) ?? getMxIdLocalPart(userId) ?? userId;
+
+    return (
+      <Box
+        className={classNames(css.EventHistory, className)}
+        direction="Column"
+        {...props}
+        ref={ref}
+      >
+        <Header className={css.Header} variant="Surface" size="600">
+          <Box grow="Yes">
+            <Text size="H3">Message version history</Text>
+          </Box>
+          <IconButton size="300" onClick={requestClose}>
+            <Icon src={Icons.Cross} />
+          </IconButton>
+        </Header>
+        <Box grow="Yes">
+          <Scroll visibility="Hover" hideTrack size="300">
+            <Box className={css.Content} direction="Column">
+              {mEvents.map((mEvent) => {
+                if (!mEvent.event.sender) return <div />;
+                const readerId = mEvent.event.sender;
+                const name = getName(readerId);
+                const avatarMxcUrl = room.getMember(readerId)?.getMxcAvatarUrl();
+                const avatarUrl = avatarMxcUrl
+                  ? mx.mxcUrlToHttp(
+                      avatarMxcUrl,
+                      100,
+                      100,
+                      'crop',
+                      undefined,
+                      false,
+                      useAuthentication
+                    )
+                  : undefined;
+
+                return (
+                  <MenuItem
+                    key={readerId}
+                    style={{ padding: `0 ${config.space.S200}` }}
+                    radii="400"
+                    onClick={(event) => {
+                      openProfile(
+                        room.roomId,
+                        space?.roomId,
+                        readerId,
+                        getMouseEventCords(event.nativeEvent),
+                        'Bottom'
+                      );
+                    }}
+                    before={
+                      <Avatar size="200">
+                        <UserAvatar
+                          userId={readerId}
+                          src={avatarUrl ?? undefined}
+                          alt={name}
+                          renderFallback={() => <Icon size="50" src={Icons.User} filled />}
+                        />
+                      </Avatar>
+                    }
+                  >
+                    <Text size="T400" truncate>
+                      {name}·{mEvent.event?.content?.body ?? ''}
+                    </Text>
+                  </MenuItem>
+                );
+              })}
+            </Box>
+          </Scroll>
+        </Box>
+      </Box>
+    );
+  }
+);

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -23,6 +23,9 @@ import { getMouseEventCords } from '$utils/dom';
 import { useAtomValue } from 'jotai';
 import { nicknamesAtom } from '$state/nicknames';
 import { UserAvatar } from '$components/user-avatar';
+import { Time } from '$components/message';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
 import * as css from './EventHistory.css';
 
 export type EventHistoryProps = {
@@ -41,6 +44,16 @@ export const EventHistory = as<'div', EventHistoryProps>(
     const getName = (userId: string) =>
       getMemberDisplayName(room, userId, nicknames) ?? getMxIdLocalPart(userId) ?? userId;
 
+    const readerId = mEvents[0].event.sender ?? '';
+    const name = getName(readerId ?? '');
+    const avatarMxcUrl = room.getMember(readerId ?? '')?.getMxcAvatarUrl();
+    const avatarUrl = avatarMxcUrl
+      ? mx.mxcUrlToHttp(avatarMxcUrl, 100, 100, 'crop', undefined, false, useAuthentication)
+      : undefined;
+
+    const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
+    const [dateFormatString] = useSetting(settingsAtom, 'dateFormatString');
+
     return (
       <Box
         className={classNames(css.EventHistory, className)}
@@ -56,53 +69,61 @@ export const EventHistory = as<'div', EventHistoryProps>(
             <Icon src={Icons.Cross} />
           </IconButton>
         </Header>
+        <Header>
+          <MenuItem
+            key={readerId}
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              padding: `0 ${config.space.S200}`,
+            }}
+            radii="400"
+            onClick={(event) => {
+              openProfile(
+                room.roomId,
+                space?.roomId,
+                readerId,
+                getMouseEventCords(event.nativeEvent),
+                'Bottom'
+              );
+            }}
+            before={
+              <Avatar size="300">
+                <UserAvatar
+                  userId={readerId ?? ''}
+                  src={avatarUrl ?? undefined}
+                  alt={name}
+                  renderFallback={() => <Icon size="50" src={Icons.User} filled />}
+                />
+              </Avatar>
+            }
+          >
+            <Text size="T400">{name}</Text>
+          </MenuItem>
+        </Header>
         <Box grow="Yes">
-          <Scroll visibility="Hover" hideTrack size="300">
+          <Scroll visibility="Hover">
             <Box className={css.Content} direction="Column">
               {mEvents.map((mEvent) => {
                 if (!mEvent.event.sender) return <div />;
-                const readerId = mEvent.event.sender;
-                const name = getName(readerId);
-                const avatarMxcUrl = room.getMember(readerId)?.getMxcAvatarUrl();
-                const avatarUrl = avatarMxcUrl
-                  ? mx.mxcUrlToHttp(
-                      avatarMxcUrl,
-                      100,
-                      100,
-                      'crop',
-                      undefined,
-                      false,
-                      useAuthentication
-                    )
-                  : undefined;
 
                 return (
                   <MenuItem
                     key={readerId}
                     style={{ padding: `0 ${config.space.S200}` }}
                     radii="400"
-                    onClick={(event) => {
-                      openProfile(
-                        room.roomId,
-                        space?.roomId,
-                        readerId,
-                        getMouseEventCords(event.nativeEvent),
-                        'Bottom'
-                      );
-                    }}
                     before={
-                      <Avatar size="200">
-                        <UserAvatar
-                          userId={readerId}
-                          src={avatarUrl ?? undefined}
-                          alt={name}
-                          renderFallback={() => <Icon size="50" src={Icons.User} filled />}
-                        />
-                      </Avatar>
+                      <Time
+                        ts={mEvent.getTs()}
+                        hour24Clock={hour24Clock}
+                        dateFormatString={dateFormatString}
+                      />
                     }
                   >
-                    <Text size="T400" truncate>
-                      {name}·{mEvent.event?.content?.body ?? ''}
+                    <Text size="T400">
+                      {mEvent?.event?.content?.['m.new_content']?.body ??
+                        mEvent.event?.content?.body ??
+                        ''}
                     </Text>
                   </MenuItem>
                 );

--- a/src/app/components/event-history/EventHistory.tsx
+++ b/src/app/components/event-history/EventHistory.tsx
@@ -125,22 +125,13 @@ export const EventHistory = as<'div', EventHistoryProps>(
                 if (!mEvent.event.sender) return <div />;
 
                 return (
-                  <MenuItem
-                    key={readerId}
-                    style={{
-                      padding: `${config.space.S200} ${config.space.S200}`,
-                      height: 'unset',
-                    }}
-                    radii="400"
-                    before={
-                      <Time
-                        ts={mEvent.getTs()}
-                        hour24Clock={hour24Clock}
-                        dateFormatString={dateFormatString}
-                      />
-                    }
-                  >
-                    <Text size="T400" style={{ wordBreak: 'break-word' }}>
+                  <Box className={css.EventItem}>
+                    <Time
+                      ts={mEvent.getTs()}
+                      hour24Clock={hour24Clock}
+                      dateFormatString={dateFormatString}
+                    />
+                    <Text size="T400" style={{ paddingLeft: '10px', wordBreak: 'break-word' }}>
                       <RenderBody
                         body={
                           mEvent?.event?.content?.['m.new_content']?.body ??
@@ -156,7 +147,7 @@ export const EventHistory = as<'div', EventHistoryProps>(
                         linkifyOpts={linkifyOpts}
                       />
                     </Text>
-                  </MenuItem>
+                  </Box>
                 );
               })}
             </Box>

--- a/src/app/components/event-history/index.ts
+++ b/src/app/components/event-history/index.ts
@@ -1,0 +1,1 @@
+export * from './EventHistory';

--- a/src/app/components/message/modals/GlobalModalManager.tsx
+++ b/src/app/components/message/modals/GlobalModalManager.tsx
@@ -5,6 +5,7 @@ import { stopPropagation } from '$utils/keyboard';
 import { modalAtom, ModalType } from '$state/modal';
 import { MessageReportInternal } from './MessageReport';
 import { MessageDeleteInternal } from './MessageDelete';
+import { MessageEditHistoryInternal } from './MessageEditHistory';
 import { MessageSourceInternal } from './MessageSource';
 import { MessageForwardInternal } from './MessageForward';
 import { MessageAllReactionInternal } from './MessageReactions';
@@ -58,6 +59,16 @@ export function GlobalModalManager() {
                 <MessageAllReactionInternal
                   room={modal.room}
                   relations={modal.relations}
+                  onClose={close}
+                />
+              </Modal>
+            )}
+
+            {modal.type === ModalType.EditHistory && (
+              <Modal variant="Surface" size="300">
+                <MessageEditHistoryInternal
+                  room={modal.room}
+                  mEvent={modal.mEvent}
                   onClose={close}
                 />
               </Modal>

--- a/src/app/components/message/modals/MessageEditHistory.tsx
+++ b/src/app/components/message/modals/MessageEditHistory.tsx
@@ -50,6 +50,7 @@ export function MessageEditHistoryInternal({
       evtTimeline &&
       getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
     if (!edits) return [mEvent];
+    edits.sort((a, b) => a.getTs() - b.getTs());
     return [mEvent, ...edits];
   };
 

--- a/src/app/components/message/modals/MessageEditHistory.tsx
+++ b/src/app/components/message/modals/MessageEditHistory.tsx
@@ -52,7 +52,6 @@ export function MessageEditHistoryInternal({
     if (!edits) return [mEvent];
     return [mEvent, ...edits];
   };
-  // console.log(getEvents().map((m) => m.event.content));
 
   return <EventHistory room={room} mEvents={getEvents()} requestClose={onClose} />;
 }

--- a/src/app/components/message/modals/MessageEditHistory.tsx
+++ b/src/app/components/message/modals/MessageEditHistory.tsx
@@ -1,0 +1,58 @@
+import { MouseEvent } from 'react';
+import { Room, MatrixEvent } from '$types/matrix-sdk';
+import { useSetAtom } from 'jotai';
+import { MenuItem, Icon, Icons, Text } from 'folds';
+import { getEventEdits } from '$utils/room';
+import { modalAtom, ModalType } from '$state/modal';
+import * as css from '$features/room/message/styles.css';
+import { EventHistory } from '$components/event-history';
+
+export function MessageEditHistoryItem({ room, mEvent }: { room: Room; mEvent: MatrixEvent }) {
+  const setModal = useSetAtom(modalAtom);
+
+  return (
+    <MenuItem
+      size="300"
+      after={<Icon size="100" src={Icons.Clock} />}
+      radii="300"
+      onClick={(e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setModal({
+          type: ModalType.EditHistory,
+          room,
+          mEvent,
+        });
+      }}
+    >
+      <Text className={css.MessageMenuItemText} as="span" size="T300" truncate>
+        Version History
+      </Text>
+    </MenuItem>
+  );
+}
+
+type MessageEditHistoryInternalProps = {
+  room: Room;
+  mEvent: MatrixEvent;
+  onClose: () => void;
+};
+
+export function MessageEditHistoryInternal({
+  room,
+  mEvent,
+  onClose,
+}: MessageEditHistoryInternalProps) {
+  const getEvents = (): MatrixEvent[] => {
+    const evtId = mEvent.getId()!;
+    const evtTimeline = room.getTimelineForEvent(evtId);
+    const edits =
+      evtTimeline &&
+      getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
+    if (!edits) return [mEvent];
+    return [mEvent, ...edits];
+  };
+  // console.log(getEvents().map((m) => m.event.content));
+
+  return <EventHistory room={room} mEvents={getEvents()} requestClose={onClose} />;
+}

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -74,6 +74,7 @@ import { useSetting } from '$state/hooks/settings';
 import { useBlobCache } from '$hooks/useBlobCache';
 import { MessageAllReactionItem } from '$components/message/modals/MessageReactions';
 import { MessageReadReceiptItem } from '$components/message/modals/MessageReadRecipts';
+import { MessageEditHistoryItem } from '$components/message/modals/MessageEditHistory';
 import { MessageSourceCodeItem } from '$components/message/modals/MessageSource';
 import { MessageForwardItem } from '$components/message/modals/MessageForward';
 import { MessageDeleteItem } from '$components/message/modals/MessageDelete';
@@ -852,6 +853,7 @@ function MessageInternal(
                         {!hideReadReceipts && (
                           <MessageReadReceiptItem room={room} eventId={mEvent.getId() ?? ''} />
                         )}
+                        <MessageEditHistoryItem room={room} mEvent={mEvent} />
                         {showDeveloperTools && (
                           <MessageSourceCodeItem room={room} mEvent={mEvent} />
                         )}
@@ -1146,6 +1148,7 @@ export const Event = as<'div', EventProps>(
                             {!hideReadReceipts && (
                               <MessageReadReceiptItem room={room} eventId={mEvent.getId() ?? ''} />
                             )}
+                            <MessageEditHistoryItem room={room} mEvent={mEvent} />
                             {showDeveloperTools && (
                               <MessageSourceCodeItem room={room} mEvent={mEvent} />
                             )}

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -49,7 +49,7 @@ import {
   Username,
   UsernameBold,
 } from '$components/message';
-import { canEditEvent, getMemberAvatarMxc } from '$utils/room';
+import { canEditEvent, getEventEdits, getMemberAvatarMxc } from '$utils/room';
 import { mxcUrlToHttp } from '$utils/matrix';
 import { getSettings, MessageLayout, MessageSpacing, settingsAtom } from '$state/settings';
 import { nicknamesAtom, setNicknameAtom } from '$state/nicknames';
@@ -651,6 +651,13 @@ function MessageInternal(
 
   const isThreadedMessage = mEvent.threadRootId !== undefined;
 
+  const evtId = mEvent.getId()!;
+  const evtTimeline = room.getTimelineForEvent(evtId);
+  const edits =
+    evtTimeline &&
+    getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
+  const isEdited = edits !== undefined;
+
   return (
     <MessageBase
       className={classNames(css.MessageBase, className, {
@@ -853,7 +860,7 @@ function MessageInternal(
                         {!hideReadReceipts && (
                           <MessageReadReceiptItem room={room} eventId={mEvent.getId() ?? ''} />
                         )}
-                        <MessageEditHistoryItem room={room} mEvent={mEvent} />
+                        {isEdited && <MessageEditHistoryItem room={room} mEvent={mEvent} />}
                         {showDeveloperTools && (
                           <MessageSourceCodeItem room={room} mEvent={mEvent} />
                         )}
@@ -1109,6 +1116,13 @@ export const Event = as<'div', EventProps>(
       setMobileOptionsOpen(true);
     });
 
+    const evtId = mEvent.getId()!;
+    const evtTimeline = room.getTimelineForEvent(evtId);
+    const edits =
+      evtTimeline &&
+      getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
+    const isEdited = edits !== undefined;
+
     return (
       <MessageBase
         className={classNames(css.MessageBase, className)}
@@ -1148,7 +1162,7 @@ export const Event = as<'div', EventProps>(
                             {!hideReadReceipts && (
                               <MessageReadReceiptItem room={room} eventId={mEvent.getId() ?? ''} />
                             )}
-                            <MessageEditHistoryItem room={room} mEvent={mEvent} />
+                            {isEdited && <MessageEditHistoryItem room={room} mEvent={mEvent} />}
                             {showDeveloperTools && (
                               <MessageSourceCodeItem room={room} mEvent={mEvent} />
                             )}

--- a/src/app/state/modal.ts
+++ b/src/app/state/modal.ts
@@ -8,6 +8,7 @@ export enum ModalType {
   Report = 'report',
   Source = 'source',
   Reactions = 'reactions',
+  EditHistory = 'edit_history',
   ReadReceipts = 'read_receipts',
 }
 
@@ -16,6 +17,7 @@ export type ModalState =
   | { type: ModalType.Forward; room: Room; mEvent: MatrixEvent }
   | { type: ModalType.Report; room: Room; mEvent: MatrixEvent }
   | { type: ModalType.Source; room: Room; mEvent: MatrixEvent }
+  | { type: ModalType.EditHistory; room: Room; mEvent: MatrixEvent }
   | { type: ModalType.Reactions; room: Room; relations: Relations }
   | { type: ModalType.ReadReceipts; room: Room; eventId: string }
   | null;


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This PR adds a button on the right-click menu whenever a message is edited to allow you to see all the previous versions of the event (except the redacted ones obviously). 

(menu option look)
<img width="385" height="485" alt="image" src="https://github.com/user-attachments/assets/6d9e979a-42a1-4872-ada6-f41c152c74ff" />

(pop-up menu)
<img width="473" height="587" alt="image" src="https://github.com/user-attachments/assets/b902f733-e65a-437b-8cb7-a89f8ce4dd9c" />

(aspect when hovering a version)
<img width="468" height="585" alt="image" src="https://github.com/user-attachments/assets/6ce7af0f-352c-4bef-98de-e1d28d5cfd84" />

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
