### PR TITLE
change msgtype to m.emote to be more standard compliant

### DIFF
--- a/.changeset/fix_msgtype_of_headpat_event.md
+++ b/.changeset/fix_msgtype_of_headpat_event.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+chang to more standard compliant msgtype `m.emote` for `/headpat` event

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -217,6 +217,15 @@ function RenderMessageContentInternal({
   }
 
   if (msgType === MsgType.Emote) {
+    if (content['fyi.cisnt.headpat']) {
+      return (
+        <MCuteEvent
+          content={content}
+          type={CuteEventType.Headpat}
+          mentionedUserIds={content?.['m.mentions']?.user_ids}
+        />
+      );
+    }
     return (
       <MEmote
         displayName={displayName}
@@ -358,6 +367,7 @@ function RenderMessageContentInternal({
         mentionedUserIds={content?.['m.mentions']?.user_ids}
       />
     );
+  // as fallback to render older events where msgtype was set instead of m.emote with a custom property
   if (msgType === 'fyi.cisnt.headpat')
     return (
       <MCuteEvent

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -1375,11 +1375,12 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
         exe: async (payload) => {
           const target = payload.trim();
           await mx.sendMessage(room.roomId, {
-            msgtype: 'fyi.cisnt.headpat',
+            msgtype: 'm.emote',
             'm.mentions': {
               user_ids: target ? [target] : [],
             },
-            body: `*pat pat*`,
+            body: `pats ${target || 'you'}`,
+            'fyi.cisnt.headpat': true,
           } as any);
         },
       },


### PR DESCRIPTION


<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Change the msgtype from the custom `fyi.cisnt.headpat` to the standard `m.emote` while still keeping the old rendering as fallback for older messages sent from sable.

it will now generate events like the following:

```json
{
  "content": {
    "body": "pats @rye:itsrye.dev",
    "fyi.cisnt.headpat": true,
    "m.mentions": {
      "user_ids": [
        "@rye:itsrye.dev"
      ]
    },
    "msgtype": "m.emote"
  },
  "event_id": "$OOWvyc9_vGKQvv9X_yI-L6Al7cZ88c45THHDP_BuaNg",
  "origin_server_ts": 1773156785613,
  "sender": "@client-testing:itsrye.dev",
  "type": "m.room.message",
  "unsigned": {
    "age": 19,
    "transaction_id": "m1773156785357.1"
  },
  "room_id": "!OVi0VXH2pr4UWMdQvm:itsrye.dev"
}
```

while keeping the current behaviour and display

<img width="550" height="93" alt="image" src="https://github.com/user-attachments/assets/efb116c9-d374-4abd-8ead-685af45546a2" />


fixes https://github.com/SableClient/Sable/issues/142
@tulir is welcome to look over it, as they raised the issue to me

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
