### PR TITLE
add max-width to custom emotes to prevent overly wide emotes

### DIFF
--- a/.changeset/fix_emoji_width.md
+++ b/.changeset/fix_emoji_width.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Prevent overly wide emotes from taking up the entire screen width.

--- a/src/app/styles/CustomHtml.css.ts
+++ b/src/app/styles/CustomHtml.css.ts
@@ -238,6 +238,7 @@ export const EmoticonImg = style([
   {
     height: '1em',
     cursor: 'default',
+    maxWidth: '800px',
   },
 ]);
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Adds max-width property to emotes, preventing overly wide emotes from taking up the entire screen width.
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Before: 
<img width="1389" height="74" alt="image" src="https://github.com/user-attachments/assets/44a2318c-4aed-421d-a6e5-f6cb4315a62a" />

After:
<img width="1322" height="84" alt="image" src="https://github.com/user-attachments/assets/a24fc735-f1ca-4dc6-8578-26c9a922b07f" />

Fixes #161 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
