### PR TITLE
Fix metadata leak in private room message forwarding

### DIFF
--- a/.changeset/security_remove_metadata_leak_in_message_forwarding.md
+++ b/.changeset/security_remove_metadata_leak_in_message_forwarding.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+fix message forwarding metadata leak when forwarding from private rooms [see issue 190](https://github.com/SableClient/Sable/issues/190)

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -214,6 +214,8 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
       // we can still include the original message content in the body of the message, so we'll just use a fallback text/plain content with the original message body
       content = {
         ...mEvent.getContent(),
+        'm.relates_to': null, // remove any relations to avoid confusion in the target room
+        'm.mentions': null, // remove mentions to avoid leaking information about users in the original room
         ...forwardedTextContent,
         'moe.sable.message.forward': {
           v: 1,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

fix metadata leak when forwarding from a private room by setting 'm.mentions' and 'm.relates_to' explicitly to 'null'

Fixes https://github.com/SableClient/Sable/issues/190

### Example

```json
{
  "content": {
    "body": "(Forwarded message from a private room)\n\n> oi3fhif3h2qoifew",
    "format": "org.matrix.custom.html",
    "formatted_body": "<div data-forward-marker><p>(Forwarded message from a private room)</p><blockquote>oi3fhif3h2qoifew</blockquote></div>",
    "m.mentions": null,
    "m.relates_to": null,
    "moe.sable.message.forward": {
      "is_forwarded": true,
      "original_event_private": true,
      "original_timestamp": 1773267714441,
      "v": 1
    },
    "msgtype": "m.text"
  },
  "event_id": "$pM0XU5end_0rfHK4e54jZq0dfZHdivUgUxCiDZalTNI",
  "origin_server_ts": 1773267722160,
  "sender": "@client-testing:itsrye.dev",
  "type": "m.room.message",
  "unsigned": {
    "age": 23622,
    "transaction_id": "m1773267721992.3"
  },
  "room_id": "!ySMjK3zfhIHXNVlNDS:itsrye.dev"
}
```

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
