### PR TITLE
fix pronoun object not being an array crashing cosmetics tab

### DIFF
--- a/.changeset/fix-pronoun-array-bug.md
+++ b/.changeset/fix-pronoun-array-bug.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fix cosmetics tab crashing if global/room/space pronouns weren't already set.

--- a/src/app/features/settings/account/PronounEditor.tsx
+++ b/src/app/features/settings/account/PronounEditor.tsx
@@ -17,9 +17,9 @@ type PronounEditorProps = {
 };
 
 export function PronounEditor({ title, current, onSave, disabled }: PronounEditorProps) {
-  const initialString = current
-    .map((p) => `${p.language ? `${p.language}:` : ''}${p.summary}`)
-    .join(', ');
+  const initialString = Array.isArray(current)
+    ? current.map((p) => `${p.language ? `${p.language}:` : ''}${p.summary}`).join(', ')
+    : '';
   const [val, setVal] = useState(initialString);
 
   useEffect(() => setVal(initialString), [initialString]);


### PR DESCRIPTION
adds a check to make sure the pronoun array is an actual array

<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #227 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
