### PR TITLE
Improve sticker handling and update documentation on limitations

### DIFF
--- a/.changeset/disable_quick_add_for_encrypted_sticker.md
+++ b/.changeset/disable_quick_add_for_encrypted_sticker.md
@@ -1,0 +1,6 @@
+---
+sable: patch
+---
+
+disabling quick add for encrypted sticker, this mitigates the issue of being unable to use quick to add encrypted sticker
+ 

--- a/.changeset/disable_quick_add_for_encrypted_sticker.md
+++ b/.changeset/disable_quick_add_for_encrypted_sticker.md
@@ -3,4 +3,3 @@ sable: patch
 ---
 
 disabling quick add for encrypted sticker, this mitigates the issue of being unable to use quick to add encrypted sticker
- 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ devAssets
 *.tfbackend
 !*.tfbackend.example
 crash.log
+
+# the following line was added with the "git ignore" tool by itsrye.dev, version 0.1.0
+.lh

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -825,6 +825,7 @@ function MessageInternal(
                             </Text>
                           </MenuItem>
                         )}
+                        {/* Only show "Add to User Sticker Pack" if the sticker isn't already in the default pack and isn't encrypted */}
                         {isStickerMessage &&
                           mEvent.getContent().url &&
                           !doesStickerExistInDefaultPack(mx, mEvent.getContent().url) && (

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -826,6 +826,7 @@ function MessageInternal(
                           </MenuItem>
                         )}
                         {isStickerMessage &&
+                          mEvent.getContent().url &&
                           !doesStickerExistInDefaultPack(mx, mEvent.getContent().url) && (
                             <MenuItem
                               size="300"
@@ -835,7 +836,7 @@ function MessageInternal(
                                 addStickerToDefaultPack(
                                   mx,
                                   `sticker-${mEvent.getId()}`,
-                                  mEvent.getContent().url,
+                                  mEvent.getContent().url ?? mEvent.getContent().file?.url ?? '',
                                   mEvent.getContent().body,
                                   mEvent.getContent().info
                                 );

--- a/src/app/utils/addStickerToDefaultStickerPack.ts
+++ b/src/app/utils/addStickerToDefaultStickerPack.ts
@@ -4,6 +4,7 @@ import { IImageInfo } from '$types/matrix/common';
 import { MatrixClient } from 'matrix-js-sdk';
 
 // Utility function to add a sticker to the default sticker pack
+// For now this only works for unencrypted stickers
 export async function addStickerToDefaultPack(
   mx: MatrixClient,
   shortcode: string,


### PR DESCRIPTION
### Description

disabling quick add for encrypted sticker, this mitigates the issue of being unable to use quick to add encrypted sticker

mitigates https://github.com/SableClient/Sable/issues/223 (it does NOT fix the issue)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
