### PR TITLE
Add settings toggle for displaying deleted message tombstones

### DIFF
--- a/.changeset/add_tombstone_settings_toggle_for_redacted_msgs.md
+++ b/.changeset/add_tombstone_settings_toggle_for_redacted_msgs.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+added settings toggle in (General>Messages) to enable showing a tombstone for deleted messages without having to set all hidden events to visible

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -573,6 +573,7 @@ export function RoomTimeline({
   const [encUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
   const showUrlPreview = room.hasEncryptionStateEvent() ? encUrlPreview : urlPreview;
   const [showHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
+  const [showTombstoneEvents] = useSetting(settingsAtom, 'showTombstoneEvents');
   const [showDeveloperTools] = useSetting(settingsAtom, 'developerTools');
   const [reducedMotion] = useSetting(settingsAtom, 'reducedMotion');
 
@@ -2063,7 +2064,7 @@ export function RoomTimeline({
     if (eventSender && ignoredUsersSet.has(eventSender)) {
       return null;
     }
-    if (mEvent.isRedacted() && !showHiddenEvents) {
+    if (mEvent.isRedacted() && !(showHiddenEvents || showTombstoneEvents)) {
       return null;
     }
 

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -826,6 +826,10 @@ function Messages() {
   const [urlPreview, setUrlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [encUrlPreview, setEncUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
   const [showHiddenEvents, setShowHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
+  const [showTombstoneEvents, setShowTombstoneEvents] = useSetting(
+    settingsAtom,
+    'showTombstoneEvents'
+  );
   const [hideMembershipInReadOnly, setHideMembershipInReadOnly] = useSetting(
     settingsAtom,
     'hideMembershipInReadOnly'
@@ -925,6 +929,18 @@ function Messages() {
           title="Show Hidden Events"
           after={
             <Switch variant="Primary" value={showHiddenEvents} onChange={setShowHiddenEvents} />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Show Tombstones for Redacted Messages"
+          after={
+            <Switch
+              variant="Primary"
+              value={showTombstoneEvents || showHiddenEvents}
+              onChange={setShowTombstoneEvents}
+            />
           }
         />
       </SequenceCard>

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -385,6 +385,16 @@ function SelectDateFormat() {
   );
 }
 
+function getTombstoneSettingToggleTitle(showHidden: boolean, showTombstone: boolean): string {
+  if (showHidden) {
+    return 'Tombstone events are always shown when "Show Hidden Events" is enabled.';
+  }
+  if (showTombstone) {
+    return 'Disable to hide redacted messages entirely instead of showing a tombstone.';
+  }
+  return 'Enable to show tombstone events for redacted messages instead of hiding them entirely.';
+}
+
 function DateAndTime() {
   const [hour24Clock, setHour24Clock] = useSetting(settingsAtom, 'hour24Clock');
 
@@ -928,7 +938,16 @@ function Messages() {
         <SettingTile
           title="Show Hidden Events"
           after={
-            <Switch variant="Primary" value={showHiddenEvents} onChange={setShowHiddenEvents} />
+            <Switch
+              variant="Primary"
+              value={showHiddenEvents}
+              onChange={setShowHiddenEvents}
+              title={
+                showHiddenEvents
+                  ? 'Disable to hide hidden events'
+                  : 'Enable to show hidden events, this will cause visual clutter in busy rooms.'
+              }
+            />
           }
         />
       </SequenceCard>
@@ -940,6 +959,8 @@ function Messages() {
               variant="Primary"
               value={showTombstoneEvents || showHiddenEvents}
               onChange={setShowTombstoneEvents}
+              disabled={showHiddenEvents}
+              title={getTombstoneSettingToggleTitle(showHiddenEvents, showTombstoneEvents)}
             />
           }
         />

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -48,6 +48,7 @@ export interface Settings {
   urlPreview: boolean;
   encUrlPreview: boolean;
   showHiddenEvents: boolean;
+  showTombstoneEvents: boolean;
   legacyUsernameColor: boolean;
   allowPipVideos: boolean;
 
@@ -123,6 +124,7 @@ const defaultSettings: Settings = {
   urlPreview: true,
   encUrlPreview: false,
   showHiddenEvents: false,
+  showTombstoneEvents: false,
   legacyUsernameColor: false,
   allowPipVideos: false,
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

add settings toggle for showing tombstones of deleted messages

<img width="559" height="129" alt="image" src="https://github.com/user-attachments/assets/3dc51927-1ca6-4ddd-bac8-cfd7e30a7a23" />


Fixes https://github.com/SableClient/Sable/issues/228

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
