### PR TITLE
Add width limit to notification banners

### DIFF
--- a/.changeset/limit-notification-width.md
+++ b/.changeset/limit-notification-width.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add width limit to notification banners

--- a/src/app/components/notification-banner/NotificationBanner.css.ts
+++ b/src/app/components/notification-banner/NotificationBanner.css.ts
@@ -39,7 +39,7 @@ export const BannerContainer = style({
   gap: config.space.S200,
   padding: config.space.S400,
   pointerEvents: 'none',
-  alignItems: 'stretch',
+  alignItems: 'flex-end',
 
   // On iOS, when keyboard opens, ensure banner stays visible at top of visual viewport
   '@supports': {
@@ -67,6 +67,7 @@ export const Banner = style({
   boxShadow: `0 ${toRem(8)} ${toRem(32)} rgba(0, 0, 0, 0.45), 0 ${toRem(2)} ${toRem(8)} rgba(0, 0, 0, 0.3)`,
   cursor: 'pointer',
   width: '100%',
+  maxWidth: '50em',
   animationName: slideIn,
   animationDuration: '260ms',
   animationTimingFunction: 'cubic-bezier(0.22, 0.8, 0.6, 1)',


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds a limit to the width of the notification banner, so that it doesn't take up the entire width on larger screens unnecessarily.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
