### PR TITLE
fix: Media blob cache and chunk loading error handling

### DIFF
--- a/.changeset/fix-media-chunk-errors.md
+++ b/.changeset/fix-media-chunk-errors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed unhandled promise rejections in media blob cache and added automatic retry for chunk loading failures after deployments.

--- a/src/app/hooks/useBlobCache.ts
+++ b/src/app/hooks/useBlobCache.ts
@@ -23,15 +23,21 @@ export function useBlobCache(url?: string): string | undefined {
 
     const fetchBlob = async () => {
       if (inflightRequests.has(url)) {
-        const existingBlobUrl = await inflightRequests.get(url);
-        if (isMounted) setCacheState({ sourceUrl: url, blobUrl: existingBlobUrl });
+        try {
+          const existingBlobUrl = await inflightRequests.get(url);
+          if (isMounted) setCacheState({ sourceUrl: url, blobUrl: existingBlobUrl });
+        } catch {
+          // Inflight request failed, silently ignore (consistent with fetchBlob behavior)
+        }
         return;
       }
 
       const requestPromise = (async () => {
         try {
           const res = await fetch(url, { mode: 'cors' });
-          if (!res.ok) throw new Error();
+          if (!res.ok) {
+            throw new Error(`Failed to fetch blob: ${res.status} ${res.statusText}`);
+          }
           const blob = await res.blob();
           const objectUrl = URL.createObjectURL(blob);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -139,6 +139,41 @@ const injectIOSMetaTags = () => {
 
 injectIOSMetaTags();
 
+// Handle chunk loading failures with automatic retry
+const CHUNK_RETRY_KEY = 'cinny_chunk_retry_count';
+const MAX_CHUNK_RETRIES = 2;
+
+window.addEventListener('error', (event) => {
+  // Check if this is a chunk loading error
+  const isChunkLoadError =
+    event.message?.includes('dynamically imported module') ||
+    event.message?.includes('Failed to fetch') ||
+    (event.error?.name === 'ChunkLoadError');
+
+  if (isChunkLoadError) {
+    const retryCount = parseInt(sessionStorage.getItem(CHUNK_RETRY_KEY) ?? '0', 10);
+    
+    if (retryCount < MAX_CHUNK_RETRIES) {
+      // Increment retry count and reload
+      sessionStorage.setItem(CHUNK_RETRY_KEY, String(retryCount + 1));
+      log.warn(`Chunk load failed, reloading (attempt ${retryCount + 1}/${MAX_CHUNK_RETRIES})`);
+      window.location.reload();
+      
+      // Prevent default error handling since we're reloading
+      event.preventDefault();
+    } else {
+      // Max retries exceeded, clear counter and let error bubble up
+      sessionStorage.removeItem(CHUNK_RETRY_KEY);
+      log.error('Chunk load failed after max retries, showing error');
+    }
+  }
+});
+
+// Clear chunk retry counter on successful page load
+window.addEventListener('load', () => {
+  sessionStorage.removeItem(CHUNK_RETRY_KEY);
+});
+
 const mountApp = () => {
   const rootContainer = document.getElementById('root');
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -148,17 +148,17 @@ window.addEventListener('error', (event) => {
   const isChunkLoadError =
     event.message?.includes('dynamically imported module') ||
     event.message?.includes('Failed to fetch') ||
-    (event.error?.name === 'ChunkLoadError');
+    event.error?.name === 'ChunkLoadError';
 
   if (isChunkLoadError) {
     const retryCount = parseInt(sessionStorage.getItem(CHUNK_RETRY_KEY) ?? '0', 10);
-    
+
     if (retryCount < MAX_CHUNK_RETRIES) {
       // Increment retry count and reload
       sessionStorage.setItem(CHUNK_RETRY_KEY, String(retryCount + 1));
       log.warn(`Chunk load failed, reloading (attempt ${retryCount + 1}/${MAX_CHUNK_RETRIES})`);
       window.location.reload();
-      
+
       // Prevent default error handling since we're reloading
       event.preventDefault();
     } else {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -91,9 +91,11 @@ async function cleanupDeadClients() {
 function setSession(clientId: string, accessToken: unknown, baseUrl: unknown) {
   if (typeof accessToken === 'string' && typeof baseUrl === 'string') {
     sessions.set(clientId, { accessToken, baseUrl });
+    console.debug('[SW] setSession: stored', clientId, baseUrl);
   } else {
     // Logout or invalid session
     sessions.delete(clientId);
+    console.debug('[SW] setSession: removed', clientId);
   }
 
   const resolveSession = clientToResolve.get(clientId);
@@ -124,12 +126,18 @@ async function requestSessionWithTimeout(
   timeoutMs = 3000
 ): Promise<SessionInfo | undefined> {
   const client = await self.clients.get(clientId);
-  if (!client) return undefined;
+  if (!client) {
+    console.warn('[SW] requestSessionWithTimeout: client not found', clientId);
+    return undefined;
+  }
 
   const sessionPromise = requestSession(client);
 
   const timeout = new Promise<undefined>((resolve) => {
-    setTimeout(() => resolve(undefined), timeoutMs);
+    setTimeout(() => {
+      console.warn('[SW] requestSessionWithTimeout: timed out after', timeoutMs, 'ms', clientId);
+      resolve(undefined);
+    }, timeoutMs);
   });
 
   return Promise.race([sessionPromise, timeout]);
@@ -274,6 +282,11 @@ self.addEventListener('fetch', (event: FetchEvent) => {
       if (s && validMediaRequest(url, s.baseUrl)) {
         return fetch(url, { ...fetchConfig(s.accessToken), redirect });
       }
+      console.warn(
+        '[SW fetch] No valid session for media request',
+        { url, clientId, hasSession: !!s },
+        'falling back to unauthenticated fetch'
+      );
       return fetch(event.request);
     })
   );


### PR DESCRIPTION
## Summary
This PR adds robust error handling for two types of client errors:

### 1. Unhandled Promise Rejection in Media Blob Cache (Commit 77046ab5)
Fixes unhandled promise rejections when multiple components fetch the same media URL that fails with 401 errors.

**Root Cause:** When a blob fetch request was in-flight and failed, subsequent callers awaiting the same promise would receive an unhandled rejection because the await was outside the try-catch block.

**Changes:**
- Wrap `inflightRequests.get()` await in try-catch block
- Improve error messages to include HTTP status codes
- Add Service Worker logging for session retrieval failures to diagnose authentication issues

**Addresses:** Sentry Issue #1 (401 errors on authenticated media endpoints)

### 2. Automatic Retry for Chunk Loading Failures (Commit bff8c3d6)
Adds automatic page reload when dynamic import failures occur due to stale HTML after deployments.

**Root Cause:** After deployments, users with cached HTML try to load JS chunks that no longer exist, causing "Failed to fetch dynamically imported module" errors.

**Changes:**
- Global error handler catches chunk load errors (ChunkLoadError, "Failed to fetch")
- Auto-reload page on first 2 failures without user intervention
- On 3rd failure, let error bubble to Sentry error boundary
- Uses sessionStorage to track retry count across reloads
- Clears counter on successful page load

**Addresses:** Sentry Issue #2 (stale HTML breaking app after deployments)

## Testing
- Error handling paths verified through code review
- sessionStorage retry logic tested locally
- Both fixes address real production errors from Sentry