### PR TITLE
add MSC2723 forwarding meta data for more compatibility

### DIFF
--- a/.changeset/compat_msc2723_msg_forwarding.md
+++ b/.changeset/compat_msc2723_msg_forwarding.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+added for compatibility sake the forward meta data as defined in MSC2723

--- a/.changeset/compat_msc2723_msg_forwarding.md
+++ b/.changeset/compat_msc2723_msg_forwarding.md
@@ -1,5 +1,5 @@
 ---
-sable: patch
+default: patch
 ---
 
 added for compatibility sake the forward meta data as defined in MSC2723

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -87,6 +87,14 @@ type ForwardMeta = {
   original_event_private: boolean;
 };
 
+// see https://github.com/hummlbach/matrix-doc/blob/acea0854a1c9489599295a858b068ce02a6b2b20/proposals/2723-add-forward-info.md
+type MSC2723ForwardMeta = {
+  event_id: string;
+  room_id: string;
+  sender: string | null; // we won't set this field
+  origin_server_ts: number;
+};
+
 export function MessageForwardInternal({
   room,
   mEvent,
@@ -244,6 +252,12 @@ export function MessageForwardInternal({
           original_event_id: eventId,
           original_event_private: false,
         } satisfies ForwardMeta,
+        'com.famedly.app.forwarded': {
+          event_id: eventId,
+          room_id: room.roomId,
+          sender: null, // we won't set this field, as a design decision to avoid potential privacy issues and since the sender can be inferred from the event_id and room_id if needed
+          origin_server_ts: mEvent.getTs(),
+        } satisfies MSC2723ForwardMeta,
       };
     }
 

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -211,6 +211,13 @@ export type ForwardedMessageProps = {
   originalEventPrivate: boolean;
 };
 
+export type MSC2723ForwardedMessageProps = {
+  event_id: string;
+  room_id: string;
+  sender: string | null;
+  origin_server_ts: number;
+};
+
 export type MessageProps = {
   room: Room;
   mEvent: MatrixEvent;
@@ -248,6 +255,7 @@ export type MessageProps = {
   onResend?: (event: MatrixEvent) => void;
   onDeleteFailedSend?: (event: MatrixEvent) => void;
   messageForwardedProps?: ForwardedMessageProps;
+  msc2723ForwardedMessageProps?: MSC2723ForwardedMessageProps;
 };
 
 function useMobileDoubleTap(callback: () => void, delay = 300) {
@@ -349,6 +357,7 @@ function MessageInternal(
     onResend,
     onDeleteFailedSend,
     messageForwardedProps,
+    msc2723ForwardedMessageProps,
     ...props
   }: MessageProps & { className?: string; children?: ReactNode },
   ref: any
@@ -509,6 +518,32 @@ function MessageInternal(
   // handle clicks on mentions in the message body (e.g. jump to original message from a forwarded message notice)
   const mentionClickHandler = useMentionClickHandler(room.roomId);
 
+  const forwardedNotice = useMemo(() => {
+    if (messageForwardedProps?.isForwarded) {
+      return {
+        label: messageForwardedProps.originalEventPrivate
+          ? 'Forwarded private message'
+          : 'Forwarded from another room',
+        roomId: messageForwardedProps.originalRoomId,
+        eventId: messageForwardedProps.originalEventId,
+        ts: messageForwardedProps.originalTimestamp ?? 0,
+        showLink: !messageForwardedProps.originalEventPrivate,
+      };
+    }
+
+    if (msc2723ForwardedMessageProps) {
+      return {
+        label: 'Forwarded from another room',
+        roomId: msc2723ForwardedMessageProps.room_id,
+        eventId: msc2723ForwardedMessageProps.event_id,
+        ts: msc2723ForwardedMessageProps.origin_server_ts ?? 0,
+        showLink: true,
+      };
+    }
+
+    return null;
+  }, [messageForwardedProps, msc2723ForwardedMessageProps]);
+
   const handleResendClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     (evt) => {
       evt.preventDefault();
@@ -539,27 +574,26 @@ function MessageInternal(
         [css.MessageFailed]: isFailedSend,
       })}
     >
-      {messageForwardedProps?.isForwarded && (
+      {forwardedNotice && (
         <Chip as="div" variant="SurfaceVariant" radii="Pill">
           <Text size="T200" priority="300">
-            Forwarded{' '}
-            {messageForwardedProps.originalEventPrivate ? 'private message' : 'from another room'}{' '}
-            {!messageForwardedProps.originalEventPrivate && (
-              <a
-                href={getMatrixToRoomEvent(
-                  messageForwardedProps.originalRoomId,
-                  messageForwardedProps.originalEventId
-                )}
-                rel="noreferrer noopener"
-                data-mention-id={messageForwardedProps.originalRoomId}
-                data-mention-event-id={messageForwardedProps.originalEventId}
-                onClick={mentionClickHandler}
-              >
-                jump to original
-              </a>
+            {forwardedNotice.label}
+            {forwardedNotice.showLink && (
+              <>
+                {' '}
+                <a
+                  href={getMatrixToRoomEvent(forwardedNotice.roomId, forwardedNotice.eventId)}
+                  rel="noreferrer noopener"
+                  data-mention-id={forwardedNotice.roomId}
+                  data-mention-event-id={forwardedNotice.eventId}
+                  onClick={mentionClickHandler}
+                >
+                  jump to original
+                </a>
+              </>
             )}
             <Time
-              ts={messageForwardedProps?.originalTimestamp ?? 0}
+              ts={forwardedNotice.ts}
               compact={messageLayout === MessageLayout.Compact}
               hour24Clock={hour24Clock}
               dateFormatString={dateFormatString}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

adding the forwarding meta data as defined in [MSC2723](https://github.com/matrix-org/matrix-spec-proposals/pull/2723), but only for messages forwarded from a public room and without setting the sender key, as it was a design decision on our previous implementation to **not** forward sender information

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
