### PR TITLE
Middle click to open the url preview card thumbnail in a new tab

### DIFF
--- a/.changeset/urlpreview-middleclick.md
+++ b/.changeset/urlpreview-middleclick.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Handles a middle-click on the url preview card thumbnail image by downloading the full image from the homeserver proxy through a fetch request and opening received blob in the new tab

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -14,8 +14,16 @@ import { UrlPreview, UrlPreviewContent, UrlPreviewDescription } from './UrlPrevi
 import { AudioContent, ImageContent, VideoContent } from '../message';
 import { Image, MediaControl, Video } from '../media';
 import { ImageViewer } from '../image-viewer';
+import { downloadMedia } from '$utils/matrix';
 
 const linkStyles = { color: color.Success.Main };
+
+const openMediaInNewTab = async (url: string | undefined) => {
+  if (!url) { console.warn("Attempted to open an empty url"); return}
+  const blob = await downloadMedia(url);
+  const blobUrl = URL.createObjectURL(blob);
+  window.open(blobUrl, "_blank");
+}
 
 export const UrlPreviewCard = as<'div', { url: string; ts: number; mediaType?: string | null }>(
   ({ url, ts, mediaType, ...props }, ref) => {
@@ -50,6 +58,17 @@ export const UrlPreviewCard = as<'div', { url: string; ts: number; mediaType?: s
         'scale',
         false
       );
+      const handleAuxClick = (ev: React.MouseEvent) => {
+        if (!prev['og:image']) { console.warn("No image"); return; }
+        if (ev.button === 1) {
+          ev.preventDefault();
+          const useAuthentication = true;
+          const mxcUrl = mxcUrlToHttp(mx, prev['og:image'], useAuthentication);
+          if (!mxcUrl) { console.error("Error converting mxc:// url."); return; };
+          openMediaInNewTab(mxcUrl);
+        }
+      };
+
 
       return (
         <Box
@@ -128,6 +147,7 @@ export const UrlPreviewCard = as<'div', { url: string; ts: number; mediaType?: s
                   <ImageContent
                     style={{ width: '100%', height: '100%', position: 'absolute', inset: 0 }}
                     autoPlay
+                    onAuxClick={handleAuxClick}
                     body={prev['og:title']}
                     url={prev['og:image']}
                     renderViewer={(p) => <ImageViewer {...p} />}
@@ -187,7 +207,6 @@ export const UrlPreviewCard = as<'div', { url: string; ts: number; mediaType?: s
         </Box>
       );
     }
-
     return (
       <UrlPreview
         {...props}

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -7,23 +7,25 @@ import {
   getIntersectionObserverEntry,
   useIntersectionObserver,
 } from '$hooks/useIntersectionObserver';
-import { mxcUrlToHttp } from '$utils/matrix';
+import { mxcUrlToHttp, downloadMedia } from '$utils/matrix';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import * as css from './UrlPreviewCard.css';
 import { UrlPreview, UrlPreviewContent, UrlPreviewDescription } from './UrlPreview';
 import { AudioContent, ImageContent, VideoContent } from '../message';
 import { Image, MediaControl, Video } from '../media';
 import { ImageViewer } from '../image-viewer';
-import { downloadMedia } from '$utils/matrix';
 
 const linkStyles = { color: color.Success.Main };
 
 const openMediaInNewTab = async (url: string | undefined) => {
-  if (!url) { console.warn("Attempted to open an empty url"); return}
+  if (!url) {
+    console.warn('Attempted to open an empty url');
+    return;
+  }
   const blob = await downloadMedia(url);
   const blobUrl = URL.createObjectURL(blob);
-  window.open(blobUrl, "_blank");
-}
+  window.open(blobUrl, '_blank');
+};
 
 export const UrlPreviewCard = as<'div', { url: string; ts: number; mediaType?: string | null }>(
   ({ url, ts, mediaType, ...props }, ref) => {
@@ -59,16 +61,20 @@ export const UrlPreviewCard = as<'div', { url: string; ts: number; mediaType?: s
         false
       );
       const handleAuxClick = (ev: React.MouseEvent) => {
-        if (!prev['og:image']) { console.warn("No image"); return; }
+        if (!prev['og:image']) {
+          console.warn('No image');
+          return;
+        }
         if (ev.button === 1) {
           ev.preventDefault();
-          const useAuthentication = true;
-          const mxcUrl = mxcUrlToHttp(mx, prev['og:image'], useAuthentication);
-          if (!mxcUrl) { console.error("Error converting mxc:// url."); return; };
+          const mxcUrl = mxcUrlToHttp(mx, prev['og:image'], /* useAuthentication */ true);
+          if (!mxcUrl) {
+            console.error('Error converting mxc:// url.');
+            return;
+          }
           openMediaInNewTab(mxcUrl);
         }
       };
-
 
       return (
         <Box


### PR DESCRIPTION
Handles a middle-click and opens the url preview card thumbnail (or actually downloads the full image, that is stored on the homeserver proxy) and opens that blob in the new tab