### PR TITLE
feat(push): encrypted push notifications via event_id_only and decryption relay

### DIFF
--- a/.changeset/feat-encrypted-push.md
+++ b/.changeset/feat-encrypted-push.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Push notifications now use `event_id_only` format — Sygnal never sees message content or sender metadata, and encrypted messages are decrypted client-side when the app tab is open

--- a/src/app/features/settings/notifications/PushNotifications.tsx
+++ b/src/app/features/settings/notifications/PushNotifications.tsx
@@ -62,8 +62,7 @@ export async function enablePushNotifications(
       lang: navigator.language || 'en',
       data: {
         url: clientConfig.pushNotificationDetails?.pushNotifyUrl,
-        // format: 'event_id_only' as const,
-        events_only: true,
+        format: 'event_id_only' as const,
         endpoint: pushSubAtom.endpoint,
         p256dh: keys.p256dh,
         auth: keys.auth,
@@ -111,7 +110,7 @@ export async function enablePushNotifications(
     lang: navigator.language || 'en',
     data: {
       url: clientConfig.pushNotificationDetails?.pushNotifyUrl,
-      // format: 'event_id_only' as const,
+      format: 'event_id_only' as const,
       endpoint: newSubscription.endpoint,
       p256dh: keys.p256dh,
       auth: keys.auth,

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -2,6 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  MatrixEvent,
   MatrixEventEvent,
   PushProcessor,
   RoomEvent,
@@ -619,6 +620,65 @@ function SlidingSyncActiveRoomSubscriber() {
   return null;
 }
 
+/**
+ * Listens for decryptPushEvent messages from the service worker, decrypts the
+ * event using the local Olm/Megolm session, then replies with pushDecryptResult
+ * so the SW can show a notification with the real message content.
+ * Falls back gracefully (success: false) on any error or if keys are missing.
+ */
+function HandleDecryptPushEvent() {
+  const mx = useMatrixClient();
+
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return undefined;
+
+    const handleMessage = async (ev: MessageEvent) => {
+      const { data } = ev;
+      if (!data || data.type !== 'decryptPushEvent') return;
+
+      const { rawEvent } = data as { rawEvent: Record<string, unknown> };
+      const eventId = rawEvent.event_id as string;
+      const roomId = rawEvent.room_id as string;
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const mxEvent = new MatrixEvent(rawEvent as any);
+        await mx.decryptEventIfNeeded(mxEvent);
+
+        const room = mx.getRoom(roomId);
+        const sender = mxEvent.getSender();
+        const senderName = sender
+          ? (room
+              ? getMemberDisplayName(room, sender) ?? getMxIdLocalPart(sender)
+              : getMxIdLocalPart(sender))
+          : 'Someone';
+
+        navigator.serviceWorker.controller?.postMessage({
+          type: 'pushDecryptResult',
+          eventId,
+          success: true,
+          eventType: mxEvent.getType(),
+          content: mxEvent.getContent(),
+          sender_display_name: senderName,
+          room_name: room?.name ?? '',
+        });
+      } catch (err) {
+        console.warn('[app] HandleDecryptPushEvent: failed to decrypt push event', err);
+        navigator.serviceWorker.controller?.postMessage({
+          type: 'pushDecryptResult',
+          eventId,
+          success: false,
+        });
+      }
+    };
+
+    navigator.serviceWorker.addEventListener('message', handleMessage);
+    return () => navigator.serviceWorker.removeEventListener('message', handleMessage);
+  }, [mx]);
+
+  return null;
+}
+
 function PresenceFeature() {
   const mx = useMatrixClient();
   const [sendPresence] = useSetting(settingsAtom, 'sendPresence');
@@ -646,6 +706,7 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <MessageNotifications />
       <BackgroundNotifications />
       <SyncNotificationSettingsWithServiceWorker />
+      <HandleDecryptPushEvent />
       <NotificationBanner />
       <SlidingSyncActiveRoomSubscriber />
       <PresenceFeature />

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -660,6 +660,7 @@ function HandleDecryptPushEvent() {
           content: mxEvent.getContent(),
           sender_display_name: senderName,
           room_name: room?.name ?? '',
+          visibilityState: document.visibilityState,
         });
       } catch (err) {
         console.warn('[app] HandleDecryptPushEvent: failed to decrypt push event', err);
@@ -667,6 +668,7 @@ function HandleDecryptPushEvent() {
           type: 'pushDecryptResult',
           eventId,
           success: false,
+          visibilityState: document.visibilityState,
         });
       }
     };

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -641,17 +641,16 @@ function HandleDecryptPushEvent() {
       const roomId = rawEvent.room_id as string;
 
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mxEvent = new MatrixEvent(rawEvent as any);
         await mx.decryptEventIfNeeded(mxEvent);
 
         const room = mx.getRoom(roomId);
         const sender = mxEvent.getSender();
-        const senderName = sender
-          ? (room
-              ? getMemberDisplayName(room, sender) ?? getMxIdLocalPart(sender)
-              : getMxIdLocalPart(sender))
-          : 'Someone';
+        let senderName = 'Someone';
+        if (sender) {
+          senderName = getMxIdLocalPart(sender) ?? sender;
+          if (room) senderName = getMemberDisplayName(room, sender) ?? senderName;
+        }
 
         navigator.serviceWorker.controller?.postMessage({
           type: 'pushDecryptResult',

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -45,12 +45,15 @@ import {
   resolveNotificationPreviewText,
 } from '$utils/notificationStyle';
 import { mobileOrTablet } from '$utils/user-agent';
+import { createDebugLogger } from '$utils/debugLogger';
 import { useSlidingSyncActiveRoom } from '$hooks/useSlidingSyncActiveRoom';
 import { getSlidingSyncManager } from '$client/initMatrix';
 import { NotificationBanner } from '$components/notification-banner';
 import { useCallSignaling } from '$hooks/useCallSignaling';
 import { getInboxInvitesPath } from '../pathUtils';
 import { BackgroundNotifications } from './BackgroundNotifications';
+
+const pushRelayLog = createDebugLogger('push-relay');
 
 function clearMediaSessionQuickly(): void {
   if (!('mediaSession' in navigator)) return;
@@ -639,6 +642,7 @@ function HandleDecryptPushEvent() {
       const { rawEvent } = data as { rawEvent: Record<string, unknown> };
       const eventId = rawEvent.event_id as string;
       const roomId = rawEvent.room_id as string;
+      const decryptStart = performance.now();
 
       try {
         const mxEvent = new MatrixEvent(rawEvent as any);
@@ -652,6 +656,14 @@ function HandleDecryptPushEvent() {
           if (room) senderName = getMemberDisplayName(room, sender) ?? senderName;
         }
 
+        const decryptMs = Math.round(performance.now() - decryptStart);
+        const visible = document.visibilityState === 'visible';
+        pushRelayLog.info('notification', 'Push relay decryption succeeded', {
+          eventType: mxEvent.getType(),
+          decryptMs,
+          appVisible: visible,
+        });
+
         navigator.serviceWorker.controller?.postMessage({
           type: 'pushDecryptResult',
           eventId,
@@ -664,6 +676,11 @@ function HandleDecryptPushEvent() {
         });
       } catch (err) {
         console.warn('[app] HandleDecryptPushEvent: failed to decrypt push event', err);
+        pushRelayLog.error(
+          'notification',
+          'Push relay decryption failed',
+          err instanceof Error ? err : new Error(String(err))
+        );
         navigator.serviceWorker.controller?.postMessage({
           type: 'pushDecryptResult',
           eventId,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,7 +80,7 @@ if ('serviceWorker' in navigator) {
     const activeId = getLocalStorageItem<string | undefined>(ACTIVE_SESSION_KEY, undefined);
     const active =
       sessions.find((s) => s.userId === activeId) ?? sessions[0] ?? getFallbackSession();
-    pushSessionToSW(active?.baseUrl, active?.accessToken);
+    pushSessionToSW(active?.baseUrl, active?.accessToken, active?.userId);
   };
 
   navigator.serviceWorker

--- a/src/sw-session.ts
+++ b/src/sw-session.ts
@@ -1,4 +1,4 @@
-export function pushSessionToSW(baseUrl?: string, accessToken?: string) {
+export function pushSessionToSW(baseUrl?: string, accessToken?: string, userId?: string) {
   if (!('serviceWorker' in navigator)) return;
   if (!navigator.serviceWorker.controller) return;
 
@@ -6,5 +6,6 @@ export function pushSessionToSW(baseUrl?: string, accessToken?: string) {
     type: 'setSession',
     accessToken,
     baseUrl,
+    userId,
   });
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -200,10 +200,7 @@ async function fetchRawEvent(
  * don't have a client ID, e.g. when the app is backgrounded but still loaded).
  */
 function getAnyStoredSession(): SessionInfo | undefined {
-  for (const session of sessions.values()) {
-    return session;
-  }
-  return undefined;
+  return sessions.values().next().value;
 }
 
 /**
@@ -223,32 +220,36 @@ async function requestDecryptionFromClient(
 ): Promise<DecryptionResult | undefined> {
   const eventId = rawEvent.event_id as string;
 
-  for (const client of windowClients) {
-    const promise = new Promise<DecryptionResult>((resolve) => {
-      decryptionPendingMap.set(eventId, resolve);
-    });
+  // Chain clients sequentially using reduce to avoid await-in-loop and for-of.
+  return Array.from(windowClients).reduce(
+    async (prevPromise, client) => {
+      const prev = await prevPromise;
+      if (prev?.success) return prev;
 
-    const timeout = new Promise<undefined>((resolve) => {
-      setTimeout(() => {
+      const promise = new Promise<DecryptionResult>((resolve) => {
+        decryptionPendingMap.set(eventId, resolve);
+      });
+
+      const timeout = new Promise<undefined>((resolve) => {
+        setTimeout(() => {
+          decryptionPendingMap.delete(eventId);
+          console.warn('[SW decryptRelay] timed out waiting for client', client.id);
+          resolve(undefined);
+        }, 5000);
+      });
+
+      try {
+        (client as WindowClient).postMessage({ type: 'decryptPushEvent', rawEvent });
+      } catch (err) {
         decryptionPendingMap.delete(eventId);
-        console.warn('[SW decryptRelay] timed out waiting for client', client.id);
-        resolve(undefined);
-      }, 5000);
-    });
+        console.warn('[SW decryptRelay] postMessage error', err);
+        return undefined;
+      }
 
-    try {
-      (client as WindowClient).postMessage({ type: 'decryptPushEvent', rawEvent });
-    } catch (err) {
-      decryptionPendingMap.delete(eventId);
-      console.warn('[SW decryptRelay] postMessage error', err);
-      continue;
-    }
-
-    const result = await Promise.race([promise, timeout]);
-    if (result?.success) return result;
-  }
-
-  return undefined;
+      return Promise.race([promise, timeout]);
+    },
+    Promise.resolve(undefined) as Promise<DecryptionResult | undefined>
+  );
 }
 
 /**
@@ -303,9 +304,10 @@ async function handleMinimalPushPayload(
 
   if (eventType === 'm.room.encrypted') {
     // Try to relay decryption to an open tab
-    const result = windowClients.length > 0
-      ? await requestDecryptionFromClient(windowClients, rawEvent)
-      : undefined;
+    const result =
+      windowClients.length > 0
+        ? await requestDecryptionFromClient(windowClients, rawEvent)
+        : undefined;
 
     if (result) {
       // Use decrypted content — reconstruct a pushData object
@@ -498,6 +500,14 @@ self.addEventListener('fetch', (event: FetchEvent) => {
   );
 });
 
+// Detect a minimal (event_id_only) payload: has room_id + event_id but no
+// event type field — meaning the homeserver stripped the event content.
+function isMinimalPushPayload(data: unknown): data is { room_id: string; event_id: string } {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return typeof d.room_id === 'string' && typeof d.event_id === 'string' && !d.type;
+}
+
 const onPushNotification = async (event: PushEvent) => {
   if (!event?.data) return;
 
@@ -566,14 +576,6 @@ const onPushNotification = async (event: PushEvent) => {
 // ---------------------------------------------------------------------------
 // Push handler
 // ---------------------------------------------------------------------------
-
-// Detect a minimal (event_id_only) payload: has room_id + event_id but no
-// event type field — meaning the homeserver stripped the event content.
-function isMinimalPushPayload(data: unknown): data is { room_id: string; event_id: string } {
-  if (!data || typeof data !== 'object') return false;
-  const d = data as Record<string, unknown>;
-  return typeof d.room_id === 'string' && typeof d.event_id === 'string' && !d.type;
-}
 
 self.addEventListener('push', (event: PushEvent) => event.waitUntil(onPushNotification(event)));
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -212,6 +212,8 @@ type DecryptionResult = {
   content?: unknown;
   sender_display_name?: string;
   room_name?: string;
+  /** document.visibilityState reported by the responding app tab. */
+  visibilityState?: string;
 };
 
 /** Pending decryption requests keyed by event_id. */
@@ -239,6 +241,49 @@ async function fetchRawEvent(
     return (await res.json()) as Record<string, unknown>;
   } catch (err) {
     console.warn('[SW fetchRawEvent] error', err);
+    return undefined;
+  }
+}
+
+/**
+ * Fetch the m.room.name state event from the homeserver.
+ * Returns undefined when not set (DMs and many encrypted rooms have no explicit name).
+ */
+async function fetchRoomName(
+  baseUrl: string,
+  accessToken: string,
+  roomId: string
+): Promise<string | undefined> {
+  try {
+    const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state/m.room.name`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as Record<string, unknown>;
+    const { name } = data;
+    return typeof name === 'string' && name.trim() ? name.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Fetch a room member's displayname from homeserver member state.
+ * Returns undefined if the member has no displayname or the request fails.
+ */
+async function fetchMemberDisplayName(
+  baseUrl: string,
+  accessToken: string,
+  roomId: string,
+  userId: string
+): Promise<string | undefined> {
+  try {
+    const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent(userId)}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as Record<string, unknown>;
+    const name = data.displayname;
+    return typeof name === 'string' && name.trim() ? name.trim() : undefined;
+  } catch {
     return undefined;
   }
 }
@@ -330,7 +375,11 @@ async function handleMinimalPushPayload(
     return;
   }
 
-  const rawEvent = await fetchRawEvent(session.baseUrl, session.accessToken, roomId, eventId);
+  // Fetch the raw event and room name state in parallel — both need only roomId.
+  const [rawEvent, roomNameFromState] = await Promise.all([
+    fetchRawEvent(session.baseUrl, session.accessToken, roomId, eventId),
+    fetchRoomName(session.baseUrl, session.accessToken, roomId),
+  ]);
 
   if (!rawEvent) {
     await self.registration.showNotification('New Message', {
@@ -346,7 +395,13 @@ async function handleMinimalPushPayload(
 
   const eventType = rawEvent.type as string | undefined;
   const sender = rawEvent.sender as string | undefined;
-  const senderDisplay = sender ? mxidLocalpart(sender) : 'Someone';
+  // Fetch sender's display name from room member state; fall back to MXID localpart.
+  const senderDisplay =
+    (sender
+      ? await fetchMemberDisplayName(session.baseUrl, session.accessToken, roomId, sender)
+      : undefined) ?? (sender ? mxidLocalpart(sender) : 'Someone');
+  // For DMs (no m.room.name state), use the sender's display name as the room name.
+  const resolvedRoomName = roomNameFromState ?? senderDisplay;
   const baseData = {
     room_id: roomId,
     event_id: eventId,
@@ -354,39 +409,44 @@ async function handleMinimalPushPayload(
   };
 
   if (eventType === 'm.room.encrypted') {
-    // Try to relay decryption to an open tab
+    // Try to relay decryption to an open app tab.
     const result =
       windowClients.length > 0
         ? await requestDecryptionFromClient(windowClients, rawEvent)
         : undefined;
 
-    if (result) {
-      // Use decrypted content — reconstruct a pushData object
+    // If the relay responded and the app is currently visible, the in-app UI is already
+    // displaying the message — skip the OS notification entirely.
+    if (result?.visibilityState === 'visible') return;
+
+    if (result?.success) {
+      // App was backgrounded but not frozen — decryption succeeded.
       await handlePushNotificationPushData({
         ...baseData,
         type: result.eventType,
         content: result.content,
         sender_display_name: result.sender_display_name ?? senderDisplay,
-        room_name: result.room_name ?? '',
+        // Prefer relay's room name (has m.direct / computed SDK name); fall back to state fetch.
+        room_name: result.room_name || resolvedRoomName,
       });
     } else {
-      // Fallback: show generic "Encrypted message"
+      // App is frozen or fully closed — show "Encrypted message" fallback.
       await handlePushNotificationPushData({
         ...baseData,
         type: 'm.room.encrypted',
         content: {},
         sender_display_name: senderDisplay,
-        room_name: '',
+        room_name: resolvedRoomName,
       });
     }
   } else {
-    // Unencrypted event — we have the plaintext, show it
+    // Unencrypted event — we have the plaintext, show it.
     await handlePushNotificationPushData({
       ...baseData,
       type: eventType,
       content: rawEvent.content,
       sender_display_name: senderDisplay,
-      room_name: '',
+      room_name: resolvedRoomName,
     });
   }
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -24,6 +24,10 @@ const { handlePushNotificationPushData } = createPushNotifications(self, () => (
 const SW_SETTINGS_CACHE = 'sable-sw-settings-v1';
 const SW_SETTINGS_URL = '/sw-settings-meta';
 
+/** Cache key used to persist the active session so push-event fetches work after SW restart. */
+const SW_SESSION_CACHE = 'sable-sw-session-v1';
+const SW_SESSION_URL = '/sw-session-meta';
+
 async function persistSettings() {
   try {
     const cache = await self.caches.open(SW_SETTINGS_CACHE);
@@ -62,6 +66,46 @@ async function loadPersistedSettings() {
   }
 }
 
+async function persistSession(session: SessionInfo): Promise<void> {
+  try {
+    const cache = await self.caches.open(SW_SESSION_CACHE);
+    await cache.put(
+      SW_SESSION_URL,
+      new Response(JSON.stringify(session), { headers: { 'Content-Type': 'application/json' } })
+    );
+  } catch {
+    // Ignore — caches may be unavailable in some environments.
+  }
+}
+
+async function clearPersistedSession(): Promise<void> {
+  try {
+    const cache = await self.caches.open(SW_SESSION_CACHE);
+    await cache.delete(SW_SESSION_URL);
+  } catch {
+    // Ignore.
+  }
+}
+
+async function loadPersistedSession(): Promise<SessionInfo | undefined> {
+  try {
+    const cache = await self.caches.open(SW_SESSION_CACHE);
+    const response = await cache.match(SW_SESSION_URL);
+    if (!response) return undefined;
+    const s = await response.json();
+    if (typeof s.accessToken === 'string' && typeof s.baseUrl === 'string') {
+      return {
+        accessToken: s.accessToken,
+        baseUrl: s.baseUrl,
+        userId: typeof s.userId === 'string' ? s.userId : undefined,
+      };
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 type SessionInfo = {
   accessToken: string;
   baseUrl: string;
@@ -92,16 +136,20 @@ async function cleanupDeadClients() {
 
 function setSession(clientId: string, accessToken: unknown, baseUrl: unknown, userId?: unknown) {
   if (typeof accessToken === 'string' && typeof baseUrl === 'string') {
-    sessions.set(clientId, {
+    const info: SessionInfo = {
       accessToken,
       baseUrl,
       userId: typeof userId === 'string' ? userId : undefined,
-    });
+    };
+    sessions.set(clientId, info);
     console.debug('[SW] setSession: stored', clientId, baseUrl);
+    // Persist so push-event fetches work after iOS restarts the SW.
+    persistSession(info).catch(() => undefined);
   } else {
     // Logout or invalid session
     sessions.delete(clientId);
     console.debug('[SW] setSession: removed', clientId);
+    clearPersistedSession().catch(() => undefined);
   }
 
   const resolveSession = clientToResolve.get(clientId);
@@ -262,11 +310,14 @@ async function handleMinimalPushPayload(
   eventId: string,
   windowClients: readonly Client[]
 ): Promise<void> {
-  const session = getAnyStoredSession();
+  // On iOS the SW is killed and restarted for every push, clearing the in-memory sessions
+  // Map.  Fall back to the Cache Storage copy that was written when the user last opened
+  // the app (same pattern as settings persistence).
+  const session = getAnyStoredSession() ?? (await loadPersistedSession());
 
   if (!session) {
-    // App is fully closed — no session in memory. Show a minimal actionable notification
-    // so the user can tap through to the room.
+    // No session anywhere — app was never opened since install, or the user logged out.
+    // Show a minimal actionable notification so the user can tap through to the room.
     console.debug('[SW push] minimal payload: no session, showing generic notification');
     await self.registration.showNotification('New Message', {
       body: undefined,
@@ -514,8 +565,9 @@ const onPushNotification = async (event: PushEvent) => {
   // The SW may have been restarted by the OS (iOS is aggressive about this),
   // so in-memory settings would be at their defaults.  Reload from cache and
   // match active clients in parallel — they are independent operations.
-  const [, clients] = await Promise.all([
+  const [, , clients] = await Promise.all([
     loadPersistedSettings(),
+    loadPersistedSession(),
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }),
   ]);
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -65,6 +65,8 @@ async function loadPersistedSettings() {
 type SessionInfo = {
   accessToken: string;
   baseUrl: string;
+  /** Matrix user ID of the account, used to identify which account a push belongs to. */
+  userId?: string;
 };
 
 /**
@@ -88,9 +90,13 @@ async function cleanupDeadClients() {
   });
 }
 
-function setSession(clientId: string, accessToken: unknown, baseUrl: unknown) {
+function setSession(clientId: string, accessToken: unknown, baseUrl: unknown, userId?: unknown) {
   if (typeof accessToken === 'string' && typeof baseUrl === 'string') {
-    sessions.set(clientId, { accessToken, baseUrl });
+    sessions.set(clientId, {
+      accessToken,
+      baseUrl,
+      userId: typeof userId === 'string' ? userId : undefined,
+    });
     console.debug('[SW] setSession: stored', clientId, baseUrl);
   } else {
     // Logout or invalid session
@@ -143,6 +149,195 @@ async function requestSessionWithTimeout(
   return Promise.race([sessionPromise, timeout]);
 }
 
+// ---------------------------------------------------------------------------
+// Encrypted push — decryption relay
+// ---------------------------------------------------------------------------
+
+/**
+ * The shape returned by the client tab after decrypting an encrypted push event.
+ * Also used as a partial pushData object for handlePushNotificationPushData.
+ */
+type DecryptionResult = {
+  eventId: string;
+  success: boolean;
+  eventType?: string;
+  content?: unknown;
+  sender_display_name?: string;
+  room_name?: string;
+};
+
+/** Pending decryption requests keyed by event_id. */
+const decryptionPendingMap = new Map<string, (result: DecryptionResult) => void>();
+
+/**
+ * Fetch a single raw Matrix event from the homeserver.
+ * Returns undefined on error (e.g. network failure, auth error, redacted event).
+ */
+async function fetchRawEvent(
+  baseUrl: string,
+  accessToken: string,
+  roomId: string,
+  eventId: string
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/event/${encodeURIComponent(eventId)}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      console.warn('[SW fetchRawEvent] HTTP', res.status, 'for', eventId);
+      return undefined;
+    }
+    return (await res.json()) as Record<string, unknown>;
+  } catch (err) {
+    console.warn('[SW fetchRawEvent] error', err);
+    return undefined;
+  }
+}
+
+/**
+ * Return the first any-session we have stored (used for push fetches where we
+ * don't have a client ID, e.g. when the app is backgrounded but still loaded).
+ */
+function getAnyStoredSession(): SessionInfo | undefined {
+  for (const session of sessions.values()) {
+    return session;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the MXID localpart (@user:server → user) for fallback display names.
+ */
+function mxidLocalpart(userId: string): string {
+  return userId.match(/^@([^:]+):/)?.[1] ?? userId;
+}
+
+/**
+ * Post a decryptPushEvent request to one of the open window clients and wait
+ * up to 5 s for the pushDecryptResult reply.
+ */
+async function requestDecryptionFromClient(
+  windowClients: readonly Client[],
+  rawEvent: Record<string, unknown>
+): Promise<DecryptionResult | undefined> {
+  const eventId = rawEvent.event_id as string;
+
+  for (const client of windowClients) {
+    const promise = new Promise<DecryptionResult>((resolve) => {
+      decryptionPendingMap.set(eventId, resolve);
+    });
+
+    const timeout = new Promise<undefined>((resolve) => {
+      setTimeout(() => {
+        decryptionPendingMap.delete(eventId);
+        console.warn('[SW decryptRelay] timed out waiting for client', client.id);
+        resolve(undefined);
+      }, 5000);
+    });
+
+    try {
+      (client as WindowClient).postMessage({ type: 'decryptPushEvent', rawEvent });
+    } catch (err) {
+      decryptionPendingMap.delete(eventId);
+      console.warn('[SW decryptRelay] postMessage error', err);
+      continue;
+    }
+
+    const result = await Promise.race([promise, timeout]);
+    if (result?.success) return result;
+  }
+
+  return undefined;
+}
+
+/**
+ * Handle a minimal push payload (event_id_only format).
+ * Fetches the event from the homeserver and shows a notification.
+ * For encrypted events, attempts to relay decryption to an open app tab.
+ */
+async function handleMinimalPushPayload(
+  roomId: string,
+  eventId: string,
+  windowClients: readonly Client[]
+): Promise<void> {
+  const session = getAnyStoredSession();
+
+  if (!session) {
+    // App is fully closed — no session in memory. Show a minimal actionable notification
+    // so the user can tap through to the room.
+    console.debug('[SW push] minimal payload: no session, showing generic notification');
+    await self.registration.showNotification('New Message', {
+      body: undefined,
+      icon: '/public/res/apple/apple-touch-icon-180x180.png',
+      badge: '/public/res/apple/apple-touch-icon-72x72.png',
+      tag: `room-${roomId}`,
+      renotify: true,
+      data: { room_id: roomId, event_id: eventId },
+    } as NotificationOptions);
+    return;
+  }
+
+  const rawEvent = await fetchRawEvent(session.baseUrl, session.accessToken, roomId, eventId);
+
+  if (!rawEvent) {
+    await self.registration.showNotification('New Message', {
+      body: undefined,
+      icon: '/public/res/apple/apple-touch-icon-180x180.png',
+      badge: '/public/res/apple/apple-touch-icon-72x72.png',
+      tag: `room-${roomId}`,
+      renotify: true,
+      data: { room_id: roomId, event_id: eventId, user_id: session.userId },
+    } as NotificationOptions);
+    return;
+  }
+
+  const eventType = rawEvent.type as string | undefined;
+  const sender = rawEvent.sender as string | undefined;
+  const senderDisplay = sender ? mxidLocalpart(sender) : 'Someone';
+  const baseData = {
+    room_id: roomId,
+    event_id: eventId,
+    user_id: session.userId,
+  };
+
+  if (eventType === 'm.room.encrypted') {
+    // Try to relay decryption to an open tab
+    const result = windowClients.length > 0
+      ? await requestDecryptionFromClient(windowClients, rawEvent)
+      : undefined;
+
+    if (result) {
+      // Use decrypted content — reconstruct a pushData object
+      await handlePushNotificationPushData({
+        ...baseData,
+        type: result.eventType,
+        content: result.content,
+        sender_display_name: result.sender_display_name ?? senderDisplay,
+        room_name: result.room_name ?? '',
+      });
+    } else {
+      // Fallback: show generic "Encrypted message"
+      await handlePushNotificationPushData({
+        ...baseData,
+        type: 'm.room.encrypted',
+        content: {},
+        sender_display_name: senderDisplay,
+        room_name: '',
+      });
+    }
+  } else {
+    // Unencrypted event — we have the plaintext, show it
+    await handlePushNotificationPushData({
+      ...baseData,
+      type: eventType,
+      content: rawEvent.content,
+      sender_display_name: senderDisplay,
+      room_name: '',
+    });
+  }
+}
+
 self.addEventListener('install', (event: ExtendableEvent) => {
   event.waitUntil(self.skipWaiting());
 });
@@ -165,11 +360,22 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
 
   const { data } = event;
   if (!data || typeof data !== 'object') return;
-  const { type, accessToken, baseUrl } = data as Record<string, unknown>;
+  const { type, accessToken, baseUrl, userId } = data as Record<string, unknown>;
 
   if (type === 'setSession') {
-    setSession(client.id, accessToken, baseUrl);
+    setSession(client.id, accessToken, baseUrl, userId);
     event.waitUntil(cleanupDeadClients());
+  }
+  if (type === 'pushDecryptResult') {
+    // Resolve a pending decryption request from handleMinimalPushPayload
+    const { eventId } = data as { eventId?: string };
+    if (typeof eventId === 'string') {
+      const resolve = decryptionPendingMap.get(eventId);
+      if (resolve) {
+        decryptionPendingMap.delete(eventId);
+        resolve(data as DecryptionResult);
+      }
+    }
   }
   if (type === 'setAppVisible') {
     if (typeof (data as { visible?: unknown }).visible === 'boolean') {
@@ -346,8 +552,28 @@ const onPushNotification = async (event: PushEvent) => {
     // Badging API absent (Firefox/Gecko) — continue to show the notification.
   }
 
+  // event_id_only format: fetch the event ourselves and (for E2EE rooms) try
+  // to relay decryption to an open app tab.
+  if (isMinimalPushPayload(pushData)) {
+    console.debug('[SW push] minimal payload detected — fetching event', pushData.event_id);
+    await handleMinimalPushPayload(pushData.room_id, pushData.event_id, clients);
+    return;
+  }
+
   await handlePushNotificationPushData(pushData);
 };
+
+// ---------------------------------------------------------------------------
+// Push handler
+// ---------------------------------------------------------------------------
+
+// Detect a minimal (event_id_only) payload: has room_id + event_id but no
+// event type field — meaning the homeserver stripped the event content.
+function isMinimalPushPayload(data: unknown): data is { room_id: string; event_id: string } {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return typeof d.room_id === 'string' && typeof d.event_id === 'string' && !d.type;
+}
 
 self.addEventListener('push', (event: PushEvent) => event.waitUntil(onPushNotification(event)));
 


### PR DESCRIPTION
## What

Implements privacy-first push notifications using the Matrix `event_id_only` pusher format, with client-side decryption relay for E2EE rooms.

## Why

Currently, even with "show encrypted message content" disabled, the homeserver sends the full encrypted event blob + sender display name + room name to Sygnal. With `event_id_only`, **Sygnal sees nothing about message content, sender, or room** — it only forwards `{ room_id, event_id }`.

## How it works

1. **Pusher registration** now sets `format: 'event_id_only'` — the homeserver strips all content before forwarding to Sygnal.
2. **Service worker** detects the minimal payload (`room_id` + `event_id`, no `type`) and fetches the raw event from the homeserver using the stored bearer token. Room name and sender display name are also resolved via homeserver state APIs.
3. **Unencrypted rooms**: event content is available immediately — notification shows real sender name, room name, and message body.
4. **Encrypted rooms (`m.room.encrypted`)**: SW posts `decryptPushEvent` to an open app tab and waits up to 5s for a `pushDecryptResult` reply. The reply includes `document.visibilityState` so the SW can suppress the OS notification entirely if the app is currently visible (avoiding a double-alert).
5. **App-side** (`HandleDecryptPushEvent`): calls `mx.decryptEventIfNeeded()` with the raw event, resolves the sender display name and room name via the SDK, and replies with the decrypted content.
6. **Session persistence**: the Matrix session (access token, homeserver URL, user ID) is persisted to Cache Storage so that iOS — which kills and restarts the SW fresh for every push event — can still fetch the raw event.

## Fallback matrix

| Scenario | Result |
|---|---|
| Unencrypted room, any state | Full content ✅ |
| Encrypted room, app tab open + visible | No OS notification (in-app UI handles it) ✅ |
| Encrypted room, app tab open (Android/desktop) | Full decrypted content after relay ✅ |
| Encrypted room, iOS app backgrounded | "Encrypted message" ⚠️ — iOS freezes the tab JS before the relay can respond |
| App fully closed | "New Message" (still navigates to room on tap) ⚠️ |

## iOS encrypted message limitation

On iOS, the system kills and restarts the service worker for every push, and any backgrounded app tabs are frozen (JS suspended). The decryption relay (SW → app tab → SW) requires a live JS context to call `decryptEventIfNeeded()`, which iOS does not provide. As a result, **encrypted message content is not shown on iOS** — the notification correctly displays sender name and room name, but the body falls back to "Encrypted message".

This is a platform limitation of iOS PWAs. A future native app (e.g. via Tauri v2 + `tauri-plugin-push-notifications`) could address this using an APNS Notification Service Extension to decrypt in a sandboxed Rust process before the notification is displayed.

## Testing/Usage

After deploying, **re-enable push notifications in Settings** to re-register the pusher with the new `format` field. Then send messages from another client while Sable is backgrounded.