### PR TITLE
fix(thread): reduce excessive whitespace between root message and replies

### DIFF
--- a/.changeset/fix-thread-empty-space.md
+++ b/.changeset/fix-thread-empty-space.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix excessive whitespace between the thread root message and replies in the thread drawer

--- a/src/app/features/room/ThreadDrawer.tsx
+++ b/src/app/features/room/ThreadDrawer.tsx
@@ -726,7 +726,7 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
             className={css.messageList}
             direction="Column"
             style={{
-              padding: `${config.space.S600} 0`,
+              padding: `${config.space.S400} 0 ${config.space.S200} 0`,
             }}
           >
             <ThreadMessage {...sharedMessageProps} mEvent={rootEvent} />
@@ -772,7 +772,7 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
               <Box
                 className={css.messageList}
                 direction="Column"
-                style={{ padding: `${config.space.S600} 0` }}
+                style={{ padding: `0 0 ${config.space.S600} 0` }}
               >
                 {replyEvents.map((mEvent, i) => {
                   const prevEvent = i > 0 ? replyEvents[i - 1] : undefined;

--- a/src/app/features/room/ThreadDrawer.tsx
+++ b/src/app/features/room/ThreadDrawer.tsx
@@ -719,6 +719,7 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
           hideTrack={false}
           style={{
             maxHeight: '200px',
+            height: 'fit-content',
             flexShrink: 0,
           }}
         >


### PR DESCRIPTION
## Summary

Fixes #294 — There was approximately 84px of dead whitespace between the thread root message and the first reply in the thread drawer.

### Root cause

- Root message box had `padding: S600 0` (adding `S600` ≈ 32px at bottom)
- Reply messages box had `padding: S600 0` (adding `S600` ≈ 32px at top)
- The reply count label between them added its own `S200` spacing

### Fix

- Root message box: `padding: S600 0` → `padding: S400 0 S200 0` (reduced bottom padding; the label provides visual separation)
- Reply list box: `padding: S600 0` → `padding: 0 0 S600 0` (removed top padding; label + root message bottom padding is sufficient)

Net result: ~84px of dead space reduced to ~32px.