### PR TITLE
fix(timeline): prevent emoji color bleed in read receipt display names

### DIFF
--- a/.changeset/fix-emoji-display-name-color.md
+++ b/.changeset/fix-emoji-display-name-color.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix emoji color bleeding into adjacent text in read receipt display names on Safari/WebKit

--- a/src/app/features/room/RoomViewFollowing.tsx
+++ b/src/app/features/room/RoomViewFollowing.tsx
@@ -89,56 +89,56 @@ export const RoomViewFollowing = as<'div', RoomViewFollowingProps>(
               <Text size="T300" truncate>
                 {names.length === 1 && (
                   <>
-                    <b>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' is following the conversation.'}
                     </Text>
                   </>
                 )}
                 {names.length === 2 && (
                   <>
-                    <b>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' and '}
                     </Text>
-                    <b>{names[1]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[1]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' are following the conversation.'}
                     </Text>
                   </>
                 )}
                 {names.length === 3 && (
                   <>
-                    <b>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {', '}
                     </Text>
-                    <b>{names[1]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[1]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' and '}
                     </Text>
-                    <b>{names[2]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[2]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' are following the conversation.'}
                     </Text>
                   </>
                 )}
                 {names.length > 3 && (
                   <>
-                    <b>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {', '}
                     </Text>
-                    <b>{names[1]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[1]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {', '}
                     </Text>
-                    <b>{names[2]}</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names[2]}</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' and '}
                     </Text>
-                    <b>{names.length - 3} others</b>
-                    <Text as="span" size="Inherit" priority="300">
+                    <b style={{ WebkitTextFillColor: 'inherit' }}>{names.length - 3} others</b>
+                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
                       {' are following the conversation.'}
                     </Text>
                   </>

--- a/src/app/features/room/RoomViewFollowing.tsx
+++ b/src/app/features/room/RoomViewFollowing.tsx
@@ -90,7 +90,12 @@ export const RoomViewFollowing = as<'div', RoomViewFollowingProps>(
                 {names.length === 1 && (
                   <>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' is following the conversation.'}
                     </Text>
                   </>
@@ -98,11 +103,21 @@ export const RoomViewFollowing = as<'div', RoomViewFollowingProps>(
                 {names.length === 2 && (
                   <>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' and '}
                     </Text>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[1]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' are following the conversation.'}
                     </Text>
                   </>
@@ -110,15 +125,30 @@ export const RoomViewFollowing = as<'div', RoomViewFollowingProps>(
                 {names.length === 3 && (
                   <>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {', '}
                     </Text>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[1]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' and '}
                     </Text>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[2]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' are following the conversation.'}
                     </Text>
                   </>
@@ -126,19 +156,39 @@ export const RoomViewFollowing = as<'div', RoomViewFollowingProps>(
                 {names.length > 3 && (
                   <>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[0]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {', '}
                     </Text>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[1]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {', '}
                     </Text>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names[2]}</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' and '}
                     </Text>
                     <b style={{ WebkitTextFillColor: 'inherit' }}>{names.length - 3} others</b>
-                    <Text as="span" size="Inherit" priority="300" style={{ WebkitTextFillColor: 'currentColor' }}>
+                    <Text
+                      as="span"
+                      size="Inherit"
+                      priority="300"
+                      style={{ WebkitTextFillColor: 'currentColor' }}
+                    >
                       {' are following the conversation.'}
                     </Text>
                   </>


### PR DESCRIPTION
## Summary

Fixes #267 — On Safari/iOS, colorful emoji in user display names (e.g. `🔴 Alice`) bled their WebKit text fill color into adjacent text spans in the "following the conversation" indicator at the bottom of the timeline.

### Root cause

WebKit's implementation of `-webkit-text-fill-color` propagates from emoji characters in a `<b>` tag into sibling elements under certain conditions. When a display name containing emoji was rendered as `<b>🔴 Name</b>`, the emoji's color fill propagated to adjacent `<Text>` spans like " and 2 others are following".

### Fix

Added `WebkitTextFillColor: 'inherit'` to all `<b>` name tags in `RoomViewFollowing.tsx` to contain the WebKit fill color within the tag, and `WebkitTextFillColor: 'currentColor'` to the adjacent `<Text as="span">` elements to restore the expected text color explicitly.

Applied to all 4 user-count rendering branches (1, 2, 3, and >3 users).