### PR TITLE
feat(search): intercept Ctrl+F / Cmd+F to open Sable search

### DIFF
--- a/.changeset/feat-ctrl-f-search.md
+++ b/.changeset/feat-ctrl-f-search.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add Ctrl+F / Cmd+F keyboard shortcut to open Sable search instead of browser find-in-page

--- a/src/app/features/search/Search.tsx
+++ b/src/app/features/search/Search.tsx
@@ -407,6 +407,8 @@ export function Search({ requestClose }: SearchProps) {
               <Text size="T200" priority="300">
                 Type <b>#</b> for rooms, <b>@</b> for DMs and <b>*</b> for spaces. Hotkey:{' '}
                 <b>{isMacOS() ? KeySymbol.Command : 'Ctrl'} + k</b>
+                {' / '}
+                <b>{isMacOS() ? KeySymbol.Command : 'Ctrl'} + f</b>
               </Text>
             </Box>
           </Modal>
@@ -423,7 +425,7 @@ export function SearchModalRenderer() {
     window,
     useCallback(
       (event) => {
-        if (isKeyHotkey('mod+k', event)) {
+        if (isKeyHotkey('mod+k', event) || isKeyHotkey('mod+f', event)) {
           event.preventDefault();
           if (opened) {
             setOpen(false);


### PR DESCRIPTION
## Summary

Fixes #179 — Pressing `Ctrl+F` / `Cmd+F` previously opened the browser's native find-in-page dialog. It now opens Sable's search modal instead.

### Change

In `SearchModalRenderer`, the keyboard shortcut handler was extended to also match `mod+f` in addition to the existing `mod+k`. Both shortcuts now:
- `preventDefault()` the event (suppressing browser find-in-page)
- Toggle the search modal open/closed
- Skip opening if another overlay (portal) is already visible

The hint text in the search modal footer was updated to show both `Ctrl+K / Ctrl+F` (or `⌘+K / ⌘+F` on macOS).