### PR TITLE
fix(call): respect saved camera/mic preferences when starting call from room header

### DIFF
--- a/.changeset/fix-call-camera-default.md
+++ b/.changeset/fix-call-camera-default.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix camera turning on by default when starting a call from the room header button

--- a/src/app/features/room/RoomCallButton.tsx
+++ b/src/app/features/room/RoomCallButton.tsx
@@ -4,6 +4,7 @@ import { Room } from '$types/matrix-sdk';
 import { useCallStart, useCallJoined } from '$hooks/useCallEmbed';
 import { callEmbedAtom } from '$state/callEmbed';
 import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useCallPreferences } from '$state/hooks/callPreferences';
 
 interface RoomCallButtonProps {
   room: Room;
@@ -14,13 +15,14 @@ export function RoomCallButton({ room }: RoomCallButtonProps) {
   const callEmbed = useAtomValue(callEmbedAtom);
   const joined = useCallJoined(callEmbed);
   const mx = useMatrixClient();
+  const { microphone, video, sound } = useCallPreferences();
 
   const isJoinedInThisRoom = joined && callEmbed?.roomId === room.roomId;
 
   if (isJoinedInThisRoom) return null;
 
   const handleStartCall = async () => {
-    startCall(room);
+    startCall(room, { microphone, video, sound });
     try {
       const now = Date.now();
       // TODO not use as any one day someday i swear


### PR DESCRIPTION
## Summary

Fixes #285 — Camera was turning on by default when starting a call from the room header button, even when the user had previously disabled video in their call preferences.

### Root cause

`RoomCallButton` called `startCall(room)` without passing any preferences. This caused `createCallEmbed` to fall back to `CallEmbed`'s default `CallControlState` (which uses hardcoded defaults), ignoring the user's saved preferences stored in `callPreferencesAtom`.

`PrescreenControls` already correctly passed `{ microphone, video, sound }` via `useCallPreferences()` when starting a call from the in-room join button. `RoomCallButton` was missing this.

### Fix

Added `useCallPreferences()` to `RoomCallButton` and passed the preferences to `startCall(room, { microphone, video, sound })`, matching the pattern used in `PrescreenControls`.