### PR TITLE
fix(sidebar): center notification dot on avatar corner

### DIFF
--- a/.changeset/fix-notification-dot-alignment.md
+++ b/.changeset/fix-notification-dot-alignment.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix notification dot badge appearing off-center on sidebar avatars

--- a/src/app/components/sidebar/Sidebar.css.ts
+++ b/src/app/components/sidebar/Sidebar.css.ts
@@ -134,8 +134,8 @@ export const SidebarItemBadge = recipe({
         left: toRem(-6),
       },
       false: {
-        top: toRem(-2),
-        left: toRem(-2),
+        top: toRem(-4),
+        left: toRem(-4),
       },
     },
   },
@@ -167,9 +167,9 @@ export const SidebarItemBadge = recipe({
       style: {
         selectors: {
           'div:has(> button[data-id]) &': {
-            top: toRem(2),
+            top: toRem(0),
             left: 'auto',
-            right: toRem(2),
+            right: toRem(0),
           },
         },
       },

--- a/src/app/pages/client/sidebar/DirectDMsList.tsx
+++ b/src/app/pages/client/sidebar/DirectDMsList.tsx
@@ -141,7 +141,7 @@ function DMItem({ room, selected }: DMItemProps) {
         <SidebarItemBadge
           hasCount={unread.total > 0}
           style={{
-            left: unread.total > 0 ? toRem(-6) : toRem(-2),
+            left: unread.total > 0 ? toRem(-6) : toRem(-4),
             right: 'auto',
           }}
         >

--- a/src/app/pages/client/sidebar/DirectTab.tsx
+++ b/src/app/pages/client/sidebar/DirectTab.tsx
@@ -118,7 +118,7 @@ export function DirectTab() {
         <SidebarItemBadge
           hasCount={directUnread.total > 0}
           style={{
-            left: directUnread.total > 0 ? toRem(-6) : toRem(-2),
+            left: directUnread.total > 0 ? toRem(-6) : toRem(-4),
             right: 'auto',
           }}
         >

--- a/src/app/pages/client/sidebar/HomeTab.tsx
+++ b/src/app/pages/client/sidebar/HomeTab.tsx
@@ -112,7 +112,7 @@ export function HomeTab() {
         <SidebarItemBadge
           hasCount={homeUnread.total > 0}
           style={{
-            left: homeUnread.total > 0 ? toRem(-6) : toRem(-2),
+            left: homeUnread.total > 0 ? toRem(-6) : toRem(-4),
             right: 'auto',
           }}
         >

--- a/src/app/pages/client/sidebar/SpaceTabs.tsx
+++ b/src/app/pages/client/sidebar/SpaceTabs.tsx
@@ -468,7 +468,7 @@ function SpaceTab({
             <SidebarItemBadge
               hasCount={unread.total > 0}
               style={{
-                left: unread.total > 0 ? toRem(-6) : toRem(-2),
+                left: unread.total > 0 ? toRem(-6) : toRem(-4),
                 right: 'auto',
               }}
             >
@@ -609,7 +609,7 @@ function ClosedSpaceFolder({
             <SidebarItemBadge
               hasCount={unread.total > 0}
               style={{
-                left: unread.total > 0 ? toRem(-6) : toRem(-2),
+                left: unread.total > 0 ? toRem(-6) : toRem(-4),
                 right: 'auto',
               }}
             >


### PR DESCRIPTION
## Summary

Fixes #293 — The notification dot badge appeared off-center relative to the avatar icon in the sidebar.

### Root cause

The dot badge (`Badge size="200"`, which is 8px × 8px) was positioned at `top: -2px, left: -2px`. This placed the dot's center at `(2px, 2px)` inside the avatar corner rather than at the corner itself.

By comparison, the count badge uses `top: -6px, left: -6px` which correctly centers a ~12px badge on the corner.

### Fix

Changed the dot badge position from `top: -2px, left: -2px` to `top: -4px, left: -4px` (i.e. `-(8/2) = -4px` for an 8px dot). This centers the dot exactly on the top-left corner of the avatar, consistent with how the count badge is positioned.

**Files changed:**
- `Sidebar.css.ts` — updated CSS recipe `hasCount: false` variant and folder compound variant
- `HomeTab.tsx`, `DirectTab.tsx`, `DirectDMsList.tsx`, `SpaceTabs.tsx` — updated inline `left` style for the dot case