### PR TITLE
Fix macOS name in the devices tab from 'Mac OS' to 'macOS'

### DIFF
--- a/.changeset/fix-macos-casing.md
+++ b/.changeset/fix-macos-casing.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixes Mac OS to macOS in the the devices tab

--- a/.changeset/fix-macos-casing.md
+++ b/.changeset/fix-macos-casing.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-Fixes Mac OS to macOS in the the devices tab
+Fix Mac OS to macOS in the the devices tab

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -9,7 +9,7 @@ const isMobileOrTablet = (() => {
   return false;
 })();
 
-const isMac = result.os.name === 'macOS';
+const isMac = result.os.name === 'Mac OS';
 
 export const ua = () => result;
 export const isMacOS = () => isMac;

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -9,7 +9,7 @@ const isMobileOrTablet = (() => {
   return false;
 })();
 
-const isMac = result.os.name === 'Mac OS';
+const isMac = result.os.name === 'macOS';
 
 export const ua = () => result;
 export const isMacOS = () => isMac;

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -9,6 +9,12 @@ const isMobileOrTablet = (() => {
   return false;
 })();
 
+const normalizeMacName = (os?: string) => {
+  if (!os) return os;
+  if (os === 'Mac OS') return 'macOS';
+  return os;
+};
+
 const isMac = result.os.name === 'Mac OS';
 
 export const ua = () => result;
@@ -17,7 +23,7 @@ export const mobileOrTablet = () => isMobileOrTablet;
 
 export const deviceDisplayName = (): string => {
   const browser = result.browser.name;
-  const os = result.os.name;
+  const os = normalizeMacName(result.os.name);
   if (!browser || !os) return 'Sable Web';
   return `Sable on ${browser} for ${os}`;
 };


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixed the issue where mac users would have their device name be Mac OS instead of macOS

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
