### PR TITLE
Hide presence badge in members list for unsupported users

### DIFF
--- a/.changeset/fix-presence-badge-member-list.md
+++ b/.changeset/fix-presence-badge-member-list.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Hide presence badge in members list for users without homeserver support, mimicking room profile apperance.

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -155,7 +155,11 @@ function MemberItem({
           }}
         >
           <AvatarPresence
-            badge={presence && <PresenceBadge presence={presence.presence} size="200" />}
+            badge={
+              presence && presence.lastActiveTs !== 0 ? (
+                <PresenceBadge presence={presence.presence} size="200" />
+              ) : undefined
+            }
           >
             <Avatar size="300" radii="400">
               <UserAvatar


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Hides the presence badge entirely for users that don't have homeservers sending out presence

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
