### PR TITLE
feat: add cosmetics support to per-message profiles

### DIFF
--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -372,6 +372,8 @@ function MessageInternal(
             avatar_url: string | undefined;
             displayname: string | undefined;
             id: string | undefined;
+            "moe.sable.app.name_color": string | undefined;
+            "io.fsky.nyx.pronouns": any | undefined;
           }
         | undefined,
     [mEvent]
@@ -379,7 +381,9 @@ function MessageInternal(
 
   // Profiles and Colors
   const profile = useUserProfile(senderId, room);
-  const { color: usernameColor, font: usernameFont } = useSableCosmetics(senderId, room);
+  const cosmetics = useSableCosmetics(senderId, room);
+  const usernameColor = pmp?.["moe.sable.app.name_color"] ?? cosmetics.color
+  const usernameFont = cosmetics.font // TODO: try allowing per-message font
 
   const [highlightMentions] = useSetting(settingsAtom, 'highlightMentions');
 
@@ -430,8 +434,9 @@ function MessageInternal(
     return getParsedPronouns(rawName, parsePronouns);
   }, [pmp, senderDisplayName, parsePronouns]);
 
+  const sourcePronouns = pmp?.["io.fsky.nyx.pronouns"] ?? profile.pronouns ?? []
   const mergedPronouns = useMemo(() => {
-    const existing = profile.pronouns ? [...profile.pronouns] : [];
+    const existing = sourcePronouns ? [...sourcePronouns] : [];
 
     if (inlinePronoun) {
       const isDupe = existing.some((p) => p.summary?.toLowerCase() === inlinePronoun);
@@ -445,7 +450,7 @@ function MessageInternal(
     }
 
     return existing;
-  }, [profile.pronouns, inlinePronoun]);
+  }, [sourcePronouns, inlinePronoun]);
 
   useEffect(() => {
     if (!mobileOptionsOpen) return undefined;


### PR DESCRIPTION
This patch allows the following keys to be set on messages' `com.beeper.per_message_profiles` key:

* `moe.sable.app.name_color`: Overrides the name color; same format as `moe.sable.app.name_color` in profiles.
* `io.fsky.nyx.pronouns`: Overrides the per-message pronouns; same format as `io.fsky.nyx.pronouns` in profiles.

# Considerations

* The ability to override custom fonts has intentionally been left unimplemented. Per-message fonts could allow users to specify custom name fonts without needing room-admin approval, which could be dangerous.
