### PR TITLE
Change URL to GitLab Pages publishing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can also download our desktop app for windows and linux from [releases](http
 ## Self-hosting
 You have a few options for self hosting, you can:
 1. Run the prebuilt docker container.
-2. Deploy on a site like GitLab Pages. Jae has a [guide here](https://docs.j4.lc/Public+documentation/Tutorials/Deploying+Sable+on+GitLab+Pages).
+2. Deploy on a site like GitLab Pages. Jae has a [guide here](https://docs.j4.lc/Tutorials/Deploying-Sable-on-GitLab-Pages).
 3. Build it yourself.
 
 ### Docker


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

After cleaning up my own docs, I realised the link to my article about how to publish Sable on GitLab Pages ended on a 404. This PR replaces the link with the new one.

I'm not sure what to check down below, as this is a README change.

Fixes:
- Correct URL to my docs in README that was pointing to the wrong place after I cleaned up the docs.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
