### PR TITLE
fix: reduce mention highlight background opacity

### DIFF
--- a/.changeset/reduce-mention-highlight-opacity.md
+++ b/.changeset/reduce-mention-highlight-opacity.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reduced the opacity of mention highlight backgrounds to be less visually intrusive while remaining noticeable.

--- a/src/app/components/message/layout/layout.css.ts
+++ b/src/app/components/message/layout/layout.css.ts
@@ -67,11 +67,11 @@ const HighlightVariant = styleVariants({
 
 const NotifyHighlightVariant = styleVariants({
   silent: {
-    backgroundColor: `color-mix(in srgb, ${color.Secondary.Container} 40%, transparent)`,
+    backgroundColor: `color-mix(in srgb, ${color.Secondary.Container} 25%, transparent)`,
     boxShadow: `inset ${config.borderWidth.B700} 0 0 ${color.Secondary.ContainerLine}`,
   },
   loud: {
-    backgroundColor: `color-mix(in srgb, ${color.Warning.Container} 40%, transparent)`,
+    backgroundColor: `color-mix(in srgb, ${color.Warning.Container} 25%, transparent)`,
     boxShadow: `inset ${config.borderWidth.B700} 0 0 ${color.Warning.ContainerLine}`,
   },
 });

--- a/src/app/components/message/layout/layout.css.ts
+++ b/src/app/components/message/layout/layout.css.ts
@@ -67,11 +67,11 @@ const HighlightVariant = styleVariants({
 
 const NotifyHighlightVariant = styleVariants({
   silent: {
-    backgroundColor: color.Secondary.Container,
+    backgroundColor: `color-mix(in srgb, ${color.Secondary.Container} 40%, transparent)`,
     boxShadow: `inset ${config.borderWidth.B700} 0 0 ${color.Secondary.ContainerLine}`,
   },
   loud: {
-    backgroundColor: color.Warning.Container,
+    backgroundColor: `color-mix(in srgb, ${color.Warning.Container} 40%, transparent)`,
     boxShadow: `inset ${config.borderWidth.B700} 0 0 ${color.Warning.ContainerLine}`,
   },
 });


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Reduces the background opacity of mention highlight rows (both silent and loud variants) from full color to 40%

Tested the change locally and here is the screenshot of the reduced opacity,
<img width="849" height="219" alt="Screenshot 2026-03-19 at 11 53 32 AM" src="https://github.com/user-attachments/assets/3069b2dd-6017-4e98-9bf3-4ce15c406d77" />

Fixes #370 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
