### PR TITLE
feat(settings): option to disable reply mentions by default

### DIFF
--- a/.changeset/pr405-silent-reply-setting.md
+++ b/.changeset/pr405-silent-reply-setting.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add a setting to disable reply mentions by default

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -258,6 +258,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
     const [isMarkdown] = useSetting(settingsAtom, 'isMarkdown');
     const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
+    const [mentionInReplies] = useSetting(settingsAtom, 'mentionInReplies');
     const commands = useCommands(mx, room);
     const emojiBtnRef = useRef<HTMLButtonElement>(null);
     const micBtnRef = useRef<HTMLButtonElement>(null);
@@ -363,7 +364,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     );
     const [scheduleMenuAnchor, setScheduleMenuAnchor] = useState<RectCords>();
     const [showSchedulePicker, setShowSchedulePicker] = useState(false);
-    const [silentReply, setSilentReply] = useState(false);
+    const [silentReply, setSilentReply] = useState(!mentionInReplies);
     const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
     const isEncrypted = room.hasEncryptionStateEvent();
 
@@ -449,9 +450,9 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     useEffect(() => {
       if (replyDraft !== undefined) {
-        setSilentReply(replyDraft.userId === mx.getUserId());
+        setSilentReply(replyDraft.userId === mx.getUserId() || !mentionInReplies);
       }
-    }, [mx, replyDraft]);
+    }, [mentionInReplies, mx, replyDraft]);
 
     const handleFileMetadata = useCallback(
       (fileItem: TUploadItem, metadata: TUploadMetadata) => {

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -421,6 +421,7 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
   const [hideActivity, setHideActivity] = useSetting(settingsAtom, 'hideActivity');
   const [hideReads, setHideReads] = useSetting(settingsAtom, 'hideReads');
   const [sendPresence, setSendPresence] = useSetting(settingsAtom, 'sendPresence');
+  const [mentionInReplies, setMentionInReplies] = useSetting(settingsAtom, 'mentionInReplies');
 
   return (
     <Box direction="Column" gap="100">
@@ -469,6 +470,15 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
           title="Presence Status"
           description="Show and receive online status from other users."
           after={<Switch variant="Primary" value={sendPresence} onChange={setSendPresence} />}
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Send notifications for replies"
+          description="Disable to use silent replies by default. You can still toggle reply notifications for each reply."
+          after={
+            <Switch variant="Primary" value={mentionInReplies} onChange={setMentionInReplies} />
+          }
         />
       </SequenceCard>
     </Box>

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -99,6 +99,7 @@ export interface Settings {
   alwaysShowCallButton: boolean;
   faviconForMentionsOnly: boolean;
   highlightMentions: boolean;
+  mentionInReplies: boolean;
 
   // furry stuff
   renderAnimals: boolean;
@@ -182,6 +183,7 @@ const defaultSettings: Settings = {
   alwaysShowCallButton: false,
   faviconForMentionsOnly: false,
   highlightMentions: true,
+  mentionInReplies: true,
 
   // furry stuff
   renderAnimals: true,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

adds this nice setting into the general/editor category:
<img width="568" height="105" alt="image" src="https://github.com/user-attachments/assets/df41caa7-6d3d-404e-877e-ca5741b9a2c0" />

default enabled, toggling it off makes your replies not mention the user you're replying to by default, without removing the ability to toggle it back on per reply

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
