### PR TITLE
feat: room abbreviations with hover tooltips

### DIFF
--- a/.changeset/feat-room-abbreviations.md
+++ b/.changeset/feat-room-abbreviations.md
@@ -2,4 +2,6 @@
 default: minor
 ---
 
+# feat: room abbreviations with hover tooltips
+
 Add room abbreviations: moderators can define a list of term/definition pairs in room settings; defined terms are highlighted with a hover tooltip in plain-text messages.

--- a/.changeset/feat-room-abbreviations.md
+++ b/.changeset/feat-room-abbreviations.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add room abbreviations: moderators can define a list of term/definition pairs in room settings; defined terms are highlighted with a hover tooltip in plain-text messages.

--- a/src/app/components/message/RenderBody.tsx
+++ b/src/app/components/message/RenderBody.tsx
@@ -41,7 +41,11 @@ function AbbreviationTerm({ text, definition }: AbbreviationTermProps) {
       <TooltipProvider position="Top" tooltip={tooltipContent}>
         {(triggerRef) => (
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-          <abbr ref={triggerRef as React.Ref<HTMLElement>} onClick={handleClick}>
+          <abbr
+            ref={triggerRef as React.Ref<HTMLElement>}
+            onClick={handleClick}
+            style={{ textDecoration: 'underline dotted', cursor: 'help' }}
+          >
             {text}
           </abbr>
         )}

--- a/src/app/components/message/RenderBody.tsx
+++ b/src/app/components/message/RenderBody.tsx
@@ -1,8 +1,11 @@
 import parse, { HTMLReactParserOptions } from 'html-react-parser';
 import Linkify from 'linkify-react';
 import { Opts } from 'linkifyjs';
+import { Text, Tooltip, TooltipProvider, toRem } from 'folds';
 import { sanitizeCustomHtml } from '$utils/sanitize';
 import { highlightText, scaleSystemEmoji } from '$plugins/react-custom-html-parser';
+import { useRoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
+import { splitByAbbreviations } from '$utils/abbreviations';
 import { MessageEmptyContent } from './content';
 
 type RenderBodyProps = {
@@ -20,11 +23,54 @@ export function RenderBody({
   htmlReactParserOptions,
   linkifyOpts,
 }: Readonly<RenderBodyProps>) {
+  const abbrMap = useRoomAbbreviationsContext();
+
   if (customBody) {
     if (customBody === '') return <MessageEmptyContent />;
     return parse(sanitizeCustomHtml(customBody), htmlReactParserOptions);
   }
   if (body === '') return <MessageEmptyContent />;
+
+  if (abbrMap.size > 0) {
+    const segments = splitByAbbreviations(body, abbrMap);
+    if (segments.some((s) => s.termKey !== undefined)) {
+      return (
+        <>
+          {segments.map((seg, i) => {
+            if (seg.termKey !== undefined) {
+              const definition = abbrMap.get(seg.termKey) ?? '';
+              return (
+                <TooltipProvider
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={i}
+                  position="Bottom"
+                  tooltip={
+                    <Tooltip style={{ maxWidth: toRem(250) }}>
+                      <Text size="T200">{definition}</Text>
+                    </Tooltip>
+                  }
+                >
+                  {(triggerRef) => (
+                    <abbr ref={triggerRef as React.Ref<HTMLElement>} title={definition}>
+                      {seg.text}
+                    </abbr>
+                  )}
+                </TooltipProvider>
+              );
+            }
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <Linkify key={i} options={linkifyOpts}>
+                {highlightRegex
+                  ? highlightText(highlightRegex, scaleSystemEmoji(seg.text))
+                  : scaleSystemEmoji(seg.text)}
+              </Linkify>
+            );
+          })}
+        </>
+      );
+    }
+  }
 
   return (
     <Linkify options={linkifyOpts}>

--- a/src/app/components/message/RenderBody.tsx
+++ b/src/app/components/message/RenderBody.tsx
@@ -1,12 +1,59 @@
+import { MouseEventHandler, useEffect, useState } from 'react';
 import parse, { HTMLReactParserOptions } from 'html-react-parser';
 import Linkify from 'linkify-react';
 import { Opts } from 'linkifyjs';
-import { Text, Tooltip, TooltipProvider, toRem } from 'folds';
+import { PopOut, RectCords, Text, Tooltip, TooltipProvider, toRem } from 'folds';
 import { sanitizeCustomHtml } from '$utils/sanitize';
 import { highlightText, scaleSystemEmoji } from '$plugins/react-custom-html-parser';
 import { useRoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
 import { splitByAbbreviations } from '$utils/abbreviations';
 import { MessageEmptyContent } from './content';
+
+type AbbreviationTermProps = {
+  text: string;
+  definition: string;
+};
+function AbbreviationTerm({ text, definition }: AbbreviationTermProps) {
+  const [anchor, setAnchor] = useState<RectCords | undefined>();
+
+  const handleClick: MouseEventHandler<HTMLElement> = (e) => {
+    e.stopPropagation();
+    setAnchor((prev) => (prev ? undefined : e.currentTarget.getBoundingClientRect()));
+  };
+
+  // On mobile, tapping an abbreviation pins the tooltip open.
+  // Tapping anywhere else (outside the abbr) dismisses it.
+  useEffect(() => {
+    if (!anchor) return undefined;
+    const dismiss = () => setAnchor(undefined);
+    document.addEventListener('click', dismiss, { once: true });
+    return () => document.removeEventListener('click', dismiss);
+  }, [anchor]);
+
+  const tooltipContent = (
+    <Tooltip style={{ maxWidth: toRem(250) }}>
+      <Text size="T200">{definition}</Text>
+    </Tooltip>
+  );
+
+  return (
+    <>
+      <TooltipProvider position="Top" tooltip={tooltipContent}>
+        {(triggerRef) => (
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+          <abbr ref={triggerRef as React.Ref<HTMLElement>} onClick={handleClick}>
+            {text}
+          </abbr>
+        )}
+      </TooltipProvider>
+      {anchor && (
+        <PopOut anchor={anchor} position="Top" align="Center" content={tooltipContent}>
+          {null}
+        </PopOut>
+      )}
+    </>
+  );
+}
 
 type RenderBodyProps = {
   body: string;
@@ -40,22 +87,8 @@ export function RenderBody({
             if (seg.termKey !== undefined) {
               const definition = abbrMap.get(seg.termKey) ?? '';
               return (
-                <TooltipProvider
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={i}
-                  position="Bottom"
-                  tooltip={
-                    <Tooltip style={{ maxWidth: toRem(250) }}>
-                      <Text size="T200">{definition}</Text>
-                    </Tooltip>
-                  }
-                >
-                  {(triggerRef) => (
-                    <abbr ref={triggerRef as React.Ref<HTMLElement>} title={definition}>
-                      {seg.text}
-                    </abbr>
-                  )}
-                </TooltipProvider>
+                // eslint-disable-next-line react/no-array-index-key
+                <AbbreviationTerm key={i} text={seg.text} definition={definition} />
               );
             }
             return (

--- a/src/app/features/room-settings/RoomSettings.tsx
+++ b/src/app/features/room-settings/RoomSettings.tsx
@@ -19,6 +19,7 @@ import { DeveloperTools } from '$features/common-settings/developer-tools';
 import { Cosmetics } from '$features/common-settings/cosmetics/Cosmetics';
 import { Permissions } from './permissions';
 import { General } from './general';
+import { RoomAbbreviations } from './abbreviations/RoomAbbreviations';
 
 type RoomSettingsMenuItem = {
   page: RoomSettingsPage;
@@ -50,6 +51,11 @@ const useRoomSettingsMenuItems = (): RoomSettingsMenuItem[] =>
         name: 'Cosmetics',
         icon: Icons.Alphabet,
         activeIcon: Icons.AlphabetUnderline,
+      },
+      {
+        page: RoomSettingsPage.AbbreviationsPage,
+        name: 'Abbreviations',
+        icon: Icons.Info,
       },
       {
         page: RoomSettingsPage.EmojisStickersPage,
@@ -195,6 +201,9 @@ export function RoomSettings({ initialPage, requestClose }: RoomSettingsProps) {
         )}
         {activePage === RoomSettingsPage.DeveloperToolsPage && (
           <DeveloperTools requestClose={handlePageRequestClose} />
+        )}
+        {activePage === RoomSettingsPage.AbbreviationsPage && (
+          <RoomAbbreviations requestClose={handlePageRequestClose} />
         )}
       </PageRoot>
     </SwipeableOverlayWrapper>

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -31,9 +31,10 @@ import { SequenceCardStyle } from '$features/common-settings/styles.css';
 
 type AbbreviationsProps = {
   requestClose: () => void;
+  isSpace?: boolean;
 };
 
-export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
+export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps) {
   const room = useRoom();
   const mx = useMatrixClient();
   const powerLevels = usePowerLevels(room);
@@ -190,7 +191,7 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
                 </Box>
               )}
 
-              {parentSpace && (
+              {!isSpace && parentSpace && (
                 <Box direction="Column" gap="100">
                   <Text size="L400">
                     {spaceEntries.length > 0
@@ -240,8 +241,8 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
               <Box direction="Column" gap="100">
                 <Text size="L400">
                   {entries.length > 0
-                    ? `Room Abbreviations (${entries.length})`
-                    : 'Room Abbreviations'}
+                    ? `${isSpace ? 'Space' : 'Room'} Abbreviations (${entries.length})`
+                    : `${isSpace ? 'Space' : 'Room'} Abbreviations`}
                 </Text>
                 {entries.length === 0 ? (
                   <SequenceCard
@@ -250,7 +251,7 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
                     direction="Column"
                   >
                     <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
-                      No room-level abbreviations defined yet.
+                      No {isSpace ? 'space' : 'room'}-level abbreviations defined yet.
                       {canEdit && ' Use the form above to add some.'}
                     </Text>
                   </SequenceCard>

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -301,7 +301,7 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
                                       <Text size="T300">
                                         <b>{entry.term}</b>
                                       </Text>
-                                      <Chip variant="Primary" radii="Pill" size="300">
+                                      <Chip variant="Primary" radii="Pill" size="400">
                                         <Text size="T200">Space - {spaceName}</Text>
                                       </Chip>
                                     </Box>

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -56,7 +56,7 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
     const definition = definitionInput.value.trim();
     if (!term || !definition) return;
 
-    const alreadyExists = entries.some((e) => e.term === term);
+    const alreadyExists = entries.some((e) => e.term.toLowerCase() === term.toLowerCase());
     if (alreadyExists) {
       termInput.setCustomValidity('This term already exists.');
       termInput.reportValidity();

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -56,7 +56,7 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
     const definition = definitionInput.value.trim();
     if (!term || !definition) return;
 
-    const alreadyExists = entries.some((e) => e.term.toLowerCase() === term.toLowerCase());
+    const alreadyExists = entries.some((e) => e.term === term);
     if (alreadyExists) {
       termInput.setCustomValidity('This term already exists.');
       termInput.reportValidity();

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -1,4 +1,5 @@
-import { FormEventHandler, useCallback } from 'react';
+import { FormEventHandler, useCallback, useMemo } from 'react';
+import { useAtomValue } from 'jotai';
 import {
   Box,
   Button,
@@ -21,12 +22,14 @@ import { usePowerLevels } from '$hooks/usePowerLevels';
 import { useRoomCreators } from '$hooks/useRoomCreators';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
 import { useStateEvent } from '$hooks/useStateEvent';
-import { useSpaceOptionally } from '$hooks/useSpace';
-import { useRoomName } from '$hooks/useRoomMeta';
+import { useStateEventCallback } from '$hooks/useStateEventCallback';
+import { useForceUpdate } from '$hooks/useForceUpdate';
 import { StateEvent } from '$types/matrix/room';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { MatrixError } from '$types/matrix-sdk';
 import { AbbreviationEntry, RoomAbbreviationsContent } from '$utils/abbreviations';
+import { getAllParents, getStateEvent } from '$utils/room';
+import { roomToParentsAtom } from '$state/room/roomToParents';
 import { SequenceCardStyle } from '$features/common-settings/styles.css';
 
 type AbbreviationsProps = {
@@ -46,16 +49,48 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
   const content = stateEvent?.getContent<RoomAbbreviationsContent>();
   const entries: AbbreviationEntry[] = Array.isArray(content?.entries) ? content.entries : [];
 
-  // Parent space abbreviations (read-only, inherited)
-  const parentSpace = useSpaceOptionally();
-  const parentSpaceName = useRoomName(parentSpace ?? room);
-  const spaceStateEvent = useStateEvent(parentSpace ?? room, StateEvent.RoomAbbreviations);
-  const spaceContent = parentSpace
-    ? spaceStateEvent?.getContent<RoomAbbreviationsContent>()
-    : undefined;
-  const spaceEntries: AbbreviationEntry[] = Array.isArray(spaceContent?.entries)
-    ? spaceContent.entries
-    : [];
+  // Ancestor space abbreviations (read-only, inherited) — full multi-level support
+  const roomToParents = useAtomValue(roomToParentsAtom);
+  const [ancestorUpdateCount, forceAncestorUpdate] = useForceUpdate();
+
+  useStateEventCallback(
+    mx,
+    useCallback(
+      (event) => {
+        if (event.getType() !== StateEvent.RoomAbbreviations) return;
+        const eventRoomId = event.getRoomId();
+        if (eventRoomId && getAllParents(roomToParents, room.roomId).has(eventRoomId)) {
+          forceAncestorUpdate();
+        }
+      },
+      [room.roomId, roomToParents, forceAncestorUpdate]
+    )
+  );
+
+  type SpaceEntryGroup = { spaceId: string; spaceName: string; entries: AbbreviationEntry[] };
+  const ancestorGroups = useMemo(
+    (): SpaceEntryGroup[] =>
+      Array.from(getAllParents(roomToParents, room.roomId)).reduce<SpaceEntryGroup[]>(
+        (groups, parentId) => {
+          const parentRoom = mx.getRoom(parentId);
+          if (!parentRoom) return groups;
+          const ev = getStateEvent(parentRoom, StateEvent.RoomAbbreviations);
+          const c = ev?.getContent<RoomAbbreviationsContent>();
+          const parentEntries: AbbreviationEntry[] = Array.isArray(c?.entries) ? c.entries : [];
+          if (parentEntries.length > 0) {
+            groups.push({ spaceId: parentId, spaceName: parentRoom.name, entries: parentEntries });
+          }
+          return groups;
+        },
+        []
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mx, roomToParents, room.roomId, ancestorUpdateCount]
+  );
+  const allAncestorEntries = useMemo(
+    () => ancestorGroups.flatMap((g) => g.entries),
+    [ancestorGroups]
+  );
 
   const canEdit = permissions.stateEvent(StateEvent.RoomAbbreviations, userId);
 
@@ -84,7 +119,7 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
 
     const alreadyExists =
       entries.some((e) => e.term.toLowerCase() === term.toLowerCase()) ||
-      spaceEntries.some((e) => e.term.toLowerCase() === term.toLowerCase());
+      allAncestorEntries.some((e) => e.term.toLowerCase() === term.toLowerCase());
     if (alreadyExists) {
       termInput.setCustomValidity('This term already exists.');
       termInput.reportValidity();
@@ -191,106 +226,97 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
                 </Box>
               )}
 
-              {!isSpace && parentSpace && (
-                <Box direction="Column" gap="100">
-                  <Text size="L400">
-                    {spaceEntries.length > 0
-                      ? `Inherited from Space (${spaceEntries.length})`
-                      : 'Inherited from Space'}
-                  </Text>
-                  {spaceEntries.length === 0 ? (
-                    <SequenceCard
-                      className={SequenceCardStyle}
-                      variant="SurfaceVariant"
-                      direction="Column"
-                    >
-                      <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
-                        No abbreviations defined in {parentSpaceName}.
-                      </Text>
-                    </SequenceCard>
-                  ) : (
-                    spaceEntries.map((entry, index) => (
-                      <SequenceCard
-                        // eslint-disable-next-line react/no-array-index-key
-                        key={index}
-                        className={SequenceCardStyle}
-                        variant="SurfaceVariant"
-                        direction="Row"
-                        gap="400"
-                        alignItems="Center"
-                      >
-                        <Box grow="Yes" direction="Column" gap="100">
-                          <Box gap="200" alignItems="Center">
-                            <Text size="T300">
-                              <b>{entry.term}</b>
-                            </Text>
-                            <Chip variant="Primary" radii="Pill" size="300">
-                              <Text size="T200">Space</Text>
-                            </Chip>
-                          </Box>
-                          <Text size="T200" style={{ opacity: 0.7 }}>
-                            {entry.definition}
-                          </Text>
-                        </Box>
-                      </SequenceCard>
-                    ))
-                  )}
-                </Box>
-              )}
-
               <Box direction="Column" gap="100">
-                <Text size="L400">
-                  {entries.length > 0
-                    ? `${isSpace ? 'Space' : 'Room'} Abbreviations (${entries.length})`
-                    : `${isSpace ? 'Space' : 'Room'} Abbreviations`}
-                </Text>
-                {entries.length === 0 ? (
-                  <SequenceCard
-                    className={SequenceCardStyle}
-                    variant="SurfaceVariant"
-                    direction="Column"
-                  >
-                    <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
-                      No {isSpace ? 'space' : 'room'}-level abbreviations defined yet.
-                      {canEdit && ' Use the form above to add some.'}
-                    </Text>
-                  </SequenceCard>
-                ) : (
-                  entries.map((entry, index) => (
-                    <SequenceCard
-                      // eslint-disable-next-line react/no-array-index-key
-                      key={index}
-                      className={SequenceCardStyle}
-                      variant="SurfaceVariant"
-                      direction="Row"
-                      gap="400"
-                      alignItems="Center"
-                    >
-                      <Box grow="Yes" direction="Column" gap="100">
-                        <Text size="T300">
-                          <b>{entry.term}</b>
-                        </Text>
-                        <Text size="T200" style={{ opacity: 0.7 }}>
-                          {entry.definition}
-                        </Text>
-                      </Box>
-                      {canEdit && (
-                        <Box shrink="No">
-                          <IconButton
-                            onClick={() => handleRemove(index)}
-                            variant="Background"
-                            size="300"
-                            radii="300"
-                            disabled={saving}
-                            aria-label={`Remove abbreviation ${entry.term}`}
-                          >
-                            <Icon src={Icons.Delete} size="100" />
-                          </IconButton>
-                        </Box>
+                {(() => {
+                  const totalCount = entries.length + (isSpace ? 0 : allAncestorEntries.length);
+                  const label = isSpace ? 'Space' : 'Room';
+                  return (
+                    <>
+                      <Text size="L400">
+                        {totalCount > 0
+                          ? `${label} Abbreviations (${totalCount})`
+                          : `${label} Abbreviations`}
+                      </Text>
+                      {totalCount === 0 ? (
+                        <SequenceCard
+                          className={SequenceCardStyle}
+                          variant="SurfaceVariant"
+                          direction="Column"
+                        >
+                          <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
+                            No {isSpace ? 'space' : 'room'}-level abbreviations defined yet.
+                            {canEdit && ' Use the form above to add some.'}
+                          </Text>
+                        </SequenceCard>
+                      ) : (
+                        <>
+                          {entries.map((entry, index) => (
+                            <SequenceCard
+                              // eslint-disable-next-line react/no-array-index-key
+                              key={`room-${index}`}
+                              className={SequenceCardStyle}
+                              variant="SurfaceVariant"
+                              direction="Row"
+                              gap="400"
+                              alignItems="Center"
+                            >
+                              <Box grow="Yes" direction="Column" gap="100">
+                                <Text size="T300">
+                                  <b>{entry.term}</b>
+                                </Text>
+                                <Text size="T200" style={{ opacity: 0.7 }}>
+                                  {entry.definition}
+                                </Text>
+                              </Box>
+                              {canEdit && (
+                                <Box shrink="No">
+                                  <IconButton
+                                    onClick={() => handleRemove(index)}
+                                    variant="Background"
+                                    size="300"
+                                    radii="300"
+                                    disabled={saving}
+                                    aria-label={`Remove abbreviation ${entry.term}`}
+                                  >
+                                    <Icon src={Icons.Delete} size="100" />
+                                  </IconButton>
+                                </Box>
+                              )}
+                            </SequenceCard>
+                          ))}
+                          {!isSpace &&
+                            ancestorGroups.flatMap(({ spaceId, spaceName, entries: spEntries }) =>
+                              spEntries.map((entry, index) => (
+                                <SequenceCard
+                                  // eslint-disable-next-line react/no-array-index-key
+                                  key={`${spaceId}-${index}`}
+                                  className={SequenceCardStyle}
+                                  variant="SurfaceVariant"
+                                  direction="Row"
+                                  gap="400"
+                                  alignItems="Center"
+                                >
+                                  <Box grow="Yes" direction="Column" gap="100">
+                                    <Box gap="200" alignItems="Center">
+                                      <Text size="T300">
+                                        <b>{entry.term}</b>
+                                      </Text>
+                                      <Chip variant="Primary" radii="Pill" size="300">
+                                        <Text size="T200">Space - {spaceName}</Text>
+                                      </Chip>
+                                    </Box>
+                                    <Text size="T200" style={{ opacity: 0.7 }}>
+                                      {entry.definition}
+                                    </Text>
+                                  </Box>
+                                </SequenceCard>
+                              ))
+                            )}
+                        </>
                       )}
-                    </SequenceCard>
-                  ))
-                )}
+                    </>
+                  );
+                })()}
               </Box>
             </Box>
           </PageContent>

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -117,7 +117,9 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
     const definition = definitionInput.value.trim();
     if (!term || !definition) return;
 
-    const alreadyExists = entries.some((e) => e.term.toLowerCase() === term.toLowerCase());
+    const alreadyExists =
+      entries.some((e) => e.term.toLowerCase() === term.toLowerCase()) ||
+      allAncestorEntries.some((e) => e.term.toLowerCase() === term.toLowerCase());
     if (alreadyExists) {
       termInput.setCustomValidity('This term already exists.');
       termInput.reportValidity();
@@ -187,6 +189,7 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
                             radii="300"
                             placeholder="e.g. FOSS"
                             readOnly={saving}
+                            onChange={(e) => e.currentTarget.setCustomValidity('')}
                           />
                         </Box>
                         <Box direction="Column" gap="100">

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -1,0 +1,226 @@
+import { FormEventHandler, useCallback } from 'react';
+import { Box, Button, Icon, IconButton, Icons, Input, Scroll, Spinner, Text, config } from 'folds';
+import { Page, PageContent, PageHeader } from '$components/page';
+import { SequenceCard } from '$components/sequence-card';
+import { SettingTile } from '$components/setting-tile';
+import { useRoom } from '$hooks/useRoom';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { usePowerLevels } from '$hooks/usePowerLevels';
+import { useRoomCreators } from '$hooks/useRoomCreators';
+import { useRoomPermissions } from '$hooks/useRoomPermissions';
+import { useStateEvent } from '$hooks/useStateEvent';
+import { StateEvent } from '$types/matrix/room';
+import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
+import { MatrixError } from '$types/matrix-sdk';
+import { AbbreviationEntry, RoomAbbreviationsContent } from '$utils/abbreviations';
+import { SequenceCardStyle } from '$features/common-settings/styles.css';
+
+type AbbreviationsProps = {
+  requestClose: () => void;
+};
+
+export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
+  const room = useRoom();
+  const mx = useMatrixClient();
+  const powerLevels = usePowerLevels(room);
+  const creators = useRoomCreators(room);
+  const permissions = useRoomPermissions(creators, powerLevels);
+  const userId = mx.getUserId() ?? '';
+
+  const stateEvent = useStateEvent(room, StateEvent.RoomAbbreviations);
+  const content = stateEvent?.getContent<RoomAbbreviationsContent>();
+  const entries: AbbreviationEntry[] = Array.isArray(content?.entries) ? content.entries : [];
+
+  const canEdit = permissions.stateEvent(StateEvent.RoomAbbreviations, userId);
+
+  const [saveState, saveAbbreviations] = useAsyncCallback<void, MatrixError, [AbbreviationEntry[]]>(
+    useCallback(
+      async (newEntries) => {
+        const newContent: RoomAbbreviationsContent = { entries: newEntries };
+        await mx.sendStateEvent(room.roomId, StateEvent.RoomAbbreviations as any, newContent, '');
+      },
+      [mx, room.roomId]
+    )
+  );
+
+  const saving = saveState.status === AsyncStatus.Loading;
+
+  const handleAdd: FormEventHandler<HTMLFormElement> = (evt) => {
+    evt.preventDefault();
+    if (saving || !canEdit) return;
+    const form = evt.target as HTMLFormElement;
+    const termInput = form.elements.namedItem('term') as HTMLInputElement | null;
+    const definitionInput = form.elements.namedItem('definition') as HTMLInputElement | null;
+    if (!termInput || !definitionInput) return;
+    const term = termInput.value.trim();
+    const definition = definitionInput.value.trim();
+    if (!term || !definition) return;
+
+    const alreadyExists = entries.some((e) => e.term.toLowerCase() === term.toLowerCase());
+    if (alreadyExists) {
+      termInput.setCustomValidity('This term already exists.');
+      termInput.reportValidity();
+      return;
+    }
+    termInput.setCustomValidity('');
+
+    const newEntries = [...entries, { term, definition }];
+    saveAbbreviations(newEntries).then(() => {
+      form.reset();
+    });
+  };
+
+  const handleRemove = (index: number) => {
+    if (saving || !canEdit) return;
+    const newEntries = entries.filter((_, i) => i !== index);
+    saveAbbreviations(newEntries);
+  };
+
+  return (
+    <Page>
+      <PageHeader outlined={false}>
+        <Box grow="Yes" gap="200">
+          <Box grow="Yes" alignItems="Center" gap="200">
+            <Text size="H3" truncate>
+              Abbreviations
+            </Text>
+          </Box>
+          <Box shrink="No">
+            <IconButton onClick={requestClose} variant="Surface">
+              <Icon src={Icons.Cross} />
+            </IconButton>
+          </Box>
+        </Box>
+      </PageHeader>
+      <Box grow="Yes">
+        <Scroll hideTrack visibility="Hover">
+          <PageContent>
+            <Box direction="Column" gap="700">
+              {canEdit && (
+                <Box direction="Column" gap="100">
+                  <Text size="L400">Add Abbreviation</Text>
+                  <SequenceCard
+                    className={SequenceCardStyle}
+                    variant="SurfaceVariant"
+                    direction="Column"
+                    gap="400"
+                  >
+                    <SettingTile
+                      title="New Entry"
+                      description="Define a term that members can hover over to see its meaning."
+                    >
+                      <Box
+                        style={{ marginTop: config.space.S200 }}
+                        as="form"
+                        onSubmit={handleAdd}
+                        direction="Column"
+                        gap="200"
+                      >
+                        <Box direction="Column" gap="100">
+                          <Text size="L400">Term</Text>
+                          <Input
+                            name="term"
+                            required
+                            size="400"
+                            variant="Secondary"
+                            radii="300"
+                            placeholder="e.g. FOSS"
+                            readOnly={saving}
+                          />
+                        </Box>
+                        <Box direction="Column" gap="100">
+                          <Text size="L400">Definition</Text>
+                          <Input
+                            name="definition"
+                            required
+                            size="400"
+                            variant="Secondary"
+                            radii="300"
+                            placeholder="e.g. Free and Open Source Software"
+                            readOnly={saving}
+                          />
+                        </Box>
+                        {saveState.status === AsyncStatus.Error && (
+                          <Text size="T200" style={{ color: 'var(--mx-danger)' }}>
+                            {saveState.error.message}
+                          </Text>
+                        )}
+                        <Box gap="200" justifyContent="End">
+                          <Button
+                            type="submit"
+                            size="300"
+                            variant="Primary"
+                            radii="300"
+                            disabled={saving}
+                            before={saving ? <Spinner size="100" variant="Primary" /> : undefined}
+                          >
+                            <Text size="B300">{saving ? 'Saving…' : 'Add'}</Text>
+                          </Button>
+                        </Box>
+                      </Box>
+                    </SettingTile>
+                  </SequenceCard>
+                </Box>
+              )}
+
+              <Box direction="Column" gap="100">
+                <Text size="L400">
+                  {entries.length > 0
+                    ? `Defined Abbreviations (${entries.length})`
+                    : 'Defined Abbreviations'}
+                </Text>
+                {entries.length === 0 ? (
+                  <SequenceCard
+                    className={SequenceCardStyle}
+                    variant="SurfaceVariant"
+                    direction="Column"
+                  >
+                    <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
+                      No abbreviations defined yet.
+                      {canEdit && ' Use the form above to add some.'}
+                    </Text>
+                  </SequenceCard>
+                ) : (
+                  entries.map((entry, index) => (
+                    <SequenceCard
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={index}
+                      className={SequenceCardStyle}
+                      variant="SurfaceVariant"
+                      direction="Row"
+                      gap="400"
+                      alignItems="Center"
+                    >
+                      <Box grow="Yes" direction="Column" gap="100">
+                        <Text size="T300">
+                          <b>{entry.term}</b>
+                        </Text>
+                        <Text size="T200" style={{ opacity: 0.7 }}>
+                          {entry.definition}
+                        </Text>
+                      </Box>
+                      {canEdit && (
+                        <Box shrink="No">
+                          <IconButton
+                            onClick={() => handleRemove(index)}
+                            variant="Background"
+                            size="300"
+                            radii="300"
+                            disabled={saving}
+                            aria-label={`Remove abbreviation ${entry.term}`}
+                          >
+                            <Icon src={Icons.Delete} size="100" />
+                          </IconButton>
+                        </Box>
+                      )}
+                    </SequenceCard>
+                  ))
+                )}
+              </Box>
+            </Box>
+          </PageContent>
+        </Scroll>
+      </Box>
+    </Page>
+  );
+}

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -117,9 +117,7 @@ export function RoomAbbreviations({ requestClose, isSpace }: AbbreviationsProps)
     const definition = definitionInput.value.trim();
     if (!term || !definition) return;
 
-    const alreadyExists =
-      entries.some((e) => e.term.toLowerCase() === term.toLowerCase()) ||
-      allAncestorEntries.some((e) => e.term.toLowerCase() === term.toLowerCase());
+    const alreadyExists = entries.some((e) => e.term.toLowerCase() === term.toLowerCase());
     if (alreadyExists) {
       termInput.setCustomValidity('This term already exists.');
       termInput.reportValidity();

--- a/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
+++ b/src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx
@@ -1,5 +1,17 @@
 import { FormEventHandler, useCallback } from 'react';
-import { Box, Button, Icon, IconButton, Icons, Input, Scroll, Spinner, Text, config } from 'folds';
+import {
+  Box,
+  Button,
+  Chip,
+  Icon,
+  IconButton,
+  Icons,
+  Input,
+  Scroll,
+  Spinner,
+  Text,
+  config,
+} from 'folds';
 import { Page, PageContent, PageHeader } from '$components/page';
 import { SequenceCard } from '$components/sequence-card';
 import { SettingTile } from '$components/setting-tile';
@@ -9,6 +21,8 @@ import { usePowerLevels } from '$hooks/usePowerLevels';
 import { useRoomCreators } from '$hooks/useRoomCreators';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
 import { useStateEvent } from '$hooks/useStateEvent';
+import { useSpaceOptionally } from '$hooks/useSpace';
+import { useRoomName } from '$hooks/useRoomMeta';
 import { StateEvent } from '$types/matrix/room';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { MatrixError } from '$types/matrix-sdk';
@@ -30,6 +44,17 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
   const stateEvent = useStateEvent(room, StateEvent.RoomAbbreviations);
   const content = stateEvent?.getContent<RoomAbbreviationsContent>();
   const entries: AbbreviationEntry[] = Array.isArray(content?.entries) ? content.entries : [];
+
+  // Parent space abbreviations (read-only, inherited)
+  const parentSpace = useSpaceOptionally();
+  const parentSpaceName = useRoomName(parentSpace ?? room);
+  const spaceStateEvent = useStateEvent(parentSpace ?? room, StateEvent.RoomAbbreviations);
+  const spaceContent = parentSpace
+    ? spaceStateEvent?.getContent<RoomAbbreviationsContent>()
+    : undefined;
+  const spaceEntries: AbbreviationEntry[] = Array.isArray(spaceContent?.entries)
+    ? spaceContent.entries
+    : [];
 
   const canEdit = permissions.stateEvent(StateEvent.RoomAbbreviations, userId);
 
@@ -56,7 +81,9 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
     const definition = definitionInput.value.trim();
     if (!term || !definition) return;
 
-    const alreadyExists = entries.some((e) => e.term.toLowerCase() === term.toLowerCase());
+    const alreadyExists =
+      entries.some((e) => e.term.toLowerCase() === term.toLowerCase()) ||
+      spaceEntries.some((e) => e.term.toLowerCase() === term.toLowerCase());
     if (alreadyExists) {
       termInput.setCustomValidity('This term already exists.');
       termInput.reportValidity();
@@ -163,11 +190,58 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
                 </Box>
               )}
 
+              {parentSpace && (
+                <Box direction="Column" gap="100">
+                  <Text size="L400">
+                    {spaceEntries.length > 0
+                      ? `Inherited from Space (${spaceEntries.length})`
+                      : 'Inherited from Space'}
+                  </Text>
+                  {spaceEntries.length === 0 ? (
+                    <SequenceCard
+                      className={SequenceCardStyle}
+                      variant="SurfaceVariant"
+                      direction="Column"
+                    >
+                      <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
+                        No abbreviations defined in {parentSpaceName}.
+                      </Text>
+                    </SequenceCard>
+                  ) : (
+                    spaceEntries.map((entry, index) => (
+                      <SequenceCard
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={index}
+                        className={SequenceCardStyle}
+                        variant="SurfaceVariant"
+                        direction="Row"
+                        gap="400"
+                        alignItems="Center"
+                      >
+                        <Box grow="Yes" direction="Column" gap="100">
+                          <Box gap="200" alignItems="Center">
+                            <Text size="T300">
+                              <b>{entry.term}</b>
+                            </Text>
+                            <Chip variant="Primary" radii="Pill" size="300">
+                              <Text size="T200">Space</Text>
+                            </Chip>
+                          </Box>
+                          <Text size="T200" style={{ opacity: 0.7 }}>
+                            {entry.definition}
+                          </Text>
+                        </Box>
+                      </SequenceCard>
+                    ))
+                  )}
+                </Box>
+              )}
+
               <Box direction="Column" gap="100">
                 <Text size="L400">
                   {entries.length > 0
-                    ? `Defined Abbreviations (${entries.length})`
-                    : 'Defined Abbreviations'}
+                    ? `Room Abbreviations (${entries.length})`
+                    : 'Room Abbreviations'}
                 </Text>
                 {entries.length === 0 ? (
                   <SequenceCard
@@ -176,7 +250,7 @@ export function RoomAbbreviations({ requestClose }: AbbreviationsProps) {
                     direction="Column"
                   >
                     <Text size="T300" style={{ color: 'var(--mx-surface-variant-on)' }}>
-                      No abbreviations defined yet.
+                      No room-level abbreviations defined yet.
                       {canEdit && ' Use the form above to add some.'}
                     </Text>
                   </SequenceCard>

--- a/src/app/features/room/Room.tsx
+++ b/src/app/features/room/Room.tsx
@@ -19,7 +19,6 @@ import { roomIdToOpenThreadAtomFamily } from '$state/room/roomToOpenThread';
 import { roomIdToThreadBrowserAtomFamily } from '$state/room/roomToThreadBrowser';
 import { createDebugLogger } from '$utils/debugLogger';
 import { useMergedAbbreviations, RoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
-import { useSpaceOptionally } from '$hooks/useSpace';
 import { RoomViewHeader } from './RoomViewHeader';
 import { MembersDrawer } from './MembersDrawer';
 import { RoomView } from './RoomView';
@@ -99,8 +98,7 @@ export function Room() {
   );
 
   const callView = room.isCallRoom();
-  const parentSpace = useSpaceOptionally();
-  const abbreviations = useMergedAbbreviations(room, parentSpace);
+  const abbreviations = useMergedAbbreviations(room);
 
   // Log call view state
   useEffect(() => {

--- a/src/app/features/room/Room.tsx
+++ b/src/app/features/room/Room.tsx
@@ -18,6 +18,7 @@ import { callChatAtom } from '$state/callEmbed';
 import { roomIdToOpenThreadAtomFamily } from '$state/room/roomToOpenThread';
 import { roomIdToThreadBrowserAtomFamily } from '$state/room/roomToThreadBrowser';
 import { createDebugLogger } from '$utils/debugLogger';
+import { useRoomAbbreviations, RoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
 import { RoomViewHeader } from './RoomViewHeader';
 import { MembersDrawer } from './MembersDrawer';
 import { RoomView } from './RoomView';
@@ -97,6 +98,7 @@ export function Room() {
   );
 
   const callView = room.isCallRoom();
+  const abbreviations = useRoomAbbreviations(room);
 
   // Log call view state
   useEffect(() => {
@@ -105,58 +107,80 @@ export function Room() {
 
   return (
     <PowerLevelsContextProvider value={powerLevels}>
-      <Box grow="Yes" style={{ position: 'relative' }}>
-        {callView && (screenSize === ScreenSize.Desktop || !chat) && (
-          <Box grow="Yes" direction="Column">
-            <RoomViewHeader callView />
-            <Box grow="Yes">
-              <CallView />
+      <RoomAbbreviationsContext.Provider value={abbreviations}>
+        <Box grow="Yes" style={{ position: 'relative' }}>
+          {callView && (screenSize === ScreenSize.Desktop || !chat) && (
+            <Box grow="Yes" direction="Column">
+              <RoomViewHeader callView />
+              <Box grow="Yes">
+                <CallView />
+              </Box>
             </Box>
-          </Box>
-        )}
-        {!callView && (
-          <Box grow="Yes" direction="Column">
-            <RoomViewHeader />
-            <Box grow="Yes">
-              <RoomView eventId={eventId} />
+          )}
+          {!callView && (
+            <Box grow="Yes" direction="Column">
+              <RoomViewHeader />
+              <Box grow="Yes">
+                <RoomView eventId={eventId} />
+              </Box>
             </Box>
-          </Box>
-        )}
+          )}
 
-        {callView && chat && (
-          <>
-            {screenSize === ScreenSize.Desktop && (
+          {callView && chat && (
+            <>
+              {screenSize === ScreenSize.Desktop && (
+                <Line variant="Background" direction="Vertical" size="300" />
+              )}
+              <CallChatView />
+            </>
+          )}
+          {!callView && screenSize === ScreenSize.Desktop && isDrawer && (
+            <>
               <Line variant="Background" direction="Vertical" size="300" />
-            )}
-            <CallChatView />
-          </>
-        )}
-        {!callView && screenSize === ScreenSize.Desktop && isDrawer && (
-          <>
-            <Line variant="Background" direction="Vertical" size="300" />
-            <MembersDrawer key={room.roomId} room={room} members={members} />
-          </>
-        )}
-        {screenSize === ScreenSize.Desktop && isWidgetDrawerOpen && (
-          <>
-            <Line variant="Background" direction="Vertical" size="300" />
-            <WidgetsDrawer key={`widgets-${room.roomId}`} room={room} />
-          </>
-        )}
-        {screenSize === ScreenSize.Desktop && openThreadId && (
-          <>
-            <Line variant="Background" direction="Vertical" size="300" />
+              <MembersDrawer key={room.roomId} room={room} members={members} />
+            </>
+          )}
+          {screenSize === ScreenSize.Desktop && isWidgetDrawerOpen && (
+            <>
+              <Line variant="Background" direction="Vertical" size="300" />
+              <WidgetsDrawer key={`widgets-${room.roomId}`} room={room} />
+            </>
+          )}
+          {screenSize === ScreenSize.Desktop && openThreadId && (
+            <>
+              <Line variant="Background" direction="Vertical" size="300" />
+              <ThreadDrawer
+                key={`thread-${room.roomId}-${openThreadId}`}
+                room={room}
+                threadRootId={openThreadId}
+                onClose={() => setOpenThread(undefined)}
+              />
+            </>
+          )}
+          {screenSize === ScreenSize.Desktop && threadBrowserOpen && !openThreadId && (
+            <>
+              <Line variant="Background" direction="Vertical" size="300" />
+              <ThreadBrowser
+                key={`thread-browser-${room.roomId}`}
+                room={room}
+                onOpenThread={(id) => {
+                  setOpenThread(id);
+                  setThreadBrowserOpen(false);
+                }}
+                onClose={() => setThreadBrowserOpen(false)}
+              />
+            </>
+          )}
+          {screenSize !== ScreenSize.Desktop && openThreadId && (
             <ThreadDrawer
               key={`thread-${room.roomId}-${openThreadId}`}
               room={room}
               threadRootId={openThreadId}
               onClose={() => setOpenThread(undefined)}
+              overlay
             />
-          </>
-        )}
-        {screenSize === ScreenSize.Desktop && threadBrowserOpen && !openThreadId && (
-          <>
-            <Line variant="Background" direction="Vertical" size="300" />
+          )}
+          {screenSize !== ScreenSize.Desktop && threadBrowserOpen && !openThreadId && (
             <ThreadBrowser
               key={`thread-browser-${room.roomId}`}
               room={room}
@@ -165,31 +189,11 @@ export function Room() {
                 setThreadBrowserOpen(false);
               }}
               onClose={() => setThreadBrowserOpen(false)}
+              overlay
             />
-          </>
-        )}
-        {screenSize !== ScreenSize.Desktop && openThreadId && (
-          <ThreadDrawer
-            key={`thread-${room.roomId}-${openThreadId}`}
-            room={room}
-            threadRootId={openThreadId}
-            onClose={() => setOpenThread(undefined)}
-            overlay
-          />
-        )}
-        {screenSize !== ScreenSize.Desktop && threadBrowserOpen && !openThreadId && (
-          <ThreadBrowser
-            key={`thread-browser-${room.roomId}`}
-            room={room}
-            onOpenThread={(id) => {
-              setOpenThread(id);
-              setThreadBrowserOpen(false);
-            }}
-            onClose={() => setThreadBrowserOpen(false)}
-            overlay
-          />
-        )}
-      </Box>
+          )}
+        </Box>
+      </RoomAbbreviationsContext.Provider>
     </PowerLevelsContextProvider>
   );
 }

--- a/src/app/features/room/Room.tsx
+++ b/src/app/features/room/Room.tsx
@@ -18,7 +18,8 @@ import { callChatAtom } from '$state/callEmbed';
 import { roomIdToOpenThreadAtomFamily } from '$state/room/roomToOpenThread';
 import { roomIdToThreadBrowserAtomFamily } from '$state/room/roomToThreadBrowser';
 import { createDebugLogger } from '$utils/debugLogger';
-import { useRoomAbbreviations, RoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
+import { useMergedAbbreviations, RoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
+import { useSpaceOptionally } from '$hooks/useSpace';
 import { RoomViewHeader } from './RoomViewHeader';
 import { MembersDrawer } from './MembersDrawer';
 import { RoomView } from './RoomView';
@@ -98,7 +99,8 @@ export function Room() {
   );
 
   const callView = room.isCallRoom();
-  const abbreviations = useRoomAbbreviations(room);
+  const parentSpace = useSpaceOptionally();
+  const abbreviations = useMergedAbbreviations(room, parentSpace);
 
   // Log call view state
   useEffect(() => {

--- a/src/app/features/space-settings/SpaceSettings.tsx
+++ b/src/app/features/space-settings/SpaceSettings.tsx
@@ -194,7 +194,7 @@ export function SpaceSettings({ initialPage, requestClose }: SpaceSettingsProps)
         <DeveloperTools requestClose={handlePageRequestClose} />
       )}
       {activePage === SpaceSettingsPage.AbbreviationsPage && (
-        <RoomAbbreviations requestClose={handlePageRequestClose} />
+        <RoomAbbreviations isSpace requestClose={handlePageRequestClose} />
       )}
     </PageRoot>
   );

--- a/src/app/features/space-settings/SpaceSettings.tsx
+++ b/src/app/features/space-settings/SpaceSettings.tsx
@@ -16,6 +16,7 @@ import { EmojisStickers } from '$features/common-settings/emojis-stickers';
 import { Members } from '$features/common-settings/members';
 import { DeveloperTools } from '$features/common-settings/developer-tools';
 import { Cosmetics } from '$features/common-settings/cosmetics/Cosmetics';
+import { RoomAbbreviations } from '$features/room-settings/abbreviations/RoomAbbreviations';
 import { General } from './general';
 import { Permissions } from './permissions';
 
@@ -49,6 +50,11 @@ const useSpaceSettingsMenuItems = (): SpaceSettingsMenuItem[] =>
         name: 'Cosmetics',
         icon: Icons.Alphabet,
         activeIcon: Icons.AlphabetUnderline,
+      },
+      {
+        page: SpaceSettingsPage.AbbreviationsPage,
+        name: 'Abbreviations',
+        icon: Icons.Info,
       },
       {
         page: SpaceSettingsPage.EmojisStickersPage,
@@ -186,6 +192,9 @@ export function SpaceSettings({ initialPage, requestClose }: SpaceSettingsProps)
       )}
       {activePage === SpaceSettingsPage.DeveloperToolsPage && (
         <DeveloperTools requestClose={handlePageRequestClose} />
+      )}
+      {activePage === SpaceSettingsPage.AbbreviationsPage && (
+        <RoomAbbreviations requestClose={handlePageRequestClose} />
       )}
     </PageRoot>
   );

--- a/src/app/hooks/useRoomAbbreviations.ts
+++ b/src/app/hooks/useRoomAbbreviations.ts
@@ -18,3 +18,26 @@ export const useRoomAbbreviations = (room: Room): Map<string, string> => {
   if (!Array.isArray(content?.entries) || content.entries.length === 0) return EMPTY_MAP;
   return buildAbbreviationsMap(content.entries);
 };
+
+/**
+ * Return a merged map of abbreviations from the parent space (if any) and the room.
+ * Room-level entries override space-level entries for the same term (case-insensitive).
+ * Pass `space` as the parent space Room, or null if there is none.
+ * Both hooks are always called unconditionally to satisfy the Rules of Hooks.
+ */
+export const useMergedAbbreviations = (room: Room, space: Room | null): Map<string, string> => {
+  // Always call with a valid Room — use `room` as a harmless fallback when space is null.
+  const spaceStateEvent = useStateEvent(space ?? room, StateEvent.RoomAbbreviations);
+  const roomStateEvent = useStateEvent(room, StateEvent.RoomAbbreviations);
+
+  const spaceContent = space ? spaceStateEvent?.getContent<RoomAbbreviationsContent>() : undefined;
+  const roomContent = roomStateEvent?.getContent<RoomAbbreviationsContent>();
+
+  const spaceEntries = Array.isArray(spaceContent?.entries) ? spaceContent.entries : [];
+  const roomEntries = Array.isArray(roomContent?.entries) ? roomContent.entries : [];
+
+  if (spaceEntries.length === 0 && roomEntries.length === 0) return EMPTY_MAP;
+
+  // Space entries first; room entries are appended so they override duplicates.
+  return buildAbbreviationsMap([...spaceEntries, ...roomEntries]);
+};

--- a/src/app/hooks/useRoomAbbreviations.ts
+++ b/src/app/hooks/useRoomAbbreviations.ts
@@ -1,8 +1,14 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useCallback, useMemo } from 'react';
+import { useAtomValue } from 'jotai';
 import { Room } from '$types/matrix-sdk';
 import { StateEvent } from '$types/matrix/room';
 import { buildAbbreviationsMap, RoomAbbreviationsContent } from '$utils/abbreviations';
+import { getAllParents, getStateEvent } from '$utils/room';
+import { roomToParentsAtom } from '$state/room/roomToParents';
+import { useMatrixClient } from './useMatrixClient';
 import { useStateEvent } from './useStateEvent';
+import { useStateEventCallback } from './useStateEventCallback';
+import { useForceUpdate } from './useForceUpdate';
 
 const EMPTY_MAP: Map<string, string> = new Map();
 
@@ -20,24 +26,54 @@ export const useRoomAbbreviations = (room: Room): Map<string, string> => {
 };
 
 /**
- * Return a merged map of abbreviations from the parent space (if any) and the room.
- * Room-level entries override space-level entries for the same term (case-insensitive).
- * Pass `space` as the parent space Room, or null if there is none.
- * Both hooks are always called unconditionally to satisfy the Rules of Hooks.
+ * Return a merged map of abbreviations from ALL ancestor spaces and the room.
+ * Nearest ancestor entries override farther ancestor entries; room entries override everything.
+ * Subscribes to abbreviation state changes across the full space hierarchy.
  */
-export const useMergedAbbreviations = (room: Room, space: Room | null): Map<string, string> => {
-  // Always call with a valid Room — use `room` as a harmless fallback when space is null.
-  const spaceStateEvent = useStateEvent(space ?? room, StateEvent.RoomAbbreviations);
-  const roomStateEvent = useStateEvent(room, StateEvent.RoomAbbreviations);
+export const useMergedAbbreviations = (room: Room): Map<string, string> => {
+  const mx = useMatrixClient();
+  const roomToParents = useAtomValue(roomToParentsAtom);
+  const [updateCount, forceUpdate] = useForceUpdate();
 
-  const spaceContent = space ? spaceStateEvent?.getContent<RoomAbbreviationsContent>() : undefined;
-  const roomContent = roomStateEvent?.getContent<RoomAbbreviationsContent>();
+  useStateEventCallback(
+    mx,
+    useCallback(
+      (event) => {
+        if (event.getType() !== StateEvent.RoomAbbreviations) return;
+        const eventRoomId = event.getRoomId();
+        if (!eventRoomId) return;
+        if (
+          eventRoomId === room.roomId ||
+          getAllParents(roomToParents, room.roomId).has(eventRoomId)
+        ) {
+          forceUpdate();
+        }
+      },
+      [room.roomId, roomToParents, forceUpdate]
+    )
+  );
 
-  const spaceEntries = Array.isArray(spaceContent?.entries) ? spaceContent.entries : [];
-  const roomEntries = Array.isArray(roomContent?.entries) ? roomContent.entries : [];
+  return useMemo(() => {
+    const allParentIds = Array.from(getAllParents(roomToParents, room.roomId));
+    const ancestorEntries = allParentIds.flatMap((parentId) => {
+      const parentRoom = mx.getRoom(parentId);
+      if (!parentRoom) return [];
+      const content = getStateEvent(
+        parentRoom,
+        StateEvent.RoomAbbreviations
+      )?.getContent<RoomAbbreviationsContent>();
+      return Array.isArray(content?.entries) ? content.entries : [];
+    });
 
-  if (spaceEntries.length === 0 && roomEntries.length === 0) return EMPTY_MAP;
+    const roomContent = getStateEvent(
+      room,
+      StateEvent.RoomAbbreviations
+    )?.getContent<RoomAbbreviationsContent>();
+    const roomEntries = Array.isArray(roomContent?.entries) ? roomContent.entries : [];
 
-  // Space entries first; room entries are appended so they override duplicates.
-  return buildAbbreviationsMap([...spaceEntries, ...roomEntries]);
+    if (ancestorEntries.length === 0 && roomEntries.length === 0) return EMPTY_MAP;
+    // Ancestor entries first; room entries appended so they override duplicates.
+    return buildAbbreviationsMap([...ancestorEntries, ...roomEntries]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mx, roomToParents, room, updateCount]);
 };

--- a/src/app/hooks/useRoomAbbreviations.ts
+++ b/src/app/hooks/useRoomAbbreviations.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+import { Room } from '$types/matrix-sdk';
+import { StateEvent } from '$types/matrix/room';
+import { buildAbbreviationsMap, RoomAbbreviationsContent } from '$utils/abbreviations';
+import { useStateEvent } from './useStateEvent';
+
+const EMPTY_MAP: Map<string, string> = new Map();
+
+export const RoomAbbreviationsContext = createContext<Map<string, string>>(EMPTY_MAP);
+
+export const useRoomAbbreviationsContext = () => useContext(RoomAbbreviationsContext);
+
+/** Read the room's abbreviations state event and return a term→definition map. */
+export const useRoomAbbreviations = (room: Room): Map<string, string> => {
+  const stateEvent = useStateEvent(room, StateEvent.RoomAbbreviations);
+  if (!stateEvent) return EMPTY_MAP;
+  const content = stateEvent.getContent<RoomAbbreviationsContent>();
+  if (!Array.isArray(content?.entries) || content.entries.length === 0) return EMPTY_MAP;
+  return buildAbbreviationsMap(content.entries);
+};

--- a/src/app/state/roomSettings.ts
+++ b/src/app/state/roomSettings.ts
@@ -8,6 +8,7 @@ export enum RoomSettingsPage {
   DeveloperToolsPage,
   // Sable pages
   CosmeticsPage,
+  AbbreviationsPage,
 }
 
 export type RoomSettingsState = {

--- a/src/app/state/spaceSettings.ts
+++ b/src/app/state/spaceSettings.ts
@@ -8,6 +8,7 @@ export enum SpaceSettingsPage {
   DeveloperToolsPage,
   // Sable pages
   CosmeticsPage,
+  AbbreviationsPage,
 }
 
 export type SpaceSettingsState = {

--- a/src/app/utils/abbreviations.test.ts
+++ b/src/app/utils/abbreviations.test.ts
@@ -8,13 +8,17 @@ describe('buildAbbreviationsMap', () => {
   });
 
   it('stores the key as lowercase regardless of input casing', () => {
-    const map = buildAbbreviationsMap([{ term: 'FOSS', definition: 'Free and Open Source Software' }]);
+    const map = buildAbbreviationsMap([
+      { term: 'FOSS', definition: 'Free and Open Source Software' },
+    ]);
     expect(map.get('foss')).toBe('Free and Open Source Software');
     expect(map.get('FOSS')).toBeUndefined();
   });
 
   it('trims surrounding whitespace from terms', () => {
-    const map = buildAbbreviationsMap([{ term: '  FOSS  ', definition: 'Free and Open Source Software' }]);
+    const map = buildAbbreviationsMap([
+      { term: '  FOSS  ', definition: 'Free and Open Source Software' },
+    ]);
     expect(map.get('foss')).toBe('Free and Open Source Software');
     expect(map.size).toBe(1);
   });
@@ -55,7 +59,9 @@ describe('splitByAbbreviations', () => {
   ]);
 
   it('returns a single plain segment when the map is empty', () => {
-    expect(splitByAbbreviations('hello FOSS world', new Map())).toEqual([{ text: 'hello FOSS world' }]);
+    expect(splitByAbbreviations('hello FOSS world', new Map())).toEqual([
+      { text: 'hello FOSS world' },
+    ]);
   });
 
   it('returns a single plain segment when there are no matches', () => {
@@ -114,7 +120,9 @@ describe('splitByAbbreviations', () => {
   it('does not match a term embedded inside a longer word', () => {
     // OSS should not match inside CROSS or GLOSS
     const ossOnlyMap = buildAbbreviationsMap([{ term: 'OSS', definition: 'Open Source Software' }]);
-    expect(splitByAbbreviations('CROSS the GLOSS', ossOnlyMap)).toEqual([{ text: 'CROSS the GLOSS' }]);
+    expect(splitByAbbreviations('CROSS the GLOSS', ossOnlyMap)).toEqual([
+      { text: 'CROSS the GLOSS' },
+    ]);
   });
 
   it('matches a shorter term standalone when the longer overlapping term is also defined', () => {

--- a/src/app/utils/abbreviations.test.ts
+++ b/src/app/utils/abbreviations.test.ts
@@ -7,15 +7,15 @@ describe('buildAbbreviationsMap', () => {
     expect(buildAbbreviationsMap([])).toEqual(new Map());
   });
 
-  it('stores the term with its original casing as the key', () => {
+  it('stores the key as lowercase regardless of input casing', () => {
     const map = buildAbbreviationsMap([{ term: 'FOSS', definition: 'Free and Open Source Software' }]);
-    expect(map.get('FOSS')).toBe('Free and Open Source Software');
-    expect(map.get('foss')).toBeUndefined();
+    expect(map.get('foss')).toBe('Free and Open Source Software');
+    expect(map.get('FOSS')).toBeUndefined();
   });
 
   it('trims surrounding whitespace from terms', () => {
     const map = buildAbbreviationsMap([{ term: '  FOSS  ', definition: 'Free and Open Source Software' }]);
-    expect(map.get('FOSS')).toBe('Free and Open Source Software');
+    expect(map.get('foss')).toBe('Free and Open Source Software');
     expect(map.size).toBe(1);
   });
 
@@ -27,13 +27,12 @@ describe('buildAbbreviationsMap', () => {
     expect(map.size).toBe(0);
   });
 
-  it('treats the same term with different casing as separate entries', () => {
+  it('deduplicates different-cased variants of the same term (last entry wins)', () => {
     const map = buildAbbreviationsMap([
       { term: 'OSS', definition: 'Open Source Software' },
       { term: 'oss', definition: 'open source software' },
     ]);
-    expect(map.size).toBe(2);
-    expect(map.get('OSS')).toBe('Open Source Software');
+    expect(map.size).toBe(1);
     expect(map.get('oss')).toBe('open source software');
   });
 
@@ -43,8 +42,8 @@ describe('buildAbbreviationsMap', () => {
       { term: 'RTFM', definition: 'Read The Fine Manual' },
     ]);
     expect(map.size).toBe(2);
-    expect(map.get('FOSS')).toBe('Free and Open Source Software');
-    expect(map.get('RTFM')).toBe('Read The Fine Manual');
+    expect(map.get('foss')).toBe('Free and Open Source Software');
+    expect(map.get('rtfm')).toBe('Read The Fine Manual');
   });
 });
 
@@ -70,14 +69,14 @@ describe('splitByAbbreviations', () => {
   it('splits a term match in the middle of a string', () => {
     expect(splitByAbbreviations('Use FOSS software', map)).toEqual([
       { text: 'Use ' },
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
       { text: ' software' },
     ]);
   });
 
   it('splits a term match at the start of a string', () => {
     expect(splitByAbbreviations('FOSS is great', map)).toEqual([
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
       { text: ' is great' },
     ]);
   });
@@ -85,21 +84,24 @@ describe('splitByAbbreviations', () => {
   it('splits a term match at the end of a string', () => {
     expect(splitByAbbreviations('I love FOSS', map)).toEqual([
       { text: 'I love ' },
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
     ]);
   });
 
   it('handles multiple terms in the same string', () => {
     expect(splitByAbbreviations('FOSS and RTFM', map)).toEqual([
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
       { text: ' and ' },
-      { text: 'RTFM', termKey: 'RTFM' },
+      { text: 'RTFM', termKey: 'rtfm' },
     ]);
   });
 
-  it('is case-sensitive and does not match the wrong casing', () => {
+  it('matches case-insensitively (termKey is always lowercase)', () => {
     expect(splitByAbbreviations('I like foss and Foss', map)).toEqual([
-      { text: 'I like foss and Foss' },
+      { text: 'I like ' },
+      { text: 'foss', termKey: 'foss' },
+      { text: ' and ' },
+      { text: 'Foss', termKey: 'foss' },
     ]);
   });
 
@@ -118,9 +120,9 @@ describe('splitByAbbreviations', () => {
   it('matches a shorter term standalone when the longer overlapping term is also defined', () => {
     // OSS is a suffix of FOSS; when standalone it should still match
     expect(splitByAbbreviations('OSS is related to FOSS', map)).toEqual([
-      { text: 'OSS', termKey: 'OSS' },
+      { text: 'OSS', termKey: 'oss' },
       { text: ' is related to ' },
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
     ]);
   });
 
@@ -128,18 +130,18 @@ describe('splitByAbbreviations', () => {
     // FOSS contains OSS; FOSS should win and OSS should not be matched separately
     expect(splitByAbbreviations('Use FOSS today', map)).toEqual([
       { text: 'Use ' },
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
       { text: ' today' },
     ]);
   });
 
   it('preserves plain text between two consecutive matches', () => {
     expect(splitByAbbreviations('FOSS, RTFM, OSS', map)).toEqual([
-      { text: 'FOSS', termKey: 'FOSS' },
+      { text: 'FOSS', termKey: 'foss' },
       { text: ', ' },
-      { text: 'RTFM', termKey: 'RTFM' },
+      { text: 'RTFM', termKey: 'rtfm' },
       { text: ', ' },
-      { text: 'OSS', termKey: 'OSS' },
+      { text: 'OSS', termKey: 'oss' },
     ]);
   });
 });

--- a/src/app/utils/abbreviations.test.ts
+++ b/src/app/utils/abbreviations.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAbbreviationsMap, splitByAbbreviations } from './abbreviations';
+
+describe('buildAbbreviationsMap', () => {
+  it('returns an empty map for empty entries', () => {
+    expect(buildAbbreviationsMap([])).toEqual(new Map());
+  });
+
+  it('stores the term with its original casing as the key', () => {
+    const map = buildAbbreviationsMap([{ term: 'FOSS', definition: 'Free and Open Source Software' }]);
+    expect(map.get('FOSS')).toBe('Free and Open Source Software');
+    expect(map.get('foss')).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace from terms', () => {
+    const map = buildAbbreviationsMap([{ term: '  FOSS  ', definition: 'Free and Open Source Software' }]);
+    expect(map.get('FOSS')).toBe('Free and Open Source Software');
+    expect(map.size).toBe(1);
+  });
+
+  it('skips empty and whitespace-only terms', () => {
+    const map = buildAbbreviationsMap([
+      { term: '', definition: 'ignored' },
+      { term: '   ', definition: 'also ignored' },
+    ]);
+    expect(map.size).toBe(0);
+  });
+
+  it('treats the same term with different casing as separate entries', () => {
+    const map = buildAbbreviationsMap([
+      { term: 'OSS', definition: 'Open Source Software' },
+      { term: 'oss', definition: 'open source software' },
+    ]);
+    expect(map.size).toBe(2);
+    expect(map.get('OSS')).toBe('Open Source Software');
+    expect(map.get('oss')).toBe('open source software');
+  });
+
+  it('stores multiple distinct entries', () => {
+    const map = buildAbbreviationsMap([
+      { term: 'FOSS', definition: 'Free and Open Source Software' },
+      { term: 'RTFM', definition: 'Read The Fine Manual' },
+    ]);
+    expect(map.size).toBe(2);
+    expect(map.get('FOSS')).toBe('Free and Open Source Software');
+    expect(map.get('RTFM')).toBe('Read The Fine Manual');
+  });
+});
+
+describe('splitByAbbreviations', () => {
+  const map = buildAbbreviationsMap([
+    { term: 'FOSS', definition: 'Free and Open Source Software' },
+    { term: 'RTFM', definition: 'Read The Fine Manual' },
+    { term: 'OSS', definition: 'Open Source Software' },
+  ]);
+
+  it('returns a single plain segment when the map is empty', () => {
+    expect(splitByAbbreviations('hello FOSS world', new Map())).toEqual([{ text: 'hello FOSS world' }]);
+  });
+
+  it('returns a single plain segment when there are no matches', () => {
+    expect(splitByAbbreviations('hello world', map)).toEqual([{ text: 'hello world' }]);
+  });
+
+  it('returns a single plain segment for an empty string', () => {
+    expect(splitByAbbreviations('', map)).toEqual([{ text: '' }]);
+  });
+
+  it('splits a term match in the middle of a string', () => {
+    expect(splitByAbbreviations('Use FOSS software', map)).toEqual([
+      { text: 'Use ' },
+      { text: 'FOSS', termKey: 'FOSS' },
+      { text: ' software' },
+    ]);
+  });
+
+  it('splits a term match at the start of a string', () => {
+    expect(splitByAbbreviations('FOSS is great', map)).toEqual([
+      { text: 'FOSS', termKey: 'FOSS' },
+      { text: ' is great' },
+    ]);
+  });
+
+  it('splits a term match at the end of a string', () => {
+    expect(splitByAbbreviations('I love FOSS', map)).toEqual([
+      { text: 'I love ' },
+      { text: 'FOSS', termKey: 'FOSS' },
+    ]);
+  });
+
+  it('handles multiple terms in the same string', () => {
+    expect(splitByAbbreviations('FOSS and RTFM', map)).toEqual([
+      { text: 'FOSS', termKey: 'FOSS' },
+      { text: ' and ' },
+      { text: 'RTFM', termKey: 'RTFM' },
+    ]);
+  });
+
+  it('is case-sensitive and does not match the wrong casing', () => {
+    expect(splitByAbbreviations('I like foss and Foss', map)).toEqual([
+      { text: 'I like foss and Foss' },
+    ]);
+  });
+
+  it('does not match a term that is a prefix of a longer word (word boundary)', () => {
+    // OSS is in the map, but should not match inside FOSS because the F provides no boundary
+    const ossOnlyMap = buildAbbreviationsMap([{ term: 'OSS', definition: 'Open Source Software' }]);
+    expect(splitByAbbreviations('FOSS rocks', ossOnlyMap)).toEqual([{ text: 'FOSS rocks' }]);
+  });
+
+  it('does not match a term embedded inside a longer word', () => {
+    // OSS should not match inside CROSS or GLOSS
+    const ossOnlyMap = buildAbbreviationsMap([{ term: 'OSS', definition: 'Open Source Software' }]);
+    expect(splitByAbbreviations('CROSS the GLOSS', ossOnlyMap)).toEqual([{ text: 'CROSS the GLOSS' }]);
+  });
+
+  it('matches a shorter term standalone when the longer overlapping term is also defined', () => {
+    // OSS is a suffix of FOSS; when standalone it should still match
+    expect(splitByAbbreviations('OSS is related to FOSS', map)).toEqual([
+      { text: 'OSS', termKey: 'OSS' },
+      { text: ' is related to ' },
+      { text: 'FOSS', termKey: 'FOSS' },
+    ]);
+  });
+
+  it('prefers the longer term when a shorter one is a suffix of it', () => {
+    // FOSS contains OSS; FOSS should win and OSS should not be matched separately
+    expect(splitByAbbreviations('Use FOSS today', map)).toEqual([
+      { text: 'Use ' },
+      { text: 'FOSS', termKey: 'FOSS' },
+      { text: ' today' },
+    ]);
+  });
+
+  it('preserves plain text between two consecutive matches', () => {
+    expect(splitByAbbreviations('FOSS, RTFM, OSS', map)).toEqual([
+      { text: 'FOSS', termKey: 'FOSS' },
+      { text: ', ' },
+      { text: 'RTFM', termKey: 'RTFM' },
+      { text: ', ' },
+      { text: 'OSS', termKey: 'OSS' },
+    ]);
+  });
+});

--- a/src/app/utils/abbreviations.ts
+++ b/src/app/utils/abbreviations.ts
@@ -7,12 +7,12 @@ export type RoomAbbreviationsContent = {
   entries: AbbreviationEntry[];
 };
 
-/** Build a map of exact-case term → definition for O(1) lookup. */
+/** Build a map of lowercase term → definition for O(1) lookup. */
 export const buildAbbreviationsMap = (entries: AbbreviationEntry[]): Map<string, string> => {
   const map = new Map<string, string>();
   entries.forEach(({ term, definition }) => {
     const t = term.trim();
-    if (t) map.set(t, definition);
+    if (t) map.set(t.toLowerCase(), definition);
   });
   return map;
 };
@@ -20,10 +20,10 @@ export const buildAbbreviationsMap = (entries: AbbreviationEntry[]): Map<string,
 /**
  * Split a plain-text string into alternating [plain, term, plain, term, …] segments.
  * Matched terms preserve their original casing from the source string.
- * Matching is whole-word and case-sensitive.
+ * Matching is whole-word and case-insensitive.
  *
  * Returns an array of `{ text, termKey }` objects where `termKey` is undefined for
- * plain segments and is the exact-case lookup key for abbreviation segments.
+ * plain segments and is the lowercase lookup key for abbreviation segments.
  */
 export type TextSegment = {
   text: string;
@@ -38,7 +38,7 @@ export const splitByAbbreviations = (text: string, abbrMap: Map<string, string>)
   // Sort longest first so "HTTP/2" matches before "HTTP".
   const terms = [...abbrMap.keys()].sort((a, b) => b.length - a.length);
   const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'g');
+  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'gi');
 
   const segments: TextSegment[] = [];
   let lastIndex = 0;
@@ -49,7 +49,7 @@ export const splitByAbbreviations = (text: string, abbrMap: Map<string, string>)
     if (match.index > lastIndex) {
       segments.push({ text: text.slice(lastIndex, match.index) });
     }
-    segments.push({ text: match[0], termKey: match[0] });
+    segments.push({ text: match[0], termKey: match[0].toLowerCase() });
     lastIndex = match.index + match[0].length;
   }
 

--- a/src/app/utils/abbreviations.ts
+++ b/src/app/utils/abbreviations.ts
@@ -1,0 +1,61 @@
+export type AbbreviationEntry = {
+  term: string;
+  definition: string;
+};
+
+export type RoomAbbreviationsContent = {
+  entries: AbbreviationEntry[];
+};
+
+/** Build a map of lowercase term → definition for O(1) lookup. */
+export const buildAbbreviationsMap = (entries: AbbreviationEntry[]): Map<string, string> => {
+  const map = new Map<string, string>();
+  entries.forEach(({ term, definition }) => {
+    const t = term.trim();
+    if (t) map.set(t.toLowerCase(), definition);
+  });
+  return map;
+};
+
+/**
+ * Split a plain-text string into alternating [plain, term, plain, term, …] segments.
+ * Matched terms preserve their original casing from the source string.
+ * Matching is whole-word and case-insensitive.
+ *
+ * Returns an array of `{ text, termKey }` objects where `termKey` is undefined for
+ * plain segments and is the lowercase lookup key for abbreviation segments.
+ */
+export type TextSegment = {
+  text: string;
+  /** Undefined for plain text; the lowercase map key for an abbreviation. */
+  termKey?: string;
+};
+
+export const splitByAbbreviations = (text: string, abbrMap: Map<string, string>): TextSegment[] => {
+  if (abbrMap.size === 0) return [{ text }];
+
+  // Build a regex that matches any of the terms at word boundaries.
+  // Sort longest first so "HTTP/2" matches before "HTTP".
+  const terms = [...abbrMap.keys()].sort((a, b) => b.length - a.length);
+  const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'gi');
+
+  const segments: TextSegment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  // eslint-disable-next-line no-cond-assign
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ text: match[0], termKey: match[0].toLowerCase() });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex) });
+  }
+
+  return segments.length > 0 ? segments : [{ text }];
+};

--- a/src/app/utils/abbreviations.ts
+++ b/src/app/utils/abbreviations.ts
@@ -7,12 +7,12 @@ export type RoomAbbreviationsContent = {
   entries: AbbreviationEntry[];
 };
 
-/** Build a map of lowercase term → definition for O(1) lookup. */
+/** Build a map of exact-case term → definition for O(1) lookup. */
 export const buildAbbreviationsMap = (entries: AbbreviationEntry[]): Map<string, string> => {
   const map = new Map<string, string>();
   entries.forEach(({ term, definition }) => {
     const t = term.trim();
-    if (t) map.set(t.toLowerCase(), definition);
+    if (t) map.set(t, definition);
   });
   return map;
 };
@@ -20,10 +20,10 @@ export const buildAbbreviationsMap = (entries: AbbreviationEntry[]): Map<string,
 /**
  * Split a plain-text string into alternating [plain, term, plain, term, …] segments.
  * Matched terms preserve their original casing from the source string.
- * Matching is whole-word and case-insensitive.
+ * Matching is whole-word and case-sensitive.
  *
  * Returns an array of `{ text, termKey }` objects where `termKey` is undefined for
- * plain segments and is the lowercase lookup key for abbreviation segments.
+ * plain segments and is the exact-case lookup key for abbreviation segments.
  */
 export type TextSegment = {
   text: string;
@@ -38,7 +38,7 @@ export const splitByAbbreviations = (text: string, abbrMap: Map<string, string>)
   // Sort longest first so "HTTP/2" matches before "HTTP".
   const terms = [...abbrMap.keys()].sort((a, b) => b.length - a.length);
   const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'gi');
+  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'g');
 
   const segments: TextSegment[] = [];
   let lastIndex = 0;
@@ -49,7 +49,7 @@ export const splitByAbbreviations = (text: string, abbrMap: Map<string, string>)
     if (match.index > lastIndex) {
       segments.push({ text: text.slice(lastIndex, match.index) });
     }
-    segments.push({ text: match[0], termKey: match[0].toLowerCase() });
+    segments.push({ text: match[0], termKey: match[0] });
     lastIndex = match.index + match[0].length;
   }
 

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -123,6 +123,7 @@ const buildListRequiredState = (): MSC3575RoomSubscription['required_state'] => 
   [EventType.RoomMember, MSC3575_STATE_KEY_ME],
   ['m.space.child', MSC3575_WILDCARD],
   ['im.ponies.room_emotes', MSC3575_WILDCARD],
+  ['moe.sable.room.abbreviations', ''],
 ];
 
 // For an active encrypted room: fetch everything so the client can decrypt all events.

--- a/src/types/matrix/room.ts
+++ b/src/types/matrix/room.ts
@@ -49,6 +49,7 @@ export enum StateEvent {
   RoomCosmeticsColor = 'moe.sable.room.cosmetics.color',
   RoomCosmeticsFont = 'moe.sable.room.cosmetics.font',
   RoomCosmeticsPronouns = 'moe.sable.room.cosmetics.pronouns',
+  RoomAbbreviations = 'moe.sable.room.abbreviations',
 }
 
 export enum MessageEvent {


### PR DESCRIPTION
Closes #403

## Summary

Adds the ability for room moderators to define a list of term/definition abbreviation pairs in room state. Defined terms are highlighted in plain-text messages with a hover tooltip showing the definition.

## Changes

### New state event: `moe.sable.room.abbreviations`
- Content: `{ entries: [{ term: string, definition: string }] }`
- Single event (empty state key)
- Synced for all rooms via sliding sync required state

### Room settings page
- New "Abbreviations" page in room settings modal (requires `stateEvent` power level)
- Add term + definition pairs via a form
- Remove individual entries
- Duplicate term detection
- Spaces can set Abbreviations for all rooms in the space

### Message rendering
- Plain-text messages: defined terms are wrapped in `<abbr>` elements with a tooltip showing the definition
- HTML/formatted messages are unaffected
- Whole-word matching (`\b`), case-insensitive, longest terms matched first
- Provided via React context (`RoomAbbreviationsContext`) — no prop threading needed

## Files changed

| File | Change |
|------|--------|
| `src/types/matrix/room.ts` | Add `StateEvent.RoomAbbreviations` |
| `src/client/slidingSync.ts` | Include abbreviations in required state |
| `src/app/state/roomSettings.ts` | Add `RoomSettingsPage.AbbreviationsPage` |
| `src/app/utils/abbreviations.ts` | New — types, `buildAbbreviationsMap`, `splitByAbbreviations` |
| `src/app/hooks/useRoomAbbreviations.ts` | New — hook + context |
| `src/app/components/message/RenderBody.tsx` | Tooltip rendering for defined terms |
| `src/app/features/room-settings/abbreviations/RoomAbbreviations.tsx` | New — settings page |
| `src/app/features/room-settings/RoomSettings.tsx` | Wire in menu item + page |
| `src/app/features/room/Room.tsx` | Provide abbreviations context |
| `.changeset/feat-room-abbreviations.md` | Knope changeset (minor) |

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### AI assistance level

- [ ] **None** — No AI tools were used
- [ ] **Research only** — AI used for research, brainstorming, or understanding existing code; no generated code included
- [ ] **AI-assisted** — AI suggested code or logic that I reviewed, tested, and understand fully; I can explain every change
- [X] **Primarily AI-generated** — The majority of code was AI-generated; I have thoroughly reviewed it, verified correctness, and made it my own

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings