### PR TITLE
Feat: Added Styling to replies to non-messages

### DIFF
--- a/.changeset/styling-state-event-replies.md
+++ b/.changeset/styling-state-event-replies.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Added styling for replies to non-messages.

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -20,7 +20,7 @@ import { useIgnoredUsers } from '$hooks/useIgnoredUsers';
 import { nicknamesAtom } from '$state/nicknames';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useMemberEventParser } from '$hooks/useMemberEventParser';
-import { StateEvent } from '$types/matrix/room';
+import { StateEvent, MessageEvent } from '$types/matrix/room';
 import { useTranslation } from 'react-i18next';
 import * as customHtmlCss from '$styles/CustomHtml.css';
 import {
@@ -50,7 +50,11 @@ export const ReplyLayout = as<'div', ReplyLayoutProps>(
         <Icon size="100" src={Icons.ReplyArrow} />
       </Box>
       {!!icon && <Icon style={{ opacity: 0.6 }} size="50" src={icon} />}
-      <Box style={{ color: userColor, maxWidth: toRem(200) }} alignItems="Center" shrink="No">
+      <Box
+        style={{ color: !icon ? userColor : 'unset', maxWidth: toRem(200) }}
+        alignItems="Center"
+        shrink="No"
+      >
         {username}
       </Box>
       <Box grow="Yes" className={css.ReplyContent}>
@@ -101,6 +105,7 @@ export const Reply = as<'div', ReplyProps>(
     const ignoredUsers = useIgnoredUsers();
     const isBlockedSender = !!sender && ignoredUsers.includes(sender);
     const { t } = useTranslation();
+    const isRedacted = replyEvent?.isRedacted() === true;
 
     const parseMemberEvent = useMemberEventParser();
 
@@ -108,11 +113,7 @@ export const Reply = as<'div', ReplyProps>(
     const nicknames = useAtomValue(nicknamesAtom);
     const useAuthentication = useMediaAuthentication();
 
-    const fallbackBody = replyEvent?.isRedacted() ? (
-      <MessageDeletedContent />
-    ) : (
-      <MessageFailedContent />
-    );
+    const fallbackBody = isRedacted ? <MessageDeletedContent /> : <MessageFailedContent />;
 
     const badEncryption = replyEvent?.getContent().msgtype === 'm.bad.encrypted';
 
@@ -164,7 +165,7 @@ export const Reply = as<'div', ReplyProps>(
       const callJoined = replyEvent.getContent<SessionMembershipData>().application;
       image = callJoined ? Icons.Phone : Icons.PhoneDown;
       bodyJSX = callJoined ? ' joined the call' : ' ended the call';
-    } else if (eventType) {
+    } else if (Object.values(MessageEvent).every((v) => v !== eventType)) {
       image = Icons.Code;
       bodyJSX = (
         <>
@@ -174,7 +175,6 @@ export const Reply = as<'div', ReplyProps>(
         </>
       );
     }
-
     return (
       <Box direction="Row" gap="200" alignItems="Center" {...props} ref={ref}>
         {threadRootId && (
@@ -204,13 +204,15 @@ export const Reply = as<'div', ReplyProps>(
               })()}
             </Text>
           ) : (
-            <LinePlaceholder
-              style={{
-                backgroundColor: color.SurfaceVariant.ContainerActive,
-                width: toRem(placeholderWidth),
-                maxWidth: '100%',
-              }}
-            />
+            (isRedacted && <MessageDeletedContent />) || (
+              <LinePlaceholder
+                style={{
+                  backgroundColor: color.SurfaceVariant.ContainerActive,
+                  width: toRem(placeholderWidth),
+                  maxWidth: '100%',
+                }}
+              />
+            )
           )}
         </ReplyLayout>
         {replyEvent === null && (

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -1,11 +1,16 @@
-import { Box, Chip, Icon, Icons, Text, as, color, toRem } from 'folds';
-import { EventTimelineSet, Room } from '$types/matrix-sdk';
+import { Box, Chip, Icon, IconSrc, Icons, Text, as, color, toRem } from 'folds';
+import { EventTimelineSet, Room, SessionMembershipData } from '$types/matrix-sdk';
 import { MouseEventHandler, ReactNode, useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import parse from 'html-react-parser';
 import { useAtomValue } from 'jotai';
-import { getMemberDisplayName, trimReplyFromBody, trimReplyFromFormattedBody } from '$utils/room';
+import {
+  getMemberDisplayName,
+  isMembershipChanged,
+  trimReplyFromBody,
+  trimReplyFromFormattedBody,
+} from '$utils/room';
 import { getMxIdLocalPart } from '$utils/matrix';
 import { randomNumberBetween } from '$utils/common';
 import {
@@ -19,6 +24,9 @@ import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { useIgnoredUsers } from '$hooks/useIgnoredUsers';
 import { nicknamesAtom } from '$state/nicknames';
 import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useMemberEventParser } from '$hooks/useMemberEventParser';
+import { StateEvent } from '$types/matrix/room';
+import { useTranslation } from 'react-i18next';
 import {
   MessageBadEncryptedContent,
   MessageBlockedContent,
@@ -31,9 +39,10 @@ import { LinePlaceholder } from './placeholder';
 type ReplyLayoutProps = {
   userColor?: string;
   username?: ReactNode;
+  icon?: IconSrc;
 };
 export const ReplyLayout = as<'div', ReplyLayoutProps>(
-  ({ username, userColor, className, children, ...props }, ref) => (
+  ({ username, userColor, icon, className, children, ...props }, ref) => (
     <Box
       className={classNames(css.Reply, className)}
       alignItems="Center"
@@ -41,8 +50,11 @@ export const ReplyLayout = as<'div', ReplyLayoutProps>(
       {...props}
       ref={ref}
     >
-      <Box style={{ color: userColor, maxWidth: toRem(200) }} alignItems="Center" shrink="No">
+      <Box style={{ color: userColor }} alignItems="Center" shrink="No">
         <Icon size="100" src={Icons.ReplyArrow} />
+      </Box>
+      {!!icon && <Icon style={{ opacity: 0.6 }} size="50" src={icon} />}
+      <Box style={{ color: userColor, maxWidth: toRem(200) }} alignItems="Center" shrink="No">
         {username}
       </Box>
       <Box grow="Yes" className={css.ReplyContent}>
@@ -91,6 +103,11 @@ export const Reply = as<'div', ReplyProps>(
 
     const ignoredUsers = useIgnoredUsers();
     const isBlockedSender = !!sender && ignoredUsers.includes(sender);
+    const eventStateType = replyEvent?.getType();
+    const { t } = useTranslation();
+
+    const isMemberShipEvent = !!replyEvent && isMembershipChanged(replyEvent);
+    const parseMemberEvent = useMemberEventParser();
 
     const { color: usernameColor, font: usernameFont } = useSableCosmetics(sender ?? '', room);
     const nicknames = useAtomValue(nicknamesAtom);
@@ -116,6 +133,7 @@ export const Reply = as<'div', ReplyProps>(
       !replyEvent.getClearContent();
 
     let bodyJSX: ReactNode = fallbackBody;
+    let image: IconSrc | undefined;
 
     if (format === 'org.matrix.custom.html' && formattedBody) {
       const strippedHtml = trimReplyFromFormattedBody(formattedBody)
@@ -134,6 +152,23 @@ export const Reply = as<'div', ReplyProps>(
     } else if (body) {
       const strippedBody = trimReplyFromBody(body).replaceAll(/(?:\r\n|\r|\n)/g, ' ');
       bodyJSX = scaleSystemEmoji(strippedBody);
+    } else if (isMemberShipEvent) {
+      const parsedMemberEvent = parseMemberEvent(replyEvent);
+      image = parsedMemberEvent.icon;
+      bodyJSX = parsedMemberEvent.body;
+    } else if (eventStateType === StateEvent.RoomName) {
+      image = Icons.Hash;
+      bodyJSX = t('Organisms.RoomCommon.changed_room_name');
+    } else if (eventStateType === StateEvent.RoomTopic) {
+      image = Icons.Hash;
+      bodyJSX = ' changed room topic';
+    } else if (eventStateType === StateEvent.RoomAvatar) {
+      image = Icons.Hash;
+      bodyJSX = ' changed room avatar';
+    } else if (!!replyEvent && eventStateType === StateEvent.GroupCallMemberPrefix) {
+      const callJoined = replyEvent.getContent<SessionMembershipData>().application;
+      image = callJoined ? Icons.Phone : Icons.PhoneDown;
+      bodyJSX = callJoined ? ' joined the call' : ' ended the call';
     }
 
     return (
@@ -144,8 +179,10 @@ export const Reply = as<'div', ReplyProps>(
         <ReplyLayout
           as="button"
           userColor={usernameColor}
+          icon={image}
           username={
-            sender && (
+            sender &&
+            !isMemberShipEvent && (
               <Text size="T300" truncate style={{ fontFamily: usernameFont }}>
                 <b>{getMemberDisplayName(room, sender, nicknames) ?? getMxIdLocalPart(sender)}</b>
               </Text>

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -50,11 +50,7 @@ export const ReplyLayout = as<'div', ReplyLayoutProps>(
         <Icon size="100" src={Icons.ReplyArrow} />
       </Box>
       {!!icon && <Icon style={{ opacity: 0.6 }} size="50" src={icon} />}
-      <Box
-        style={{ color: !icon ? userColor : 'unset', maxWidth: toRem(200) }}
-        alignItems="Center"
-        shrink="No"
-      >
+      <Box style={{ color: userColor, maxWidth: toRem(200) }} alignItems="Center" shrink="No">
         {username}
       </Box>
       <Box grow="Yes" className={css.ReplyContent}>

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -5,12 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import parse from 'html-react-parser';
 import { useAtomValue } from 'jotai';
-import {
-  getMemberDisplayName,
-  isMembershipChanged,
-  trimReplyFromBody,
-  trimReplyFromFormattedBody,
-} from '$utils/room';
+import { getMemberDisplayName, trimReplyFromBody, trimReplyFromFormattedBody } from '$utils/room';
 import { getMxIdLocalPart } from '$utils/matrix';
 import { randomNumberBetween } from '$utils/common';
 import {
@@ -27,6 +22,7 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useMemberEventParser } from '$hooks/useMemberEventParser';
 import { StateEvent } from '$types/matrix/room';
 import { useTranslation } from 'react-i18next';
+import * as customHtmlCss from '$styles/CustomHtml.css';
 import {
   MessageBadEncryptedContent,
   MessageBlockedContent,
@@ -100,13 +96,12 @@ export const Reply = as<'div', ReplyProps>(
 
     const { body, formatted_body: formattedBody, format } = replyEvent?.getContent() ?? {};
     const sender = replyEvent?.getSender();
+    const eventType = replyEvent?.getType();
 
     const ignoredUsers = useIgnoredUsers();
     const isBlockedSender = !!sender && ignoredUsers.includes(sender);
-    const eventStateType = replyEvent?.getType();
     const { t } = useTranslation();
 
-    const isMemberShipEvent = !!replyEvent && isMembershipChanged(replyEvent);
     const parseMemberEvent = useMemberEventParser();
 
     const { color: usernameColor, font: usernameFont } = useSableCosmetics(sender ?? '', room);
@@ -152,23 +147,32 @@ export const Reply = as<'div', ReplyProps>(
     } else if (body) {
       const strippedBody = trimReplyFromBody(body).replaceAll(/(?:\r\n|\r|\n)/g, ' ');
       bodyJSX = scaleSystemEmoji(strippedBody);
-    } else if (isMemberShipEvent) {
+    } else if (eventType === StateEvent.RoomMember && !!replyEvent) {
       const parsedMemberEvent = parseMemberEvent(replyEvent);
       image = parsedMemberEvent.icon;
       bodyJSX = parsedMemberEvent.body;
-    } else if (eventStateType === StateEvent.RoomName) {
+    } else if (eventType === StateEvent.RoomName) {
       image = Icons.Hash;
       bodyJSX = t('Organisms.RoomCommon.changed_room_name');
-    } else if (eventStateType === StateEvent.RoomTopic) {
+    } else if (eventType === StateEvent.RoomTopic) {
       image = Icons.Hash;
       bodyJSX = ' changed room topic';
-    } else if (eventStateType === StateEvent.RoomAvatar) {
+    } else if (eventType === StateEvent.RoomAvatar) {
       image = Icons.Hash;
       bodyJSX = ' changed room avatar';
-    } else if (!!replyEvent && eventStateType === StateEvent.GroupCallMemberPrefix) {
+    } else if (eventType === StateEvent.GroupCallMemberPrefix && !!replyEvent) {
       const callJoined = replyEvent.getContent<SessionMembershipData>().application;
       image = callJoined ? Icons.Phone : Icons.PhoneDown;
       bodyJSX = callJoined ? ' joined the call' : ' ended the call';
+    } else if (eventType) {
+      image = Icons.Code;
+      bodyJSX = (
+        <>
+          {' sent '}
+          <code className={customHtmlCss.Code}>{eventType}</code>
+          {' state event'}
+        </>
+      );
     }
 
     return (
@@ -182,7 +186,7 @@ export const Reply = as<'div', ReplyProps>(
           icon={image}
           username={
             sender &&
-            !isMemberShipEvent && (
+            eventType !== StateEvent.RoomMember && (
               <Text size="T300" truncate style={{ fontFamily: usernameFont }}>
                 <b>{getMemberDisplayName(room, sender, nicknames) ?? getMxIdLocalPart(sender)}</b>
               </Text>

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -351,6 +351,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     );
 
     const replyEvent = replyDraft ? room.findEventById(replyDraft.eventId) : undefined;
+
+    // Seed the reply draft with the thread relation whenever we're in thread
+    // mode (e.g. on first render or when the thread root changes). We use the
+    // current user's ID as userId so that the mention logic skips it.
     useEffect(() => {
       if (!threadRootId) return;
       setReplyDraft((prev) => {

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -3,7 +3,6 @@ import {
   KeyboardEventHandler,
   MouseEvent,
   RefObject,
-  ReactNode,
   useCallback,
   useEffect,
   useRef,
@@ -44,13 +43,6 @@ import {
   toRem,
 } from 'folds';
 
-import parse from 'html-react-parser';
-import {
-  getReactCustomHtmlParser,
-  LINKIFY_OPTS,
-  scaleSystemEmoji,
-} from '$plugins/react-custom-html-parser';
-
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import {
   AutocompletePrefix,
@@ -83,7 +75,6 @@ import {
   TUploadContent,
   encryptFile,
   getImageInfo,
-  getMxIdLocalPart,
   mxcUrlToHttp,
   toggleReaction,
 } from '$utils/matrix';
@@ -113,23 +104,16 @@ import { safeFile } from '$utils/mimeTypes';
 import { fulfilledPromiseSettledResult } from '$utils/common';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
-import {
-  getMemberDisplayName,
-  getMentionContent,
-  reactionOrEditEvent,
-  trimReplyFromBody,
-  trimReplyFromFormattedBody,
-} from '$utils/room';
+import { getMentionContent, reactionOrEditEvent } from '$utils/room';
 import { Command, SHRUG, TABLEFLIP, UNFLIP, useCommands } from '$hooks/useCommands';
 import { mobileOrTablet } from '$utils/user-agent';
 import { useElementSizeObserver } from '$hooks/useElementSizeObserver';
-import { ReplyLayout, ThreadIndicator } from '$components/message';
+import { Reply, ThreadIndicator } from '$components/message';
 import { roomToParentsAtom } from '$state/room/roomToParents';
 import { nicknamesAtom } from '$state/nicknames';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { useImagePackRooms } from '$hooks/useImagePackRooms';
 import { useComposingCheck } from '$hooks/useComposingCheck';
-import { useSableCosmetics } from '$hooks/useSableCosmetics';
 import { createLogger } from '$utils/debug';
 import { createDebugLogger } from '$utils/debugLogger';
 import FocusTrap from 'focus-trap-react';
@@ -275,12 +259,6 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     const [msgDraft, setMsgDraft] = useAtom(roomIdToMsgDraftAtomFamily(draftKey));
     const [replyDraft, setReplyDraft] = useAtom(roomIdToReplyDraftAtomFamily(draftKey));
-    const replyUserID = replyDraft?.userId;
-
-    const { color: replyUsernameColor, font: replyUsernameFont } = useSableCosmetics(
-      replyUserID ?? '',
-      room
-    );
 
     const [uploadBoard, setUploadBoard] = useState(true);
     const [selectedFiles, setSelectedFiles] = useAtom(roomIdToUploadItemsAtomFamily(draftKey));
@@ -373,45 +351,6 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     );
 
     const replyEvent = replyDraft ? room.findEventById(replyDraft.eventId) : undefined;
-    const {
-      body: replyBody,
-      formatted_body: replyFormattedBody,
-      format: replyFormat,
-    } = replyEvent?.getContent() ?? {};
-
-    // Prefer the live event content; fall back to what was snapshotted in the
-    // draft when the user hit Reply (the event may not be in SDK state if it
-    // was redacted or evicted, but the draft always carries the original body).
-    const htmlBody =
-      replyFormat === 'org.matrix.custom.html' ? replyFormattedBody : replyDraft?.formattedBody;
-    const plainBody = replyBody ?? replyDraft?.body;
-
-    let replyBodyJSX: ReactNode = replyDraft ? trimReplyFromBody(replyDraft.body) : null;
-
-    if (htmlBody) {
-      /**
-       * message with linebreaks, etc stripped
-       */
-      const strippedHtml = trimReplyFromFormattedBody(htmlBody)
-        .replaceAll(/<br\s*\/?>/gi, ' ')
-        .replaceAll(/<\/p>\s*<p[^>]*>/gi, ' ')
-        .replaceAll(/<\/?p[^>]*>/gi, '')
-        .replaceAll(/(?:\r\n|\r|\n)/g, ' ')
-        .trim();
-      const parserOpts = getReactCustomHtmlParser(mx, roomId, {
-        linkifyOpts: LINKIFY_OPTS,
-        useAuthentication,
-        nicknames,
-      });
-      replyBodyJSX = parse(strippedHtml, parserOpts);
-    } else if (plainBody) {
-      const strippedBody = trimReplyFromBody(plainBody).replaceAll(/(?:\r\n|\r|\n)/g, ' ');
-      replyBodyJSX = scaleSystemEmoji(strippedBody);
-    }
-
-    // Seed the reply draft with the thread relation whenever we're in thread
-    // mode (e.g. on first render or when the thread root changes). We use the
-    // current user's ID as userId so that the mention logic skips it.
     useEffect(() => {
       if (!threadRootId) return;
       setReplyDraft((prev) => {
@@ -1260,22 +1199,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                         {replyDraft.relation?.rel_type === RelationType.Thread && !threadRootId && (
                           <ThreadIndicator />
                         )}
-                        <ReplyLayout
-                          userColor={replyUsernameColor}
-                          username={
-                            <Text size="T300" truncate style={{ fontFamily: replyUsernameFont }}>
-                              <b>
-                                {getMemberDisplayName(room, replyDraft.userId, nicknames) ??
-                                  getMxIdLocalPart(replyDraft.userId) ??
-                                  replyDraft.userId}
-                              </b>
-                            </Text>
-                          }
-                        >
-                          <Text size="T300" truncate>
-                            {replyBodyJSX}
-                          </Text>
-                        </ReplyLayout>
+                        <Reply room={room} replyEventId={replyDraft.eventId} />
                       </Box>
                       <IconButton
                         variant="SurfaceVariant"

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -1332,6 +1332,25 @@ export const Event = as<'div', EventProps>(
                         }}
                       >
                         <Menu {...props} ref={ref}>
+                          <MenuItem
+                            size="300"
+                            after={<Icon size="100" src={Icons.ReplyArrow} />}
+                            radii="300"
+                            data-event-id={mEvent.getId()}
+                            onClick={(evt: any) => {
+                              onReplyClick(evt);
+                              closeMenu();
+                            }}
+                          >
+                            <Text
+                              className={css.MessageMenuItemText}
+                              as="span"
+                              size="T300"
+                              truncate
+                            >
+                              Reply
+                            </Text>
+                          </MenuItem>
                           <Box direction="Column" gap="100" className={css.MessageMenuGroup}>
                             {!hideReadReceipts && (
                               <MessageReadReceiptItem room={room} eventId={mEvent.getId() ?? ''} />


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This PR fixes the current look when you reply to a non-message event and it shows an error "unable to load message" error. 
It also makes the reply tab when you write a message out to look the same as how a regular reply looks. 
Lastly it adds the reply button to the right click Menu on non-message events so you can just reply easier

(the look of a reply to a non-message event)
<img width="798" height="807" alt="image" src="https://github.com/user-attachments/assets/6afa63db-c345-4d64-8bc9-8507fc366850" />

(**this is not in the actual version but could be an alternative it could be changed to by removing the very last commit**)
<img width="875" height="805" alt="image" src="https://github.com/user-attachments/assets/59b445a9-9acb-442f-9ee9-87c33ea7cc9f" />


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
