### PR TITLE
fix: suppress unread dot for rooms set to Mute

### DIFF
--- a/.changeset/fix-muted-room-unread-indicator.md
+++ b/.changeset/fix-muted-room-unread-indicator.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Hide unread dot/highlight for rooms with notification mode set to Mute.

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -343,6 +343,9 @@ export function RoomNavItem({
   };
 
   const optionsVisible = hover || !!menuAnchor;
+  const isMutedRoom = notificationMode === RoomNotificationMode.Mute;
+  const shouldShowUnreadIndicator = !isMutedRoom && (!!unread || hasRoomUnread);
+
   let unreadCount = 0;
   if (unread) {
     unreadCount = unread.highlight > 0 ? unread.highlight : unread.total;
@@ -368,7 +371,7 @@ export function RoomNavItem({
       <NavItem
         variant="Background"
         radii="400"
-        highlight={unread !== undefined || hasRoomUnread}
+        highlight={shouldShowUnreadIndicator}
         aria-selected={selected}
         data-hover={!!menuAnchor}
         onContextMenu={handleContextMenu}
@@ -425,7 +428,7 @@ export function RoomNavItem({
                   <TypingIndicator size="300" disableAnimation />
                 </Badge>
               )}
-              {!optionsVisible && (unread || hasRoomUnread) && (
+              {!optionsVisible && shouldShowUnreadIndicator && (
                 <UnreadBadgeCenter>
                   <UnreadBadge
                     highlight={!!unread && unread.highlight > 0}


### PR DESCRIPTION
## Bug
Fixes https://github.com/SableClient/Sable/issues/395 — muted rooms still showed unread dot/highlight even when notification mode was set to Mute.

## Fix
- Added explicit muted-room check in `RoomNavItem`.
- Introduced `shouldShowUnreadIndicator` guard that requires:
  - room is **not** in `RoomNotificationMode.Mute`
  - room has unread data (`unread` or `hasRoomUnread`)
- Applied this guard to:
  - room row highlight state
  - unread badge/dot rendering

This keeps muted rooms visually quiet in the room list while preserving unread behavior for non-muted rooms.

## Testing
- Verified logic path in `src/app/features/room-nav/RoomNavItem.tsx` for both muted and non-muted room notification modes.

Greetings, saschabuehrle
