### PR TITLE
fix(threads): skip classic-sync backfill when server-side thread support is active

### DIFF
--- a/.changeset/fix-thread-drawer-server-side-backfill.md
+++ b/.changeset/fix-thread-drawer-server-side-backfill.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix thread drawer flooding console with "Ignoring event" warnings when server-side thread support is enabled.

--- a/src/app/features/room/ThreadDrawer.tsx
+++ b/src/app/features/room/ThreadDrawer.tsx
@@ -428,13 +428,25 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
 
   const rootEvent = room.findEventById(threadRootId);
 
-  // When the drawer is opened with classic sync, room.createThread() may have
-  // been called with empty initialEvents so thread.events only has the root.
-  // Backfill events from the main room timeline into the Thread object so the
-  // authoritative source is populated for subsequent renders and receipts.
+  // When the drawer is opened with classic sync (no server-side thread support),
+  // room.createThread() may have been called with empty initialEvents so
+  // thread.events only has the root.  Backfill events from the main room
+  // timeline so the authoritative source is populated for subsequent renders.
+  //
+  // IMPORTANT: skip this backfill when server-side thread support is active
+  // (initialEventsFetched starts false).  In that case the SDK will call
+  // updateThreadMetadata() → resetLiveTimeline() + paginateEventTimeline()
+  // automatically.  Calling thread.addEvents() ourselves first would trigger
+  // that same cascade prematurely and cause a flood of
+  // "EventTimelineSet.addEventToTimeline: Ignoring event=…" warnings because
+  // canContain() fails while the timeline is in the middle of being reset and
+  // repopulated.
   useEffect(() => {
     const thread = room.getThread(threadRootId);
     if (!thread) return;
+    // initialEventsFetched === false  ↔  Thread.hasServerSideSupport is set.
+    // The SDK handles initialization itself; our manual backfill must not run.
+    if (!thread.initialEventsFetched) return;
     const hasRepliesInThread = thread.events.some(
       (ev) => ev.getId() !== threadRootId && !reactionOrEditEvent(ev)
     );


### PR DESCRIPTION
### Description

Fixes a flood of `EventTimelineSet.addEventToTimeline: Ignoring event=… that does not belong in timeline=… timelineSet(threadId=…)` console warnings that appeared whenever a thread was opened in rooms with server-side thread support enabled (the default on Synapse/element.io homeservers).

**Root cause:** PR #343 added a backfill `useEffect` in `ThreadDrawer` that calls `thread.addEvents(liveEvents, false)` when the Thread object had no replies (classic-sync workaround). However, when server-side thread support is active `thread.initialEventsFetched` starts as `false` — meaning the SDK is already going to call `updateThreadMetadata()` → `timelineSet.resetLiveTimeline()` + `client.paginateEventTimeline()` automatically. Calling `thread.addEvents()` ourselves _before_ that completes causes events to be inserted into a timeline that is mid-reset, so `canContain()` fails for every event → warning flood.

**Fix:** Guard the backfill with `if (!thread.initialEventsFetched) return`. This is `false` exactly when `Thread.hasServerSideSupport` is set, so the backfill now only runs in the pure classic-sync case it was designed for.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### AI assistance level

- [ ] **None** — No AI tools were used
- [ ] **Research only** — AI used for research, brainstorming, or understanding existing code; no generated code included
- [ ] **AI-assisted** — AI suggested code or logic that I reviewed, tested, and understand fully; I can explain every change
- [x] **Primarily AI-generated** — The majority of code was AI-generated; I have thoroughly reviewed it, verified correctness, and made it my own

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings