### PR TITLE
fix: Fix Width for Call Chat View

### DIFF
--- a/.changeset/fixes_width_mismatch_for_the_call_chat_view.md
+++ b/.changeset/fixes_width_mismatch_for_the_call_chat_view.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixes width mismatch for the call chat view.

--- a/src/app/features/room/CallChatView.tsx
+++ b/src/app/features/room/CallChatView.tsx
@@ -16,7 +16,7 @@ export function CallChatView() {
   return (
     <Page
       style={{
-        width: screenSize === ScreenSize.Desktop ? toRem(456) : '100%',
+        width: screenSize === ScreenSize.Desktop ? toRem(399) : '100%',
         flexShrink: 0,
         flexGrow: 0,
       }}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

In the current Sable client, there is a mismatch between the width values set for the containing page for CallChatView and the RoomView inside of it. This PR is a simple change to make these values match.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
