### PR TITLE
Fix "Default" menu item height in room notification switcher.

### DIFF
--- a/.changeset/fix_default_menu_item_height_in_room_notification_switcher.md
+++ b/.changeset/fix_default_menu_item_height_in_room_notification_switcher.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix "Default" menu item height in room notification switcher.

--- a/src/app/components/RoomNotificationSwitcher.tsx
+++ b/src/app/components/RoomNotificationSwitcher.tsx
@@ -90,7 +90,7 @@ export function RoomNotificationModeSwitcher({
               {modes.map((mode) => (
                 <MenuItem
                   key={mode}
-                  size="300"
+                  size={mode === RoomNotificationMode.Unset ? '300' : '400'}
                   variant="Surface"
                   aria-pressed={mode === value}
                   radii="300"

--- a/src/app/components/RoomNotificationSwitcher.tsx
+++ b/src/app/components/RoomNotificationSwitcher.tsx
@@ -1,4 +1,4 @@
-import { Box, config, Icon, Menu, MenuItem, PopOut, RectCords, Text } from 'folds';
+import { Box, config, Icon, Menu, MenuItem, PopOut, RectCords, Text, toRem } from 'folds';
 import { MouseEventHandler, ReactNode, useMemo, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import { stopPropagation } from '$utils/keyboard';
@@ -90,9 +90,10 @@ export function RoomNotificationModeSwitcher({
               {modes.map((mode) => (
                 <MenuItem
                   key={mode}
-                  size={mode === RoomNotificationMode.Unset ? '300' : '400'}
+                  size="300"
                   variant="Surface"
                   aria-pressed={mode === value}
+                  style={mode === RoomNotificationMode.Unset ? { height: toRem(48) } : undefined}
                   radii="300"
                   disabled={changing}
                   onClick={() => handleSelect(mode)}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Another papercut fix - currently, the "Default" room notification switcher menu item is cut off because its double the content height of the other items, but does not have an increased button height to compensate this. This PR adds a style override to fix this.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
