### PR TITLE
Fix: fix file messages to show better on other clients

### DIFF
--- a/.changeset/small-image-fix.md
+++ b/.changeset/small-image-fix.md
@@ -1,4 +1,5 @@
 ---
 default: patch
 ---
+
 Fix messages sent from sable showing wrong on other client(s)

--- a/.changeset/small-image-fix.md
+++ b/.changeset/small-image-fix.md
@@ -1,0 +1,4 @@
+---
+default: patch
+---
+Fix messages sent from sable showing wrong on other client(s)

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -1354,26 +1354,26 @@ export const Event = as<'div', EventProps>(
                         }}
                       >
                         <Menu {...props} ref={ref}>
-                          <MenuItem
-                            size="300"
-                            after={<Icon size="100" src={Icons.ReplyArrow} />}
-                            radii="300"
-                            data-event-id={mEvent.getId()}
-                            onClick={(evt: any) => {
-                              onReplyClick(evt);
-                              closeMenu();
-                            }}
-                          >
-                            <Text
-                              className={css.MessageMenuItemText}
-                              as="span"
-                              size="T300"
-                              truncate
-                            >
-                              Reply
-                            </Text>
-                          </MenuItem>
                           <Box direction="Column" gap="100" className={css.MessageMenuGroup}>
+                            <MenuItem
+                              size="300"
+                              after={<Icon size="100" src={Icons.ReplyArrow} />}
+                              radii="300"
+                              data-event-id={mEvent.getId()}
+                              onClick={(evt: any) => {
+                                onReplyClick(evt);
+                                closeMenu();
+                              }}
+                            >
+                              <Text
+                                className={css.MessageMenuItemText}
+                                as="span"
+                                size="T300"
+                                truncate
+                              >
+                                Reply
+                              </Text>
+                            </MenuItem>
                             {!hideReadReceipts && (
                               <MessageReadReceiptItem room={room} eventId={mEvent.getId() ?? ''} />
                             )}

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -59,8 +59,6 @@ export const getImageMsgContent = async (
     msgtype: MsgType.Image,
     filename: file.name,
     body: file.name,
-    format: 'org.matrix.custom.html',
-    formatted_body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
   if (imgEl) {
@@ -101,8 +99,6 @@ export const getVideoMsgContent = async (
     msgtype: MsgType.Video,
     filename: file.name,
     body: file.name,
-    format: 'org.matrix.custom.html',
-    formatted_body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
   if (videoEl) {
@@ -155,8 +151,6 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string): AudioMsgCont
     msgtype: MsgType.Audio,
     filename: file.name,
     body: item.body && item.body.length > 0 ? item.body : 'a voice message',
-    format: 'org.matrix.custom.html',
-    formatted_body: item.body && item.body.length > 0 ? item.body : '<em>a voice message</em>',
     info: {
       mimetype: file.type,
       size: file.size,
@@ -220,8 +214,6 @@ export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
     msgtype: MsgType.File,
     filename: file.name,
     body: file.name,
-    format: 'org.matrix.custom.html',
-    formatted_body: file.name,
     info: {
       mimetype: file.type,
       size: file.size,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This change fixes the fact that on some clients (fluffychat) if you have a formatted body at all no matter what it is it will display it, it just removes the fields until they are used.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
