### PR TITLE
Fix cinny-dark-theme link colors being too dark

### DIFF
--- a/.changeset/fix_cinny_dark_theme_link_colors_being_too_dark.md
+++ b/.changeset/fix_cinny_dark_theme_link_colors_being_too_dark.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Fix cinny-dark-theme link colors being too dark

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,7 @@
 }
 
 .dark-theme,
+.cinny-dark-theme,
 .butter-theme {
   --tc-link: hsl(213deg 100% 80%);
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds `cinny-dark-theme` to the list of "normal" dark themes to keep the colors more consistent.

Fixes #459

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
