### PR TITLE
Add knocking support

### DIFF
--- a/.changeset/add_knocking_support_when_attempting_to_join_a_room_from_the_directory_an_address_a_room_mention_or_space_hierarchy.md
+++ b/.changeset/add_knocking_support_when_attempting_to_join_a_room_from_the_directory_an_address_a_room_mention_or_space_hierarchy.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-# Add knocking support when attempting to join a room from the directory, an address, a room mention, or space hierarchy, as well as text command support for knocking.
+# Add knocking support when attempting to join a room from the directory, an address, a room mention, or space hierarchy, as well as text command support for knocking. Also improves rendering for knock notifications in rooms.

--- a/.changeset/add_knocking_support_when_attempting_to_join_a_room_from_the_directory_an_address_a_room_mention_or_space_hierarchy.md
+++ b/.changeset/add_knocking_support_when_attempting_to_join_a_room_from_the_directory_an_address_a_room_mention_or_space_hierarchy.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-# Add knocking support when attempting to join a room from the directory, an address, a room mention, or space hierarchy.
+# Add knocking support when attempting to join a room from the directory, an address, a room mention, or space hierarchy, as well as text command support for knocking.

--- a/.changeset/add_knocking_support_when_attempting_to_join_a_room_from_the_directory_an_address_a_room_mention_or_space_hierarchy.md
+++ b/.changeset/add_knocking_support_when_attempting_to_join_a_room_from_the_directory_an_address_a_room_mention_or_space_hierarchy.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add knocking support when attempting to join a room from the directory, an address, a room mention, or space hierarchy.

--- a/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
+++ b/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
@@ -47,7 +47,7 @@ export function KnockRoomPrompt({ roomId, via, onDone, onCancel }: KnockRoomProp
 
   useEffect(() => {
     if (knockState.status === AsyncStatus.Success) {
-      debugLog.info('ui', 'Successfully left room', { roomId });
+      debugLog.info('ui', 'Successfully knocked on room', { roomId });
       onDone();
     }
   }, [knockState, onDone, roomId]);

--- a/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
+++ b/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
@@ -22,7 +22,7 @@ import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { stopPropagation } from '$utils/keyboard';
 import { createDebugLogger } from '$utils/debugLogger';
 
-const debugLog = createDebugLogger('KockRoomPrompt');
+const debugLog = createDebugLogger('KnockRoomPrompt');
 
 type KnockRoomProps = {
   roomId: string;

--- a/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
+++ b/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, FormEventHandler } from 'react';
 import FocusTrap from 'focus-trap-react';
 import {
   Dialog,
@@ -12,6 +12,7 @@ import {
   IconButton,
   Icon,
   Icons,
+  Input,
   color,
   Button,
   Spinner,
@@ -32,17 +33,23 @@ type KnockRoomProps = {
 };
 export function KnockRoomPrompt({ roomId, via, onDone, onCancel }: KnockRoomProps) {
   const mx = useMatrixClient();
-  const [reason, setReason] = useState('');
 
-  const [knockState, knockRoom] = useAsyncCallback<undefined, MatrixError, []>(
-    useCallback(async () => {
-      debugLog.info('ui', 'Knock room button clicked', { roomId });
-      mx.knockRoom(roomId, { viaServers: via || undefined, reason: reason.trim() || undefined });
-    }, [mx, roomId, reason, via])
+  const [knockState, knockRoom] = useAsyncCallback<undefined, MatrixError, [string?]>(
+    useCallback(
+      async (reason?: string) => {
+        debugLog.info('ui', 'Knock room button clicked', { roomId });
+        mx.knockRoom(roomId, { viaServers: via || undefined, reason });
+      },
+      [mx, roomId, via]
+    )
   );
 
-  const handleKnock = () => {
-    knockRoom();
+  const handleKnock: FormEventHandler<HTMLFormElement> = (evt) => {
+    evt.preventDefault();
+    const target = evt.target as HTMLFormElement;
+    const reasonInput = (target?.reasonInput as HTMLInputElement) || undefined;
+    const reason = reasonInput?.value.trim() || undefined;
+    knockRoom(reason);
   };
 
   useEffect(() => {
@@ -79,28 +86,35 @@ export function KnockRoomPrompt({ roomId, via, onDone, onCancel }: KnockRoomProp
                 <Icon src={Icons.Cross} />
               </IconButton>
             </Header>
-            <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
+            <Box
+              as="form"
+              onSubmit={handleKnock}
+              style={{ padding: config.space.S400 }}
+              direction="Column"
+              gap="400"
+            >
               <Box direction="Column" gap="200">
                 <Text priority="400">
                   Request to join this room. You can optionally leave a reason for the moderators.
                 </Text>
-                <textarea
-                  value={reason}
-                  onChange={(e) => setReason(e.target.value)}
-                  placeholder="Reason"
-                  rows={3}
-                  style={{ resize: 'vertical', width: '100%' }}
-                />
-                {knockState.status === AsyncStatus.Error && (
-                  <Text style={{ color: color.Critical.Main }} size="T300">
-                    Failed to knock! {knockState.error.message}
+                <Box direction="Column" gap="100">
+                  <Text size="L400">
+                    Reason{' '}
+                    <Text as="span" size="T200">
+                      (Optional)
+                    </Text>
                   </Text>
-                )}
+                  <Input name="reasonInput" variant="Background" />
+                  {knockState.status === AsyncStatus.Error && (
+                    <Text style={{ color: color.Critical.Main }} size="T300">
+                      Failed to knock! {knockState.error.message}
+                    </Text>
+                  )}
+                </Box>
               </Box>
               <Button
                 type="submit"
                 variant="Primary"
-                onClick={handleKnock}
                 before={
                   knockState.status === AsyncStatus.Loading ? (
                     <Spinner fill="Solid" variant="Primary" size="200" />

--- a/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
+++ b/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
@@ -18,6 +18,7 @@ import {
   Spinner,
 } from 'folds';
 import { MatrixError } from '$types/matrix-sdk';
+
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { stopPropagation } from '$utils/keyboard';
@@ -27,7 +28,7 @@ const debugLog = createDebugLogger('KnockRoomPrompt');
 
 type KnockRoomProps = {
   roomId: string;
-  via?: string;
+  via?: string | string[];
   onDone: () => void;
   onCancel: () => void;
 };
@@ -80,7 +81,7 @@ export function KnockRoomPrompt({ roomId, via, onDone, onCancel }: KnockRoomProp
               size="500"
             >
               <Box grow="Yes">
-                <Text size="H4">Knock on Room</Text>
+                <Text size="H4">Knock On Room</Text>
               </Box>
               <IconButton size="300" onClick={onCancel} radii="300">
                 <Icon src={Icons.Cross} />

--- a/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
+++ b/src/app/components/knock-room-prompt/KnockRoomPrompt.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from 'react';
+import FocusTrap from 'focus-trap-react';
+import {
+  Dialog,
+  Overlay,
+  OverlayCenter,
+  OverlayBackdrop,
+  Header,
+  config,
+  Box,
+  Text,
+  IconButton,
+  Icon,
+  Icons,
+  color,
+  Button,
+  Spinner,
+} from 'folds';
+import { MatrixError } from '$types/matrix-sdk';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
+import { stopPropagation } from '$utils/keyboard';
+import { createDebugLogger } from '$utils/debugLogger';
+
+const debugLog = createDebugLogger('KockRoomPrompt');
+
+type KnockRoomProps = {
+  roomId: string;
+  via?: string;
+  onDone: () => void;
+  onCancel: () => void;
+};
+export function KnockRoomPrompt({ roomId, via, onDone, onCancel }: KnockRoomProps) {
+  const mx = useMatrixClient();
+  const [reason, setReason] = useState('');
+
+  const [knockState, knockRoom] = useAsyncCallback<undefined, MatrixError, []>(
+    useCallback(async () => {
+      debugLog.info('ui', 'Knock room button clicked', { roomId });
+      mx.knockRoom(roomId, { viaServers: via || undefined, reason: reason.trim() || undefined });
+    }, [mx, roomId, reason, via])
+  );
+
+  const handleKnock = () => {
+    knockRoom();
+  };
+
+  useEffect(() => {
+    if (knockState.status === AsyncStatus.Success) {
+      debugLog.info('ui', 'Successfully left room', { roomId });
+      onDone();
+    }
+  }, [knockState, onDone, roomId]);
+
+  return (
+    <Overlay open backdrop={<OverlayBackdrop />}>
+      <OverlayCenter>
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: false,
+            onDeactivate: onCancel,
+            clickOutsideDeactivates: true,
+            escapeDeactivates: stopPropagation,
+          }}
+        >
+          <Dialog variant="Surface">
+            <Header
+              style={{
+                padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
+                borderBottomWidth: config.borderWidth.B300,
+              }}
+              variant="Surface"
+              size="500"
+            >
+              <Box grow="Yes">
+                <Text size="H4">Knock on Room</Text>
+              </Box>
+              <IconButton size="300" onClick={onCancel} radii="300">
+                <Icon src={Icons.Cross} />
+              </IconButton>
+            </Header>
+            <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
+              <Box direction="Column" gap="200">
+                <Text priority="400">
+                  Request to join this room. You can optionally leave a reason for the moderators.
+                </Text>
+                <textarea
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="Reason"
+                  rows={3}
+                  style={{ resize: 'vertical', width: '100%' }}
+                />
+                {knockState.status === AsyncStatus.Error && (
+                  <Text style={{ color: color.Critical.Main }} size="T300">
+                    Failed to knock! {knockState.error.message}
+                  </Text>
+                )}
+              </Box>
+              <Button
+                type="submit"
+                variant="Primary"
+                onClick={handleKnock}
+                before={
+                  knockState.status === AsyncStatus.Loading ? (
+                    <Spinner fill="Solid" variant="Primary" size="200" />
+                  ) : undefined
+                }
+                aria-disabled={
+                  knockState.status === AsyncStatus.Loading ||
+                  knockState.status === AsyncStatus.Success
+                }
+              >
+                <Text size="B400">
+                  {knockState.status === AsyncStatus.Loading ? 'Knocking...' : 'Knock'}
+                </Text>
+              </Button>
+            </Box>
+          </Dialog>
+        </FocusTrap>
+      </OverlayCenter>
+    </Overlay>
+  );
+}

--- a/src/app/components/knock-room-prompt/index.ts
+++ b/src/app/components/knock-room-prompt/index.ts
@@ -1,0 +1,1 @@
+export * from './KnockRoomPrompt';

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -280,7 +280,7 @@ export const RoomCard = as<'div', RoomCardProps>(
             <>
               <Button onClick={() => setKnocking(true)} variant="Secondary" size="300">
                 <Text size="B300" truncate>
-                  {knocking ? 'Knock' : 'Knocked'}
+                  Knock
                 </Text>
               </Button>
 

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useCallback, useRef, useState } from 'react';
-import { MatrixError, Room } from '$types/matrix-sdk';
+import { JoinRule, MatrixError, Room } from '$types/matrix-sdk';
 import {
   Avatar,
   Badge,
@@ -31,6 +31,7 @@ import { useElementSizeObserver } from '$hooks/useElementSizeObserver';
 import { getRoomAvatarUrl, getStateEvent } from '$utils/room';
 import { useStateEventCallback } from '$hooks/useStateEventCallback';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import { KnockRoomPrompt } from '$components/knock-room-prompt';
 import { RoomAvatar } from '$components/room-avatar';
 import * as css from './style.css';
 
@@ -143,6 +144,7 @@ type RoomCardProps = {
   topic?: string;
   memberCount?: number;
   roomType?: string;
+  joinRule?: JoinRule;
   viaServers?: string[];
   onView?: (roomId: string) => void;
   renderTopicViewer: (name: string, topic: string, requestClose: () => void) => ReactNode;
@@ -158,6 +160,7 @@ export const RoomCard = as<'div', RoomCardProps>(
       topic,
       memberCount,
       roomType,
+      joinRule,
       viaServers,
       onView,
       renderTopicViewer,
@@ -172,7 +175,7 @@ export const RoomCard = as<'div', RoomCardProps>(
     const [topicEvent, setTopicEvent] = useState(() =>
       joinedRoom ? getStateEvent(joinedRoom, StateEvent.RoomTopic) : undefined
     );
-
+    const [knocking, setKnocking] = useState(false);
     const fallbackName = getMxIdLocalPart(roomIdOrAlias) ?? roomIdOrAlias;
     const fallbackTopic = roomIdOrAlias;
 
@@ -271,19 +274,38 @@ export const RoomCard = as<'div', RoomCardProps>(
             </Text>
           </Button>
         )}
-        {typeof joinedRoomId !== 'string' && joinState.status !== AsyncStatus.Error && (
-          <Button
-            onClick={join}
-            variant="Secondary"
-            size="300"
-            disabled={joining}
-            before={joining && <Spinner size="50" variant="Secondary" fill="Soft" />}
-          >
-            <Text size="B300" truncate>
-              {joining ? 'Joining' : 'Join'}
-            </Text>
-          </Button>
-        )}
+        {typeof joinedRoomId !== 'string' &&
+          joinState.status !== AsyncStatus.Error &&
+          (joinRule === JoinRule.Knock ? (
+            <>
+              <Button onClick={() => setKnocking(true)} variant="Secondary" size="300">
+                <Text size="B300" truncate>
+                  {knocking ? 'Knock' : 'Knocked'}
+                </Text>
+              </Button>
+
+              {knocking && (
+                <KnockRoomPrompt
+                  roomId={roomIdOrAlias}
+                  via={viaServers}
+                  onDone={() => setKnocking(false)}
+                  onCancel={() => setKnocking(false)}
+                />
+              )}
+            </>
+          ) : (
+            <Button
+              onClick={join}
+              variant="Secondary"
+              size="300"
+              disabled={joining}
+              before={joining && <Spinner size="50" variant="Secondary" fill="Soft" />}
+            >
+              <Text size="B300" truncate>
+                {joining ? 'Joining' : 'Join'}
+              </Text>
+            </Button>
+          ))}
         {typeof joinedRoomId !== 'string' && joinState.status === AsyncStatus.Error && (
           <Box gap="200">
             <Button

--- a/src/app/features/join-before-navigate/JoinBeforeNavigate.tsx
+++ b/src/app/features/join-before-navigate/JoinBeforeNavigate.tsx
@@ -65,6 +65,7 @@ export function JoinBeforeNavigate({
                   topic={summary?.topic}
                   memberCount={summary?.num_joined_members}
                   roomType={summary?.room_type}
+                  joinRule={summary?.join_rule}
                   viaServers={viaServers}
                   renderTopicViewer={(name, topic, requestClose) => (
                     <RoomTopicViewer name={name} topic={topic} requestClose={requestClose} />

--- a/src/app/features/lobby/RoomItem.tsx
+++ b/src/app/features/lobby/RoomItem.tsx
@@ -25,6 +25,7 @@ import { SequenceCard } from '$components/sequence-card';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { HierarchyItem } from '$hooks/useSpaceHierarchy';
 import { millify } from '$plugins/millify';
+import { KnockRoomPrompt } from '$components/knock-room-prompt';
 import { LocalRoomSummaryLoader } from '$components/RoomSummaryLoader';
 import { UseStateProvider } from '$components/UseStateProvider';
 import { RoomTopicViewer } from '$components/room-topic-viewer';
@@ -97,48 +98,43 @@ function RoomJoinButton({ roomId, via }: RoomJoinButtonProps) {
 
 function RoomKnockButton({ roomId, via }: RoomJoinButtonProps) {
   return (
-    <Box shrink="No" gap="200" alignItems="Center">
-      {/* {joinState.status === AsyncStatus.Error && (
-        <TooltipProvider
-          tooltip={
-            <Tooltip variant="Critical" style={{ maxWidth: toRem(200) }}>
-              <Box direction="Column" gap="100">
-                <Text style={{ wordBreak: 'break-word' }} size="T400">
-                  {joinState.error.data?.error || joinState.error.message}
-                </Text>
-                <Text size="T200">{joinState.error.name}</Text>
-              </Box>
-            </Tooltip>
-          }
-        >
-          {(triggerRef) => (
-            <Icon
-              ref={triggerRef}
-              style={{ color: color.Critical.Main, cursor: 'pointer' }}
-              src={Icons.Warning}
-              size="400"
-              filled
-              tabIndex={0}
-              aria-label={joinState.error.data?.error || joinState.error.message}
+    <UseStateProvider initial={false}>
+      {(knocking, setKnocking) => (
+        <Box shrink="No" gap="200" alignItems="Center">
+          <Chip
+            variant="Secondary"
+            fill="Soft"
+            size="400"
+            radii="Pill"
+            before=<Icon src={Icons.MailPlus} size="50" />
+            onClick={() => setKnocking(true)}
+          >
+            <Text size="B300">Knock</Text>
+          </Chip>
+          {knocking && (
+            <KnockRoomPrompt
+              roomId={roomId}
+              via={via}
+              onDone={() => setKnocking(false)}
+              onCancel={() => setKnocking(false)}
             />
           )}
-        </TooltipProvider>
-      )} */}
-      <Chip
-        variant="Secondary"
-        fill="Soft"
-        size="400"
-        radii="Pill"
-        // before={
-        //   canJoin ? <Icon src={Icons.Plus} size="50" /> : <Spinner variant="Secondary" size="100" />
-        // }
-        onClick={join}
-        // disabled={!canJoin}
-      >
-        <Text size="B300">Knock</Text>
-      </Chip>
-    </Box>
+        </Box>
+      )}
+    </UseStateProvider>
   );
+}
+
+type RoomJoinOrKnockButtonProps = {
+  roomId: string;
+  via?: string[];
+  joinRule?: JoinRule;
+};
+function RoomJoinOrKnockButton({ roomId, via, joinRule }: RoomJoinOrKnockButtonProps) {
+  if (joinRule === JoinRule.Knock) {
+    return <RoomKnockButton roomId={roomId} via={via} />;
+  }
+  return <RoomJoinButton roomId={roomId} via={via} />;
 }
 
 function RoomProfileLoading() {
@@ -212,7 +208,7 @@ function RoomProfileError({ roomId, suggested, inaccessibleRoom, via }: RoomProf
           )}
         </Box>
       </Box>
-      {!inaccessibleRoom && <RoomJoinButton roomId={roomId} via={via} />}
+      {!inaccessibleRoom && <RoomJoinOrKnockButton roomId={roomId} via={via} />}
     </Box>
   );
 }
@@ -409,7 +405,11 @@ export const RoomItemCard = as<'div', RoomItemCardProps>(
                         </Chip>
                       </Box>
                     ) : (
-                      <RoomJoinButton roomId={roomId} via={content.via} />
+                      <RoomJoinOrKnockButton
+                        roomId={roomId}
+                        via={content.via}
+                        joinRule={localSummary.joinRule}
+                      />
                     )
                   }
                 />
@@ -453,7 +453,13 @@ export const RoomItemCard = as<'div', RoomItemCardProps>(
                   memberCount={summary.num_joined_members}
                   suggested={content.suggested}
                   joinRule={summary.join_rule}
-                  options={<RoomJoinButton roomId={roomId} via={content.via} />}
+                  options={
+                    <RoomJoinOrKnockButton
+                      roomId={roomId}
+                      via={content.via}
+                      joinRule={summary.join_rule}
+                    />
+                  }
                 />
               )}
             </>

--- a/src/app/features/lobby/RoomItem.tsx
+++ b/src/app/features/lobby/RoomItem.tsx
@@ -44,7 +44,6 @@ type RoomJoinButtonProps = {
 };
 function RoomJoinButton({ roomId, via }: RoomJoinButtonProps) {
   const mx = useMatrixClient();
-
   const [joinState, join] = useAsyncCallback<Room, MatrixError, []>(
     useCallback(() => mx.joinRoom(roomId, { viaServers: via }), [mx, roomId, via])
   );
@@ -91,6 +90,52 @@ function RoomJoinButton({ roomId, via }: RoomJoinButtonProps) {
         disabled={!canJoin}
       >
         <Text size="B300">Join</Text>
+      </Chip>
+    </Box>
+  );
+}
+
+function RoomKnockButton({ roomId, via }: RoomJoinButtonProps) {
+  return (
+    <Box shrink="No" gap="200" alignItems="Center">
+      {/* {joinState.status === AsyncStatus.Error && (
+        <TooltipProvider
+          tooltip={
+            <Tooltip variant="Critical" style={{ maxWidth: toRem(200) }}>
+              <Box direction="Column" gap="100">
+                <Text style={{ wordBreak: 'break-word' }} size="T400">
+                  {joinState.error.data?.error || joinState.error.message}
+                </Text>
+                <Text size="T200">{joinState.error.name}</Text>
+              </Box>
+            </Tooltip>
+          }
+        >
+          {(triggerRef) => (
+            <Icon
+              ref={triggerRef}
+              style={{ color: color.Critical.Main, cursor: 'pointer' }}
+              src={Icons.Warning}
+              size="400"
+              filled
+              tabIndex={0}
+              aria-label={joinState.error.data?.error || joinState.error.message}
+            />
+          )}
+        </TooltipProvider>
+      )} */}
+      <Chip
+        variant="Secondary"
+        fill="Soft"
+        size="400"
+        radii="Pill"
+        // before={
+        //   canJoin ? <Icon src={Icons.Plus} size="50" /> : <Spinner variant="Secondary" size="100" />
+        // }
+        onClick={join}
+        // disabled={!canJoin}
+      >
+        <Text size="B300">Knock</Text>
       </Chip>
     </Box>
   );

--- a/src/app/features/lobby/RoomItem.tsx
+++ b/src/app/features/lobby/RoomItem.tsx
@@ -106,7 +106,7 @@ function RoomKnockButton({ roomId, via }: RoomJoinButtonProps) {
             fill="Soft"
             size="400"
             radii="Pill"
-            before=<Icon src={Icons.MailPlus} size="50" />
+            before={<Icon src={Icons.MailPlus} size="50" />}
             onClick={() => setKnocking(true)}
           >
             <Text size="B300">Knock</Text>

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -233,6 +233,7 @@ export enum Command {
   Delete = 'delete',
   Acl = 'acl',
   // Sable commands
+  Knock = 'knock',
   Color = 'color',
   SColor = 'scolor',
   Font = 'font',
@@ -763,6 +764,20 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
         },
       },
       // Sable commands
+      [Command.Knock]: {
+        name: Command.Knock,
+        description:
+          'Knock on (request to join) room with address. Example: /knock address1 address2',
+        exe: async (payload) => {
+          const rawIds = splitWithSpace(payload);
+          const roomIdOrAliases = rawIds.filter(
+            (idOrAlias) => isRoomId(idOrAlias) || isRoomAlias(idOrAlias)
+          );
+          roomIdOrAliases.forEach(async (idOrAlias) => {
+            await mx.knockRoom(idOrAlias);
+          });
+        },
+      },
       [Command.Color]: {
         name: Command.Color,
         description: 'Set a room-specific color. Example: /color #ff00ff | /color reset',

--- a/src/app/hooks/useMemberEventParser.tsx
+++ b/src/app/hooks/useMemberEventParser.tsx
@@ -63,12 +63,12 @@ export const useMemberEventParser = (): MemberEventParser => {
 
       if (content.membership === Membership.Knock) {
         return {
-          icon: Icons.ArrowGoRightPlus,
+          icon: Icons.Mail,
           body: (
             <>
               <b>{userName}</b>
-              {' request to join room '}
-              {reason}
+              {' requested to join room: '}
+              <i>{reason}</i>
             </>
           ),
         };

--- a/src/app/pages/client/explore/Featured.tsx
+++ b/src/app/pages/client/explore/Featured.tsx
@@ -67,6 +67,7 @@ export function FeaturedRooms() {
                                 name={roomSummary?.name}
                                 topic={roomSummary?.topic}
                                 memberCount={roomSummary?.num_joined_members}
+                                joinRule={roomSummary?.join_rule}
                                 onView={navigateSpace}
                                 renderTopicViewer={(name, topic, requestClose) => (
                                   <RoomTopicViewer
@@ -96,6 +97,7 @@ export function FeaturedRooms() {
                                 name={roomSummary?.name}
                                 topic={roomSummary?.topic}
                                 memberCount={roomSummary?.num_joined_members}
+                                joinRule={roomSummary?.join_rule}
                                 onView={navigateRoom}
                                 renderTopicViewer={(name, topic, requestClose) => (
                                   <RoomTopicViewer

--- a/src/app/pages/client/explore/Server.tsx
+++ b/src/app/pages/client/explore/Server.tsx
@@ -599,6 +599,7 @@ export function PublicRooms() {
                               topic={chunkRoom.topic}
                               memberCount={chunkRoom.num_joined_members}
                               roomType={chunkRoom.room_type}
+                              joinRule={chunkRoom.join_rule}
                               onView={
                                 chunkRoom.room_type === RoomType.Space
                                   ? navigateSpace


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This adds support for room knocking to Sable from both space hierarchy and the room card (as seen when joining from address, clicking a room mention, or in the featured page of discovery). It additionally adds a new modal type that may be used for all knock attempts.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
