### PR TITLE
fix: recover timeline after TimelineReset

### DIFF
--- a/.changeset/fix-timeline-reset-recovery.md
+++ b/.changeset/fix-timeline-reset-recovery.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix messages disappearing from rooms after reconnects and timeline resets.

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -1,0 +1,128 @@
+import { EventEmitter } from 'events';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Room, RoomEvent } from '$types/matrix-sdk';
+import { useTimelineSync } from './useTimelineSync';
+
+vi.mock('@sentry/react', () => ({
+  default: {},
+  startSpan: async (_options: unknown, fn: () => Promise<unknown>) => fn(),
+  addBreadcrumb: vi.fn(),
+  captureMessage: vi.fn(),
+  metrics: {
+    distribution: vi.fn(),
+  },
+}));
+
+type FakeTimeline = {
+  getEvents: () => unknown[];
+  getNeighbouringTimeline: () => undefined;
+  getPaginationToken: () => undefined;
+  getRoomId: () => string;
+};
+
+type FakeTimelineSet = EventEmitter & {
+  getLiveTimeline: () => FakeTimeline;
+  getTimelineForEvent: () => undefined;
+};
+
+type FakeRoom = Room &
+  EventEmitter & {
+    emit: EventEmitter['emit'];
+  };
+
+function createTimeline(events: unknown[] = [{}]): FakeTimeline {
+  return {
+    getEvents: () => events,
+    getNeighbouringTimeline: () => undefined,
+    getPaginationToken: () => undefined,
+    getRoomId: () => '!room:test',
+  };
+}
+
+function createRoom(events: unknown[] = [{}]): {
+  room: FakeRoom;
+  timelineSet: FakeTimelineSet;
+  events: unknown[];
+} {
+  const timeline = createTimeline(events);
+  const timelineSet = new EventEmitter() as FakeTimelineSet;
+  timelineSet.getLiveTimeline = () => timeline;
+  timelineSet.getTimelineForEvent = () => undefined;
+
+  const roomEmitter = new EventEmitter();
+  const room = {
+    on: roomEmitter.on.bind(roomEmitter),
+    removeListener: roomEmitter.removeListener.bind(roomEmitter),
+    emit: roomEmitter.emit.bind(roomEmitter),
+    roomId: '!room:test',
+    getUnfilteredTimelineSet: () => timelineSet as never,
+    getEventReadUpTo: () => null,
+    getThread: () => null,
+    client: {
+      getUserId: () => '@alice:test',
+    },
+  } as unknown as FakeRoom;
+
+  return { room, timelineSet, events };
+}
+
+describe('useTimelineSync', () => {
+  it('does not snap a non-bottom user to latest after TimelineReset', async () => {
+    const { room, timelineSet, events } = createRoom();
+    const scrollToBottom = vi.fn();
+
+    renderHook(() =>
+      useTimelineSync({
+        room: room as Room,
+        mx: { getUserId: () => '@alice:test' } as never,
+        isAtBottom: false,
+        isAtBottomRef: { current: false },
+        scrollToBottom,
+        unreadInfo: undefined,
+        setUnreadInfo: vi.fn(),
+        hideReadsRef: { current: false },
+        readUptoEventIdRef: { current: undefined },
+      })
+    );
+
+    await act(async () => {
+      timelineSet.emit(RoomEvent.TimelineReset);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      events.push({});
+      room.emit(RoomEvent.LocalEchoUpdated, {}, room);
+      await Promise.resolve();
+    });
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('keeps a bottom-pinned user anchored after TimelineReset', async () => {
+    const { room, timelineSet } = createRoom();
+    const scrollToBottom = vi.fn();
+
+    renderHook(() =>
+      useTimelineSync({
+        room: room as Room,
+        mx: { getUserId: () => '@alice:test' } as never,
+        isAtBottom: true,
+        isAtBottomRef: { current: true },
+        scrollToBottom,
+        unreadInfo: undefined,
+        setUnreadInfo: vi.fn(),
+        hideReadsRef: { current: false },
+        readUptoEventIdRef: { current: undefined },
+      })
+    );
+
+    await act(async () => {
+      timelineSet.emit(RoomEvent.TimelineReset);
+      await Promise.resolve();
+    });
+
+    expect(scrollToBottom).toHaveBeenCalledWith('instant');
+  });
+});

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -203,8 +203,11 @@ const useLiveEventArrive = (room: Room, onArrive: (mEvent: MatrixEvent) => void)
   onArriveRef.current = onArrive;
 
   useEffect(() => {
-    const liveTimeline = getLiveTimeline(room);
-    const registeredAt = Date.now();
+    // Both are mutable: if TimelineReset replaces the live EventTimeline object
+    // we re-anchor them together inside the handler so the isLive check always
+    // runs against the current timeline and a fresh 60 s backfill window.
+    let liveTimeline = getLiveTimeline(room);
+    let registeredAt = Date.now();
     const handleTimelineEvent: EventTimelineSetHandlerMap[RoomEvent.Timeline] = (
       mEvent: MatrixEvent,
       eventRoom: Room | undefined,
@@ -213,6 +216,16 @@ const useLiveEventArrive = (room: Room, onArrive: (mEvent: MatrixEvent) => void)
       data: IRoomTimelineData
     ) => {
       if (eventRoom?.roomId !== room.roomId) return;
+
+      // Lazily re-anchor on timeline replacement. Capturing liveTimeline once
+      // at registration causes events on the new timeline to fail the reference
+      // check and be silently dropped after a sync gap / reconnect.
+      const currentLiveTimeline = getLiveTimeline(room);
+      if (currentLiveTimeline !== liveTimeline) {
+        liveTimeline = currentLiveTimeline;
+        registeredAt = Date.now();
+      }
+
       const { getTs } = mEvent;
       const isLive =
         data.liveEvent ||
@@ -345,7 +358,7 @@ export function useTimelineSync({
     | undefined
   >();
 
-  const timelineJustResetRef = useRef(false);
+  const resetAutoScrollPendingRef = useRef(false);
 
   const eventsLength = getTimelinesEventsCount(timeline.linkedTimelines);
   const liveTimelineLinked = timeline.linkedTimelines.at(-1) === getLiveTimeline(room);
@@ -485,7 +498,7 @@ export function useTimelineSync({
     room,
     useCallback(() => {
       const wasAtBottom = isAtBottomRef.current;
-      timelineJustResetRef.current = true;
+      resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
       if (wasAtBottom) {
         scrollToBottom('instant');
@@ -508,12 +521,21 @@ export function useTimelineSync({
   );
 
   useEffect(() => {
-    const resetPending = timelineJustResetRef.current;
-    if (resetPending) timelineJustResetRef.current = false;
+    const resetAutoScrollPending = resetAutoScrollPendingRef.current;
+    if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;
 
-    if (!(isAtBottom || resetPending) || !liveTimelineLinked || eventsLength === 0) return;
+    // liveTimelineLinked can be transiently false after TimelineReset: the SDK
+    // fires the event before React commits the new linkedTimelines, so the stored
+    // chain still references the old detached timeline. When auto-scroll recovery
+    // is pending for a bottom-pinned user, the guard is meaningless lag.
+    if (
+      !(isAtBottom || resetAutoScrollPending) ||
+      (!liveTimelineLinked && !resetAutoScrollPending) ||
+      eventsLength === 0
+    )
+      return;
 
-    if (eventsLength <= lastScrolledAtEventsLengthRef.current && !resetPending) return;
+    if (eventsLength <= lastScrolledAtEventsLengthRef.current && !resetAutoScrollPending) return;
 
     lastScrolledAtEventsLengthRef.current = eventsLength;
     scrollToBottom('instant');


### PR DESCRIPTION
### Description

This PR fixes the reconnect / limited-sync recovery path in the room timeline. Managed to track it down, thanks to this sentry report [SABLE-1V](https://sable-client.sentry.io/issues/104545427/events/741b82918ba34554996ad673efe75a6f/)

After `TimelineReset`, the hook now re-anchors live event detection to the current live timeline, allows bottom-pinned recovery to bypass the transient `liveTimelineLinked` lag, and avoids snapping non-bottom users to latest.

It also adds a regression test covering the reset behavior so the scroll recovery and non-bottom path stay locked down.

Fixes #360

Repro (It's a tricky one):

- Use a broken build on Android Chrome if possible. Desktop Chrome works too, but mobile/backgrounding is closer to the original report.
- Open a busy room and stay pinned to the bottom.
- In another client/account, send several messages to that room while the first client is disconnected.
- Force a real sync gap:
  - Mobile: background the app/tab, lock the phone, or toggle Wi‑Fi/mobile data off for 30-60s.
  - Desktop: open DevTools and set network to Offline for 30-60s.
- Reconnect and return to the room.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->