### PR TITLE
chore(ci): group dependabot npm major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,9 +46,14 @@ updates:
     commit-message:
       prefix: chore
     groups:
-      # Group all non-major updates together to reduce noise
-      npm-minor-patch:
+      npm-major:
+        patterns:
+          - '*'
+        update-types:
+          - major
+      npm-non-major:
+        patterns:
+          - '*'
         update-types:
           - minor
           - patch
-      # Major updates are ungrouped so they get individual review

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,13 +47,9 @@ updates:
       prefix: chore
     groups:
       npm-major:
-        patterns:
-          - '*'
         update-types:
           - major
       npm-non-major:
-        patterns:
-          - '*'
         update-types:
           - minor
           - patch


### PR DESCRIPTION
### Description

Group npm Dependabot version updates into separate major and non-major PR buckets so routine updates stay consolidated while breaking changes remain isolated.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
