### PR TITLE
Fix touchpad zooming in image viewer

### DIFF
--- a/.changeset/fixes_touchpad_zooming_behaviour.md
+++ b/.changeset/fixes_touchpad_zooming_behaviour.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# fixes touchpad zooming behaviour

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -25,8 +25,15 @@ export const ImageViewer = as<'div', ImageViewerProps>(
     };
 
     const handleWheel = (e: WheelEvent) => {
-      if (e.deltaY < 0) zoomIn();
-      else zoomOut();
+      const { deltaY } = e;
+      // Mouse wheel scrolls only by integer delta values, therefore
+      // If deltaY is an integer, then it's a mouse wheel action
+      if (Number.isInteger(deltaY)) {
+        if (deltaY < 0) {
+          zoomIn();
+        } else zoomOut();
+      }
+      // If it's not an integer, then it's a touchpad action, do nothing and let the browser handle the zooming
     };
 
     return (


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

When using the touchpad both browser and app zoom gets activated, so let the browser handle zooming when using a touchpad

Fixes #463 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
