### PR TITLE
Fix Video Camera auto enabling on Electron (and Tauri) clients using Sable Call.

### DIFF
--- a/.changeset/fix-video-auto-enabled.md
+++ b/.changeset/fix-video-auto-enabled.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Camera being enabled by default even when the client has it off pre joining in browsers that permit the video (Electron/Tauri as examples).

--- a/src/app/hooks/useCallEmbed.ts
+++ b/src/app/hooks/useCallEmbed.ts
@@ -52,7 +52,7 @@ export const createCallEmbed = (
   const ongoing =
     MatrixRTCSession.sessionMembershipsForRoom(room, rtcSession.sessionDescription).length > 0;
 
-  const intent = CallEmbed.getIntent(dm, ongoing);
+  const intent = CallEmbed.getIntent(dm, ongoing, pref.video);
   const widget = CallEmbed.getWidget(mx, room, intent, themeKind);
   const controlState = pref && new CallControlState(pref.microphone, pref.video, pref.sound);
 

--- a/src/app/hooks/useCallEmbed.ts
+++ b/src/app/hooks/useCallEmbed.ts
@@ -52,7 +52,7 @@ export const createCallEmbed = (
   const ongoing =
     MatrixRTCSession.sessionMembershipsForRoom(room, rtcSession.sessionDescription).length > 0;
 
-  const intent = CallEmbed.getIntent(dm, ongoing, pref.video);
+  const intent = CallEmbed.getIntent(dm, ongoing, pref?.video);
   const widget = CallEmbed.getWidget(mx, room, intent, themeKind);
   const controlState = pref && new CallControlState(pref.microphone, pref.video, pref.sound);
 

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -52,12 +52,12 @@ export class CallEmbed {
 
   private readonly disposables: Array<() => void> = [];
 
-  static getIntent(dm: boolean, ongoing: boolean): ElementCallIntent {
+  static getIntent(dm: boolean, ongoing: boolean, video: boolean): ElementCallIntent {
     if (ongoing) {
-      return dm ? ElementCallIntent.JoinExistingDM : ElementCallIntent.JoinExisting;
+      return !video ? ElementCallIntent.JoinExistingDMVoice : (dm ? ElementCallIntent.JoinExistingDM : ElementCallIntent.JoinExisting);
     }
 
-    return dm ? ElementCallIntent.StartCallDM : ElementCallIntent.StartCall;
+    return !video ? (dm ? ElementCallIntent.StartCallDMVoice : ElementCallIntent.JoinExistingDMVoice) : (dm ? ElementCallIntent.StartCallDM : ElementCallIntent.StartCall);
   }
 
   static getWidget(

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -53,11 +53,15 @@ export class CallEmbed {
   private readonly disposables: Array<() => void> = [];
 
   static getIntent(dm: boolean, ongoing: boolean, video: boolean): ElementCallIntent {
-    if (ongoing) {
-      return !video ? ElementCallIntent.JoinExistingDMVoice : (dm ? ElementCallIntent.JoinExistingDM : ElementCallIntent.JoinExisting);
+    if (!dm) {
+      return video ? ElementCallIntent.JoinExisting : ElementCallIntent.JoinExistingDMVoice;
     }
 
-    return !video ? (dm ? ElementCallIntent.StartCallDMVoice : ElementCallIntent.JoinExistingDMVoice) : (dm ? ElementCallIntent.StartCallDM : ElementCallIntent.StartCall);
+    if (ongoing) {
+      return video ? ElementCallIntent.JoinExistingDM : ElementCallIntent.JoinExistingDMVoice;
+    }
+
+    return video ? ElementCallIntent.StartCallDM : ElementCallIntent.StartCallDMVoice;
   }
 
   static getWidget(

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -52,7 +52,7 @@ export class CallEmbed {
 
   private readonly disposables: Array<() => void> = [];
 
-  static getIntent(dm: boolean, ongoing: boolean, video: boolean): ElementCallIntent {
+  static getIntent(dm: boolean, ongoing: boolean, video: boolean | undefined): ElementCallIntent {
     if (!dm) {
       return video ? ElementCallIntent.JoinExisting : ElementCallIntent.JoinExistingDMVoice;
     }


### PR DESCRIPTION
### Description

Fixes #285 for good. Element Call (and thus Sable Call) use a `callIntent` paramter derived from the `intent` parameter to decide if the Camera should be requested. The Camera was being requested on every call, and thus auto approved on Electron clients (and Tauri clients). This affected both starting a room call and joining a VC room. This is likely  due to the fact that in Element they are 'Video Rooms'. This change simply uses `JoinExistingDMVoice` which sets the correct parameters to join a VC room OR call from the room header. The `StartCall` and `JoinExisting` intents function the same on Sable Call's end, this can be changed if they start to diverge in future updates of course though.

I have tested this change in both scenarios of calling with multiple people and it has functioned as intended.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
