### PR TITLE
Fix: Add max height to state events

### DIFF
--- a/.changeset/maxHeight-stateEvent-fix.md
+++ b/.changeset/maxHeight-stateEvent-fix.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Added maximum height to state events

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -179,7 +179,12 @@ export const Reply = as<'div', ReplyProps>(
       const parsedMemberEvent = parseMemberEvent(replyEvent);
       image = parsedMemberEvent.icon;
       mentioned = false;
-      bodyJSX = parsedMemberEvent.body;
+      bodyJSX = (
+        <Box direction="Row" style={{ columnGap: toRem(6) }}>
+          {' '}
+          {parsedMemberEvent.body}{' '}
+        </Box>
+      );
     } else if (eventType === StateEvent.RoomName) {
       image = Icons.Hash;
       bodyJSX = t('Organisms.RoomCommon.changed_room_name');

--- a/src/app/hooks/timeline/TimelineEventRenderer.css.ts
+++ b/src/app/hooks/timeline/TimelineEventRenderer.css.ts
@@ -1,7 +1,0 @@
-import { style } from '@vanilla-extract/css';
-import { toRem } from 'folds';
-
-export const StateEvent = style({
-  overflowY: 'scroll',
-  maxHeight: toRem(96),
-});

--- a/src/app/hooks/timeline/TimelineEventRenderer.css.ts
+++ b/src/app/hooks/timeline/TimelineEventRenderer.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+import { toRem } from 'folds';
+
+export const StateEvent = style({
+  overflowY: 'scroll',
+  maxHeight: toRem(96),
+});

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -55,7 +55,6 @@ import {
 } from '$features/room/message';
 
 import { useSableCosmetics } from '$hooks/useSableCosmetics';
-import * as css from './TimelineEventRenderer.css';
 
 function DecoratedUser({ room, userId, userName }: DecoratedUserProps) {
   const { color, font } = useSableCosmetics(userId, room ?? ({} as Room));

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -52,6 +52,7 @@ import {
   Message,
   Reactions,
 } from '$features/room/message';
+import * as css from './TimelineEventRenderer.css';
 
 type ThreadReplyChipProps = {
   room: Room;
@@ -748,7 +749,7 @@ export function useTimelineEventRenderer({
               iconSrc={parsed.icon}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
+                  <Text size="T300" priority="300" className={css.StateEvent}>
                     {parsed.body}
                   </Text>
                 </Box>
@@ -794,7 +795,7 @@ export function useTimelineEventRenderer({
               iconSrc={Icons.Hash}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
+                  <Text size="T300" priority="300" className={css.StateEvent}>
                     <b>{senderName}</b>
                     {t('Organisms.RoomCommon.changed_room_name')}
                   </Text>
@@ -841,7 +842,7 @@ export function useTimelineEventRenderer({
               iconSrc={Icons.Hash}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
+                  <Text size="T300" priority="300" className={css.StateEvent}>
                     <b>{senderName}</b>
                     {' changed room topic'}
                   </Text>
@@ -888,7 +889,7 @@ export function useTimelineEventRenderer({
               iconSrc={Icons.Hash}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
+                  <Text size="T300" priority="300" className={css.StateEvent}>
                     <b>{senderName}</b>
                     {' changed room avatar'}
                   </Text>
@@ -942,7 +943,7 @@ export function useTimelineEventRenderer({
               iconSrc={callJoined ? Icons.Phone : Icons.PhoneDown}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
+                  <Text size="T300" priority="300" className={css.StateEvent}>
                     <b>{senderName}</b>
                     {callJoined ? ' joined the call' : ' ended the call'}
                   </Text>

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -59,7 +59,11 @@ import * as css from './TimelineEventRenderer.css';
 
 function DecoratedUser({ room, userId, userName }: DecoratedUserProps) {
   const { color, font } = useSableCosmetics(userId, room ?? ({} as Room));
-  return <b style={{ color, font }}> {userName ?? userId} </b>;
+  return (
+    <Text truncate>
+      <b style={{ color, font }}> {userName ?? userId} </b>
+    </Text>
+  );
 }
 
 type DecoratedUserProps = {
@@ -765,11 +769,11 @@ export function useTimelineEventRenderer({
               time={timeJSX}
               iconSrc={parsed.icon}
               content={
-                <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300" className={css.StateEvent}>
+                <Text size="T300" priority="300">
+                  <Box direction="Row" style={{ flexWrap: 'wrap', columnGap: toRem(6) }}>
                     {parsed.body}
-                  </Text>
-                </Box>
+                  </Box>
+                </Text>
               }
             />
           </Event>
@@ -811,7 +815,7 @@ export function useTimelineEventRenderer({
               iconSrc={Icons.Hash}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300" className={css.StateEvent}>
+                  <Text size="T300" priority="300">
                     <DecoratedUser userId={senderId} userName={senderName} room={room} />
                     {t('Organisms.RoomCommon.changed_room_name')}
                   </Text>
@@ -858,7 +862,7 @@ export function useTimelineEventRenderer({
               iconSrc={Icons.Hash}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300" className={css.StateEvent}>
+                  <Text size="T300" priority="300">
                     <DecoratedUser userId={senderId} userName={senderName} room={room} />
                     {' changed room topic'}
                   </Text>
@@ -905,7 +909,7 @@ export function useTimelineEventRenderer({
               iconSrc={Icons.Hash}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300" className={css.StateEvent}>
+                  <Text size="T300" priority="300">
                     <DecoratedUser userId={senderId} userName={senderName} room={room} />
                     {' changed room avatar'}
                   </Text>
@@ -959,7 +963,7 @@ export function useTimelineEventRenderer({
               iconSrc={callJoined ? Icons.Phone : Icons.PhoneDown}
               content={
                 <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300" className={css.StateEvent}>
+                  <Text size="T300" priority="300">
                     <DecoratedUser userId={senderId} userName={senderName} room={room} />
                     {callJoined ? ' joined the call' : ' ended the call'}
                   </Text>
@@ -1094,7 +1098,7 @@ export function useTimelineEventRenderer({
             iconSrc={Icons.Code}
             content={
               <Box grow="Yes" direction="Column">
-                <Text size="T300" priority="300" className={css.StateEvent}>
+                <Text size="T300" priority="300">
                   <DecoratedUser userId={senderId} userName={senderName} room={room} />
                   {' sent '}
                   <code className={customHtmlCss.Code}>{getType.call(mEvent)}</code>
@@ -1155,7 +1159,7 @@ export function useTimelineEventRenderer({
             iconSrc={Icons.Code}
             content={
               <Box grow="Yes" direction="Column">
-                <Text size="T300" priority="300" className={css.StateEvent}>
+                <Text size="T300" priority="300">
                   <b>{senderName}</b>
                   {' sent '}
                   <code className={customHtmlCss.Code}>{getType.call(mEvent)}</code>

--- a/src/app/hooks/useMemberEventParser.tsx
+++ b/src/app/hooks/useMemberEventParser.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { IconSrc, Icons } from 'folds';
+import { IconSrc, Icons, Text } from 'folds';
 import { MatrixEvent, Room } from '$types/matrix-sdk';
 import { IMemberContent, Membership } from '$types/matrix/room';
 import { getMxIdLocalPart } from '$utils/matrix';
@@ -17,7 +17,11 @@ function DecoratedUser({ roomId, userId, userName }: DecoratedUserProps) {
   const mx = useMatrixClient();
   const room = mx.getRoom(roomId);
   const { color, font } = useSableCosmetics(userId, room ?? ({} as Room));
-  return <b style={{ color, font }}> {userName ?? userId} </b>;
+  return (
+    <Text truncate>
+      <b style={{ color, font }}>{userName ?? userId} </b>
+    </Text>
+  );
 }
 
 export type ParsedResult = {
@@ -56,10 +60,12 @@ export const useMemberEventParser = (): MemberEventParser => {
             body: (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
-                {' accepted '}
+                <Text>{' accepted '}</Text>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                {`'s join request `}
-                {reason}
+                <Text>
+                  {`'s join request `}
+                  {reason}
+                </Text>
               </>
             ),
           };
@@ -70,9 +76,9 @@ export const useMemberEventParser = (): MemberEventParser => {
           body: (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
-              {' invited '}
+              <Text>{' invited '}</Text>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              {reason}
+              <Text>{reason}</Text>
             </>
           ),
         };
@@ -84,8 +90,10 @@ export const useMemberEventParser = (): MemberEventParser => {
           body: (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              {' requested to join room: '}
-              <i>{reason}</i>
+              <Text>
+                {' requested to join room: '}
+                <i>{reason}</i>
+              </Text>
             </>
           ),
         };
@@ -97,7 +105,7 @@ export const useMemberEventParser = (): MemberEventParser => {
           body: (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              {' joined the room'}
+              <Text>{' joined the room'}</Text>
             </>
           ),
         };
@@ -111,16 +119,20 @@ export const useMemberEventParser = (): MemberEventParser => {
               senderId === userId ? (
                 <>
                   <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                  {' rejected the invitation '}
-                  {reason}
+                  <Text>
+                    {' rejected the invitation '}
+                    {reason}
+                  </Text>
                 </>
               ) : (
                 <>
                   <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
-                  {' rejected '}
+                  <Text>{' rejected '}</Text>
                   <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                  {`'s join request `}
-                  {reason}
+                  <Text>
+                    {`'s join request `}
+                    {reason}
+                  </Text>
                 </>
               ),
           };
@@ -133,16 +145,20 @@ export const useMemberEventParser = (): MemberEventParser => {
               senderId === userId ? (
                 <>
                   <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                  {' revoked joined request '}
-                  {reason}
+                  <Text>
+                    {' revoked joined request '}
+                    {reason}
+                  </Text>
                 </>
               ) : (
                 <>
                   <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
                   {' revoked '}
                   <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                  {`'s invite `}
-                  {reason}
+                  <Text>
+                    {`'s invite `}
+                    {reason}
+                  </Text>
                 </>
               ),
           };
@@ -154,9 +170,9 @@ export const useMemberEventParser = (): MemberEventParser => {
             body: (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
-                {' unbanned '}
+                <Text>{' unbanned '}</Text>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                {reason}
+                <Text>{reason}</Text>
               </>
             ),
           };
@@ -168,15 +184,17 @@ export const useMemberEventParser = (): MemberEventParser => {
             senderId === userId ? (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                {' left the room '}
-                {reason}
+                <Text>
+                  {' left the room '}
+                  {reason}
+                </Text>
               </>
             ) : (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
-                {' kicked '}
+                <Text>{' kicked '}</Text>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                {reason}
+                <Text>{reason}</Text>
               </>
             ),
         };
@@ -188,9 +206,9 @@ export const useMemberEventParser = (): MemberEventParser => {
           body: (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
-              {' banned '}
+              <Text>{' banned '}</Text>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              {reason}
+              <Text>{reason}</Text>
             </>
           ),
         };
@@ -209,13 +227,13 @@ export const useMemberEventParser = (): MemberEventParser => {
           typeof content.displayname === 'string' ? (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={prevUserName} />
-              {' changed display name to '}
+              <Text>{' changed display name to '}</Text>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
             </>
           ) : (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={prevUserName} />
-              {' removed their display name '}
+              <Text>{' removed their display name '}</Text>
             </>
           ),
       };
@@ -227,12 +245,12 @@ export const useMemberEventParser = (): MemberEventParser => {
           content.avatar_url && typeof content.avatar_url === 'string' ? (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              {' changed their avatar'}
+              <Text>{' changed their avatar'}</Text>
             </>
           ) : (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              {' removed their avatar '}
+              <Text>{' removed their avatar '}</Text>
             </>
           ),
       };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This PR wants to cap the height of an event to prevent one single event taking the entire screensize.

(before the PR)
<img width="1331" height="867" alt="image" src="https://github.com/user-attachments/assets/b299cacd-85ff-4496-ac28-174c9f511faa" />

(after the PR)
<img width="1321" height="769" alt="image" src="https://github.com/user-attachments/assets/abbdcab2-b375-4572-909c-d59ff6e294b5" />


Fixes #

#### Type of change
prevents

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
