### PR TITLE
Fix (dev branch bug) description field having been broken by being undersized

### DIFF
--- a/src/app/components/editor/Editor.css.ts
+++ b/src/app/components/editor/Editor.css.ts
@@ -14,7 +14,6 @@ export const Editor = style([
 ]);
 
 export const EditorRow = style({
-  display: 'grid',
   gridTemplateColumns: 'auto 1fr auto',
   alignItems: 'center',
 });

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -420,6 +420,7 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
             ref={rowRef}
             className={`${css.EditorRow} ${layoutIsMultiline ? css.EditorRowMultiline : ''} ${showResponsiveAfterInFooter ? css.EditorRowMultilineWithResponsiveAfter : ''}`}
             alignItems="Start"
+            style={{ display: after ? 'grid' : 'flex' }}
           >
             {hasBefore && (
               <Box


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This PR fixes a bug in the dev branch where if you try to edit a file description the field becomes broken

(how it used to look while the issue was present)
<img width="638" height="549" alt="image" src="https://github.com/user-attachments/assets/f9af1901-032d-4ce2-b5f7-8ad0d6e22e13" />


also i didnt add a change md because its a bug in dev so it would be useless to show up on the changelog
Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
The fix was revealed to me in a dream