### PR TITLE
Add youtube link embeds

### DIFF
--- a/.changeset/add_support_for_youtube_embeds.md
+++ b/.changeset/add_support_for_youtube_embeds.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add support for youtube embeds.

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -114,16 +114,17 @@ function RenderMessageContentInternal({
 
       return (
         <UrlPreviewHolder>
-          {toRender.map(({ url, type }) => (!!type ? (
-            <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />
-		  ) : (clientUrlPreview ? (
-			<ClientPreview url={url} />
-		  ) : undefined)
-          ))}
+          {toRender.map(({ url, type }) =>
+            type ? (
+              <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />
+            ) : clientUrlPreview ? (
+              <ClientPreview url={url} />
+            ) : undefined
+          )}
         </UrlPreviewHolder>
       );
     },
-    [ts]
+    [ts, clientUrlPreview]
   );
 
   const renderCaption = () => {

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -114,13 +114,13 @@ function RenderMessageContentInternal({
 
       return (
         <UrlPreviewHolder>
-          {toRender.map(({ url, type }) =>
-            type ? (
-              <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />
-            ) : clientUrlPreview ? (
-              <ClientPreview url={url} />
-            ) : undefined
-          )}
+          {toRender.map(({ url, type }) => {
+            if (type) {
+              return <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />;
+            } else if (clientUrlPreview) {
+              return <ClientPreview url={url} />;
+            }
+          })}
         </UrlPreviewHolder>
       );
     },

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -28,6 +28,7 @@ import {
   VideoContent,
 } from './message';
 import { UrlPreviewCard, UrlPreviewHolder } from './url-preview';
+import { ClientPreview } from './url-preview/ClientPreview';
 import { Image, MediaControl, PersistedVolumeVideo } from './media';
 import { ImageViewer } from './image-viewer';
 import { PdfViewer } from './Pdf-viewer';
@@ -43,6 +44,7 @@ type RenderMessageContentProps = {
   getContent: <T>() => T;
   mediaAutoLoad?: boolean;
   urlPreview?: boolean;
+  clientUrlPreview?: boolean;
   highlightRegex?: RegExp;
   htmlReactParserOptions: HTMLReactParserOptions;
   linkifyOpts: Opts;
@@ -68,6 +70,7 @@ function RenderMessageContentInternal({
   getContent,
   mediaAutoLoad,
   urlPreview,
+  clientUrlPreview,
   highlightRegex,
   htmlReactParserOptions,
   linkifyOpts,
@@ -112,8 +115,12 @@ function RenderMessageContentInternal({
 
       return (
         <UrlPreviewHolder>
-          {toRender.map(({ url, type }) => (
+          {toRender.map(({ url, type }) => (!!type ? (
             <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />
+		  ) : (clientUrlPreview ? (
+			
+			<ClientPreview url={url} />
+		  ) : undefined)
           ))}
         </UrlPreviewHolder>
       );

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -117,11 +117,11 @@ function RenderMessageContentInternal({
           {toRender.map(({ url, type }) => {
             if (type) {
               return <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />;
-            } else if (clientUrlPreview) {
-              return <ClientPreview url={url} />;
-            } else {
-              return null;
             }
+            if (clientUrlPreview) {
+              return <ClientPreview url={url} />;
+            }
+            return null;
           })}
         </UrlPreviewHolder>
       );

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -27,8 +27,7 @@ import {
   UnsupportedContent,
   VideoContent,
 } from './message';
-import { UrlPreviewCard, UrlPreviewHolder } from './url-preview';
-import { ClientPreview } from './url-preview/ClientPreview';
+import { UrlPreviewCard, UrlPreviewHolder, ClientPreview } from './url-preview';
 import { Image, MediaControl, PersistedVolumeVideo } from './media';
 import { ImageViewer } from './image-viewer';
 import { PdfViewer } from './Pdf-viewer';
@@ -118,7 +117,6 @@ function RenderMessageContentInternal({
           {toRender.map(({ url, type }) => (!!type ? (
             <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />
 		  ) : (clientUrlPreview ? (
-			
 			<ClientPreview url={url} />
 		  ) : undefined)
           ))}

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -119,6 +119,8 @@ function RenderMessageContentInternal({
               return <UrlPreviewCard key={url} url={url} ts={ts} mediaType={type} />;
             } else if (clientUrlPreview) {
               return <ClientPreview url={url} />;
+            } else {
+              return null;
             }
           })}
         </UrlPreviewHolder>

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, ReactNode } from 'react';
 import { Box, Badge, Icon, IconButton, Icons, Spinner, Text, as, toRem } from 'folds';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { useSetting } from '$state/hooks/settings';
@@ -82,6 +82,8 @@ export const YoutubeElement = as<'div', YoutubeElementProps>(({ videoId, embedDa
 
   const [blurHash, setBlurHash] = useState<string | undefined>();
 
+  const title = embedData.title ? embedData.title : '';
+
   return (
     <Attachment
       style={{
@@ -92,11 +94,7 @@ export const YoutubeElement = as<'div', YoutubeElementProps>(({ videoId, embedDa
       }}
     >
       <AttachmentHeader>
-        <EmbedHeader
-          title={embedData.title}
-          source="YOUTUBE"
-          after={EmbedOpenButton({ url: videoUrl })}
-        />
+        <EmbedHeader title={title} source="YOUTUBE" after={EmbedOpenButton({ url: videoUrl })} />
       </AttachmentHeader>
       <AttachmentBox
         style={{
@@ -105,7 +103,8 @@ export const YoutubeElement = as<'div', YoutubeElementProps>(({ videoId, embedDa
         }}
       >
         <VideoContent
-          body={embedData.title}
+          body={title}
+          mimeType="fake"
           url={videoUrl}
           info={{
             thumbnail_info: { [MATRIX_BLUR_HASH_PROPERTY_NAME]: blurHash },

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -148,7 +148,7 @@ export const ClientPreview = as<'div', { url: string }>(({ url, ...props }, ref)
 
   // this component is overly complicated, because it was designed to support more embed types than just youtube
   // i'm leaving this mess here to support later expansion
-  const isYoutube = youtubeUrl(url);
+  const isYoutube = !!youtubeUrl(url);
   const videoId = isYoutube ? url.match(/(?:shorts\/|watch\?v=|youtu\.be\/)(.{11})/)?.[1] : null;
 
   const fetchUrl =
@@ -164,7 +164,7 @@ export const ClientPreview = as<'div', { url: string }>(({ url, ...props }, ref)
     const fetchYoutube = isYoutube && showYoutube;
 
     if (fetchYoutube) loadEmbed();
-  }, [loadEmbed]);
+  }, [isYoutube, showYoutube, loadEmbed]);
 
   let previewContent;
 

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -1,479 +1,207 @@
-import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
-import { IPreviewUrlResponse } from '$types/matrix-sdk';
-import {
-	Box,
-	Badge,
-	Button,
-	Icon,
-	IconButton,
-	Icons,
-	Scroll,
-	Spinner,
-	Text,
-	as,
-	color,
-	config,
-	toRem,
-} from 'folds';
+import { useCallback, useEffect, useState } from 'react';
+import { Box, Badge, Icon, IconButton, Icons, Spinner, Text, as, toRem } from 'folds';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
-import { useMatrixClient } from '$hooks/useMatrixClient';
-import { mxcUrlToHttp, downloadMedia } from '$utils/matrix';
-import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
-import * as css from './UrlPreviewCard.css';
-import { UrlPreview, UrlPreviewContent, UrlPreviewDescription } from './UrlPreview';
-import { AudioContent, ImageContent, VideoContent } from '../message';
-import { Image, MediaControl, Video } from '../media';
-import { ImageViewer } from '../image-viewer';
-import classNames from 'classnames';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
-import {
-	Attachment,
-	AttachmentBox,
-	AttachmentContent,
-	AttachmentHeader,
-} from '../message/attachment';
 import { encodeBlurHash } from '$utils/blurHash';
 import { MATRIX_BLUR_HASH_PROPERTY_NAME } from '$types/matrix/common';
-
-const linkStyles = { color: color.Success.Main };
+import { Attachment, AttachmentBox, AttachmentHeader } from '../message/attachment';
+import { Image } from '../media';
+import { UrlPreview } from './UrlPreview';
+import { VideoContent } from '../message';
 
 interface OEmbed {
-	type: 'photo' | 'video' | 'link' | 'rich';
-	version: '1.0';
-	title?: string;
-	author_name?: string;
-	author_url?: string;
-	provider_name?: string;
-	provider_url?: string;
-	cache_age?: string;
-	thumbnail_url?: string;
-	thumbnail_width?: number;
-	thumbnail_height?: number;
-	url?: string;
-	html?: string;
-	width?: number;
-	height?: number;
+  type: 'photo' | 'video' | 'link' | 'rich';
+  version: '1.0';
+  title?: string;
+  author_name?: string;
+  author_url?: string;
+  provider_name?: string;
+  provider_url?: string;
+  cache_age?: string;
+  thumbnail_url?: string;
+  thumbnail_width?: number;
+  thumbnail_height?: number;
+  url?: string;
+  html?: string;
+  width?: number;
+  height?: number;
 }
 
-// const oEmbedProxy = 'http://localhost:3000/oembed';
 async function oEmbedData(url: string): Promise<OEmbed> {
-	const data = await fetch(false ? `${oEmbedProxy}/${encodeURIComponent(url)}` : url)
-		.then((resp) => resp.json())
-		.catch(() => console.error(`Unable to fetch oembed data for ${url}`));
+  const data = await fetch(url).then((resp) => resp.json());
 
-	if (data?.html) data.html = preProcessHtml(data.html);
-
-	return data;
-}
-
-const preProcessHtml = (html: string) => {
-	const cssInjection = `
-  <style>
-  body { margin: 0; overflow: hidden; }
-  iframe { width: 100% !important; height: 100% !important; border: none; }
-  </style>
-`;
-
-	return cssInjection + html;
-};
-
-function oEmbedElement(
-	data: OEmbed,
-	loadFullPreview: boolean,
-	setLoadFullPreview: any
-): ReactElement {
-	let innerContent;
-	if (data.url) {
-		innerContent = <img src={data.url} width={data.width ? data.width : 390} />;
-	} else if (data.html) {
-		const width: number = data.width
-			? data.width
-			: data.thumbnail_width
-				? data.thumbnail_width
-				: 640;
-		const height: number = data.height
-			? data.height
-			: data.thumbnail_height
-				? data.thumbnail_height
-				: 390;
-
-		innerContent = (
-			<div
-				style={{
-					width: '100%',
-					maxWidth: `${width}px`,
-				}}
-				onClick={() => setLoadFullPreview(true)}
-			>
-				{!loadFullPreview ? (
-					<div
-						style={{
-							position: 'relative',
-							width: 'fit-content',
-							cursor: 'pointer',
-						}}
-					>
-						{data.thumbnail_url ? (
-							<img
-								src={data.thumbnail_url}
-								width={data.thumbnail_width}
-								height={data.thumbnail_height}
-							/>
-						) : (
-							<></>
-						)}
-					</div>
-				) : (
-					<iframe
-						// sandbox="allow-scripts allow-popups allow-forms"
-						security="restricted"
-						srcDoc={preProcessHtml(data.html)}
-						style={{ border: 'none', width: '100%', height: '100%' }}
-					/>
-				)}
-			</div>
-		);
-	}
-
-	return (
-		<Box
-			grow="Yes"
-			direction="Column"
-			style={{
-				overflow: 'hidden',
-				width: '100%',
-			}}
-		>
-			{data.provider_name && data.provider_url ? (
-				<Text
-					style={linkStyles}
-					truncate
-					as="a"
-					href={data.provider_url}
-					target="_blank"
-					rel="noreferrer"
-					size="T200"
-					priority="300"
-				>
-					{data.provider_name}
-				</Text>
-			) : (
-				<></>
-			)}
-			{data.author_name && data.author_url ? (
-				<Text
-					style={linkStyles}
-					truncate
-					as="a"
-					href={data.author_url}
-					target="_blank"
-					rel="noreferrer"
-					size="T300"
-					priority="300"
-				>
-					{data.author_name}
-				</Text>
-			) : (
-				<></>
-			)}
-			{data.title ? (
-				<Text size="T400" priority="300">
-					{data.title}
-				</Text>
-			) : (
-				<></>
-			)}
-			{innerContent}
-		</Box>
-	);
+  return data;
 }
 
 export type EmbedHeaderProps = {
-	title: string;
-	source: string;
-	after?: ReactNode;
+  title: string;
+  source: string;
+  after?: ReactNode;
 };
-export const EmbedHeader = as<'div', EmbedHeaderProps>(({ title, source, after }, ref) => (
-	<AttachmentHeader>
-		<Box alignItems="Center" gap="200" grow="Yes">
-			<Box shrink="No">
-				<Badge style={{ maxWidth: toRem(100) }} variant="Secondary" radii="Pill">
-					<Text size="O400" truncate>
-						{source}
-					</Text>
-				</Badge>
-			</Box>
-			<Box grow="Yes">
-				<Text size="T300" truncate>
-					{title}
-				</Text>
-			</Box>
-			{after}
-		</Box>
-	</AttachmentHeader>
+export const EmbedHeader = as<'div', EmbedHeaderProps>(({ title, source, after }) => (
+  <AttachmentHeader>
+    <Box alignItems="Center" gap="200" grow="Yes">
+      <Box shrink="No">
+        <Badge style={{ maxWidth: toRem(100) }} variant="Secondary" radii="Pill">
+          <Text size="O400" truncate>
+            {source}
+          </Text>
+        </Badge>
+      </Box>
+      <Box grow="Yes">
+        <Text size="T300" truncate>
+          {title}
+        </Text>
+      </Box>
+      {after}
+    </Box>
+  </AttachmentHeader>
 ));
 
 type EmbedOpenButtonProps = {
-	url: string;
+  url: string;
 };
 export function EmbedOpenButton({ url }: EmbedOpenButtonProps) {
-	return (
-		<IconButton size="300" radii="300" onClick={() => window.open(url, '_blank')}>
-			<Icon size="100" src={Icons.Link} />
-		</IconButton>
-	);
+  return (
+    <IconButton size="300" radii="300" onClick={() => window.open(url, '_blank')}>
+      <Icon size="100" src={Icons.Link} />
+    </IconButton>
+  );
 }
 
 type YoutubeElementProps = {
-	videoId: string;
-	embedData: OEmbed;
-	loadFullPreview: boolean;
-	setLoadFullPreview: any;
+  videoId: string;
+  embedData: OEmbed;
 };
 
-export const YoutubeElement = as<'div', YoutubeElementProps>(
-	({ videoId, embedData, loadFullPreview, setLoadFullPreview }, ref) => {
-		const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
-		const iframeSrc = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?autoplay=1`;
+export const YoutubeElement = as<'div', YoutubeElementProps>(({ videoId, embedData }) => {
+  const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  const iframeSrc = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?autoplay=1`;
+  const videoUrl = `https://youtube.com/watch?v=${videoId}`;
 
-		const [blurHash, setBlurHash] = useState<string | undefined>();
+  const [blurHash, setBlurHash] = useState<string | undefined>();
 
-		useEffect(() => {
-			let img = document.createElement('img');
-			img.crossOrigin = 'Anonymous';
-			img.src = thumbnailUrl;
-			img.onload = () => {
-				const hash = encodeBlurHash(img, 32, 32);
-				setBlurHash(hash);
-			};
-		}, []);
-
-		return (
-			<Attachment
-				style={{
-					flexGrow: 1,
-					flexShrink: 0,
-					width: '640px',
-					height: '400px',
-				}}
-			>
-				<AttachmentHeader>
-					<EmbedHeader
-						title={embedData.title}
-						source="YOUTUBE"
-						after={EmbedOpenButton({ url: `https://youtube.com/watch?v=${videoId}` })}
-					/>
-				</AttachmentHeader>
-				<AttachmentBox
-					style={{
-						height: '100%',
-						width: '100%',
-					}}
-				>
-					<VideoContent
-						body={embedData.title}
-						url={`https://youtube.com/watch?v=${videoId}`}
-						info={{
-							thumbnail_info: { [MATRIX_BLUR_HASH_PROPERTY_NAME]: blurHash },
-						}}
-						renderThumbnail={() => <Image src={thumbnailUrl} />}
-						renderVideo={({ onLoadedMetadata }) => {
-							return (
-								<iframe
-									src={iframeSrc}
-									title="YouTube embed"
-									onLoad={onLoadedMetadata}
-									allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-									referrerPolicy="strict-origin-when-cross-origin"
-									width="640"
-									height="360"
-									allowFullScreen
-								/>
-							);
-						}}
-					/>
-					{/*
-				<div
-					style={{
-						width: '100%',
-						aspectRatio: '16 / 9',
-					}}
-					onClick={() => setLoadFullPreview(true)}
-				>
-					{!loadFullPreview ? (
-						<div style={{ position: 'relative', width: 'fit-content', cursor: 'pointer' }}>
-							<Box
-								className={classNames(css.AbsoluteContainer)}
-								alignItems="Center"
-								justifyContent="Center"
-							>
-								<Image
-									src={thumbnail ?? undefined}
-									alt="YouTube Thumbnail"
-									style={{
-										align: 'center',
-										width: '100%',
-										height: '100%',
-										objectFit: 'contain',
-									}}
-								/>
-							</Box>
-							<Box className={css.AbsoluteContainer} alignItems="Center" justifyContent="Center">
-								<Button
-									variant="Secondary"
-									fill="Solid"
-									radii="300"
-									size="300"
-									onClick={() => setLoadFullPreview(true)}
-									before={<Icon size="Inherit" src={Icons.Play} filled />}
-								>
-									<Text size="B300">Watch</Text>
-								</Button>
-							</Box>
-						</div>
-					) : (
-						<iframe
-							src={iframeSrc}
-							title="YouTube embed"
-							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-							referrerPolicy="strict-origin-when-cross-origin"
-							width="640"
-							height="360"
-							allowFullScreen
-						/>
-					)}
-				</div>
-   */}
-				</AttachmentBox>
-			</Attachment>
-		);
-	}
-);
+  return (
+    <Attachment
+      style={{
+        flexGrow: 1,
+        flexShrink: 0,
+        width: '640px',
+        height: '400px',
+      }}
+    >
+      <AttachmentHeader>
+        <EmbedHeader
+          title={embedData.title}
+          source="YOUTUBE"
+          after={EmbedOpenButton({ url: videoUrl })}
+        />
+      </AttachmentHeader>
+      <AttachmentBox
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
+        <VideoContent
+          body={embedData.title}
+          url={videoUrl}
+          info={{
+            thumbnail_info: { [MATRIX_BLUR_HASH_PROPERTY_NAME]: blurHash },
+          }}
+          renderThumbnail={() => (
+            <Image
+              src={thumbnailUrl}
+              /*
+								this allows the blurhash to be computed, otherwise it throws an "insecure operation" error
+								maybe that happens for a good reason, in which case this should probably be removed
+								*/
+              crossOrigin="anonymous"
+              onLoad={(e) => {
+                setBlurHash(encodeBlurHash(e.currentTarget, 32, 32));
+              }}
+            />
+          )}
+          renderVideo={({ onLoadedMetadata }) => (
+            <iframe
+              src={iframeSrc}
+              title="YouTube embed"
+              onLoad={onLoadedMetadata}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              width="640"
+              height="360"
+              allowFullScreen
+            />
+          )}
+        />
+      </AttachmentBox>
+    </Attachment>
+  );
+});
 
 const youtubeUrl = (url: string) => url.match(/(https:\/\/)(www\.|m\.|)(youtube\.com|youtu\.be)\//);
 
 export const ClientPreview = as<'div', { url: string }>(({ url, ...props }, ref) => {
-	const [loadFullPreview, setLoadFullPreview] = useState(false);
-	const [showYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
-	const [showOEmbed] = useSetting(settingsAtom, 'clientPreviewOEmbed');
+  const [showYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
 
-	const isYoutube = youtubeUrl(url);
-	// const urlMatch = ;
-	const videoId = isYoutube ? url.match(/(?:shorts\/|watch\?v=|youtu\.be\/)(.{11})/)?.[1] : null;
+  // this component is overly complicated, because it was designed to support more embed types than just youtube
+  // i'm leaving this mess here to support later expansion
+  const isYoutube = youtubeUrl(url);
+  const videoId = isYoutube ? url.match(/(?:shorts\/|watch\?v=|youtu\.be\/)(.{11})/)?.[1] : null;
 
-	const fetchUrl =
-		isYoutube && videoId
-			? `https://www.youtube.com/oembed?url=${encodeURIComponent(`https://youtube.com/watch?v=${videoId}`)}`
-			: url;
+  const fetchUrl =
+    isYoutube && videoId
+      ? `https://www.youtube.com/oembed?url=${encodeURIComponent(`https://youtube.com/watch?v=${videoId}`)}`
+      : url;
 
-	const [embedStatus, loadEmbed] = useAsyncCallback(
-		useCallback(() => {
-			return oEmbedData(fetchUrl);
-		}, [fetchUrl])
-	);
+  const [embedStatus, loadEmbed] = useAsyncCallback(
+    useCallback(() => oEmbedData(fetchUrl), [fetchUrl])
+  );
 
-	useEffect(() => {
-		const fetchYoutube = isYoutube && showYoutube;
-		const fetchOEmbed = showOEmbed;
+  useEffect(() => {
+    const fetchYoutube = isYoutube && showYoutube;
 
-		if (fetchYoutube || fetchOEmbed) loadEmbed();
-	}, [fetchUrl, loadEmbed]);
+    if (fetchYoutube) loadEmbed();
+  }, [loadEmbed]);
 
-	let previewContent;
+  let previewContent;
 
-	if (isYoutube && videoId) {
-		if (showYoutube) {
-			if (embedStatus.status === AsyncStatus.Error) return null;
+  if (isYoutube && videoId) {
+    if (showYoutube) {
+      if (embedStatus.status === AsyncStatus.Error) return null;
 
-			if (embedStatus.status === AsyncStatus.Success) {
-				previewContent = embedStatus.data ? (
-					<YoutubeElement
-						videoId={videoId}
-						embedData={embedStatus.data}
-						loadFullPreview={loadFullPreview}
-						setLoadFullPreview={setLoadFullPreview}
-					/>
-				) : (
-					<UrlPreviewContent>
-						<Text
-							style={linkStyles}
-							truncate
-							as="a"
-							href={url}
-							target="_blank"
-							rel="noreferrer"
-							size="T200"
-							priority="300"
-						>
-							{decodeURIComponent(url)}
-						</Text>
-					</UrlPreviewContent>
-				);
-			} else {
-				previewContent = (
-					<Box grow="Yes" alignItems="Center" justifyContent="Center">
-						<Spinner variant="Secondary" size="400" />
-					</Box>
-				);
-			}
-		} else {
-			previewContent = <Text size="L400">YouTube previews disabled</Text>;
-		}
-	} else {
-		if (showOEmbed) {
-			// generic oembed
-			if (embedStatus.status === AsyncStatus.Error) return null;
+      if (embedStatus.status === AsyncStatus.Success && embedStatus.data) {
+        previewContent = <YoutubeElement videoId={videoId} embedData={embedStatus.data} />;
+      } else {
+        previewContent = (
+          <Box grow="Yes" alignItems="Center" justifyContent="Center">
+            <Spinner variant="Secondary" size="400" />
+          </Box>
+        );
+      }
+    }
+  }
 
-			if (embedStatus.status === AsyncStatus.Success) {
-				previewContent = embedStatus.data ? (
-					oEmbedElement(embedStatus.data, loadFullPreview, setLoadFullPreview)
-				) : (
-					<UrlPreviewContent>
-						<Text
-							style={linkStyles}
-							truncate
-							as="a"
-							href={url}
-							target="_blank"
-							rel="noreferrer"
-							size="T200"
-							priority="300"
-						>
-							{decodeURIComponent(url)}
-						</Text>
-					</UrlPreviewContent>
-				);
-			} else {
-				previewContent = (
-					<Box grow="Yes" alignItems="Center" justifyContent="Center">
-						<Spinner variant="Secondary" size="400" />
-					</Box>
-				);
-			}
-		} else {
-			previewContent = <Text size="L400">Generic previews disabled</Text>;
-		}
-	}
-
-	return (
-		<UrlPreview
-			{...props}
-			ref={ref}
-			style={{
-				background: 'transparent',
-				border: 'none',
-				padding: 0,
-				boxShadow: 'none',
-				display: 'inline-block',
-				verticalAlign: 'middle',
-				width: 'max-content',
-				minWidth: 0,
-				maxWidth: '100%',
-				margin: 0,
-			}}
-		>
-			{previewContent}
-		</UrlPreview>
-	);
+  return (
+    <UrlPreview
+      {...props}
+      ref={ref}
+      style={{
+        background: 'transparent',
+        border: 'none',
+        padding: 0,
+        boxShadow: 'none',
+        display: 'inline-block',
+        verticalAlign: 'middle',
+        width: 'max-content',
+        minWidth: 0,
+        maxWidth: '100%',
+        margin: 0,
+      }}
+    >
+      {previewContent}
+    </UrlPreview>
+  );
 });

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -1,0 +1,479 @@
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { IPreviewUrlResponse } from '$types/matrix-sdk';
+import {
+	Box,
+	Badge,
+	Button,
+	Icon,
+	IconButton,
+	Icons,
+	Scroll,
+	Spinner,
+	Text,
+	as,
+	color,
+	config,
+	toRem,
+} from 'folds';
+import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { mxcUrlToHttp, downloadMedia } from '$utils/matrix';
+import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import * as css from './UrlPreviewCard.css';
+import { UrlPreview, UrlPreviewContent, UrlPreviewDescription } from './UrlPreview';
+import { AudioContent, ImageContent, VideoContent } from '../message';
+import { Image, MediaControl, Video } from '../media';
+import { ImageViewer } from '../image-viewer';
+import classNames from 'classnames';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
+import {
+	Attachment,
+	AttachmentBox,
+	AttachmentContent,
+	AttachmentHeader,
+} from '../message/attachment';
+import { encodeBlurHash } from '$utils/blurHash';
+import { MATRIX_BLUR_HASH_PROPERTY_NAME } from '$types/matrix/common';
+
+const linkStyles = { color: color.Success.Main };
+
+interface OEmbed {
+	type: 'photo' | 'video' | 'link' | 'rich';
+	version: '1.0';
+	title?: string;
+	author_name?: string;
+	author_url?: string;
+	provider_name?: string;
+	provider_url?: string;
+	cache_age?: string;
+	thumbnail_url?: string;
+	thumbnail_width?: number;
+	thumbnail_height?: number;
+	url?: string;
+	html?: string;
+	width?: number;
+	height?: number;
+}
+
+// const oEmbedProxy = 'http://localhost:3000/oembed';
+async function oEmbedData(url: string): Promise<OEmbed> {
+	const data = await fetch(false ? `${oEmbedProxy}/${encodeURIComponent(url)}` : url)
+		.then((resp) => resp.json())
+		.catch(() => console.error(`Unable to fetch oembed data for ${url}`));
+
+	if (data?.html) data.html = preProcessHtml(data.html);
+
+	return data;
+}
+
+const preProcessHtml = (html: string) => {
+	const cssInjection = `
+  <style>
+  body { margin: 0; overflow: hidden; }
+  iframe { width: 100% !important; height: 100% !important; border: none; }
+  </style>
+`;
+
+	return cssInjection + html;
+};
+
+function oEmbedElement(
+	data: OEmbed,
+	loadFullPreview: boolean,
+	setLoadFullPreview: any
+): ReactElement {
+	let innerContent;
+	if (data.url) {
+		innerContent = <img src={data.url} width={data.width ? data.width : 390} />;
+	} else if (data.html) {
+		const width: number = data.width
+			? data.width
+			: data.thumbnail_width
+				? data.thumbnail_width
+				: 640;
+		const height: number = data.height
+			? data.height
+			: data.thumbnail_height
+				? data.thumbnail_height
+				: 390;
+
+		innerContent = (
+			<div
+				style={{
+					width: '100%',
+					maxWidth: `${width}px`,
+				}}
+				onClick={() => setLoadFullPreview(true)}
+			>
+				{!loadFullPreview ? (
+					<div
+						style={{
+							position: 'relative',
+							width: 'fit-content',
+							cursor: 'pointer',
+						}}
+					>
+						{data.thumbnail_url ? (
+							<img
+								src={data.thumbnail_url}
+								width={data.thumbnail_width}
+								height={data.thumbnail_height}
+							/>
+						) : (
+							<></>
+						)}
+					</div>
+				) : (
+					<iframe
+						// sandbox="allow-scripts allow-popups allow-forms"
+						security="restricted"
+						srcDoc={preProcessHtml(data.html)}
+						style={{ border: 'none', width: '100%', height: '100%' }}
+					/>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<Box
+			grow="Yes"
+			direction="Column"
+			style={{
+				overflow: 'hidden',
+				width: '100%',
+			}}
+		>
+			{data.provider_name && data.provider_url ? (
+				<Text
+					style={linkStyles}
+					truncate
+					as="a"
+					href={data.provider_url}
+					target="_blank"
+					rel="noreferrer"
+					size="T200"
+					priority="300"
+				>
+					{data.provider_name}
+				</Text>
+			) : (
+				<></>
+			)}
+			{data.author_name && data.author_url ? (
+				<Text
+					style={linkStyles}
+					truncate
+					as="a"
+					href={data.author_url}
+					target="_blank"
+					rel="noreferrer"
+					size="T300"
+					priority="300"
+				>
+					{data.author_name}
+				</Text>
+			) : (
+				<></>
+			)}
+			{data.title ? (
+				<Text size="T400" priority="300">
+					{data.title}
+				</Text>
+			) : (
+				<></>
+			)}
+			{innerContent}
+		</Box>
+	);
+}
+
+export type EmbedHeaderProps = {
+	title: string;
+	source: string;
+	after?: ReactNode;
+};
+export const EmbedHeader = as<'div', EmbedHeaderProps>(({ title, source, after }, ref) => (
+	<AttachmentHeader>
+		<Box alignItems="Center" gap="200" grow="Yes">
+			<Box shrink="No">
+				<Badge style={{ maxWidth: toRem(100) }} variant="Secondary" radii="Pill">
+					<Text size="O400" truncate>
+						{source}
+					</Text>
+				</Badge>
+			</Box>
+			<Box grow="Yes">
+				<Text size="T300" truncate>
+					{title}
+				</Text>
+			</Box>
+			{after}
+		</Box>
+	</AttachmentHeader>
+));
+
+type EmbedOpenButtonProps = {
+	url: string;
+};
+export function EmbedOpenButton({ url }: EmbedOpenButtonProps) {
+	return (
+		<IconButton size="300" radii="300" onClick={() => window.open(url, '_blank')}>
+			<Icon size="100" src={Icons.Link} />
+		</IconButton>
+	);
+}
+
+type YoutubeElementProps = {
+	videoId: string;
+	embedData: OEmbed;
+	loadFullPreview: boolean;
+	setLoadFullPreview: any;
+};
+
+export const YoutubeElement = as<'div', YoutubeElementProps>(
+	({ videoId, embedData, loadFullPreview, setLoadFullPreview }, ref) => {
+		const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+		const iframeSrc = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?autoplay=1`;
+
+		const [blurHash, setBlurHash] = useState<string | undefined>();
+
+		useEffect(() => {
+			let img = document.createElement('img');
+			img.crossOrigin = 'Anonymous';
+			img.src = thumbnailUrl;
+			img.onload = () => {
+				const hash = encodeBlurHash(img, 32, 32);
+				setBlurHash(hash);
+			};
+		}, []);
+
+		return (
+			<Attachment
+				style={{
+					flexGrow: 1,
+					flexShrink: 0,
+					width: '640px',
+					height: '400px',
+				}}
+			>
+				<AttachmentHeader>
+					<EmbedHeader
+						title={embedData.title}
+						source="YOUTUBE"
+						after={EmbedOpenButton({ url: `https://youtube.com/watch?v=${videoId}` })}
+					/>
+				</AttachmentHeader>
+				<AttachmentBox
+					style={{
+						height: '100%',
+						width: '100%',
+					}}
+				>
+					<VideoContent
+						body={embedData.title}
+						url={`https://youtube.com/watch?v=${videoId}`}
+						info={{
+							thumbnail_info: { [MATRIX_BLUR_HASH_PROPERTY_NAME]: blurHash },
+						}}
+						renderThumbnail={() => <Image src={thumbnailUrl} />}
+						renderVideo={({ onLoadedMetadata }) => {
+							return (
+								<iframe
+									src={iframeSrc}
+									title="YouTube embed"
+									onLoad={onLoadedMetadata}
+									allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+									referrerPolicy="strict-origin-when-cross-origin"
+									width="640"
+									height="360"
+									allowFullScreen
+								/>
+							);
+						}}
+					/>
+					{/*
+				<div
+					style={{
+						width: '100%',
+						aspectRatio: '16 / 9',
+					}}
+					onClick={() => setLoadFullPreview(true)}
+				>
+					{!loadFullPreview ? (
+						<div style={{ position: 'relative', width: 'fit-content', cursor: 'pointer' }}>
+							<Box
+								className={classNames(css.AbsoluteContainer)}
+								alignItems="Center"
+								justifyContent="Center"
+							>
+								<Image
+									src={thumbnail ?? undefined}
+									alt="YouTube Thumbnail"
+									style={{
+										align: 'center',
+										width: '100%',
+										height: '100%',
+										objectFit: 'contain',
+									}}
+								/>
+							</Box>
+							<Box className={css.AbsoluteContainer} alignItems="Center" justifyContent="Center">
+								<Button
+									variant="Secondary"
+									fill="Solid"
+									radii="300"
+									size="300"
+									onClick={() => setLoadFullPreview(true)}
+									before={<Icon size="Inherit" src={Icons.Play} filled />}
+								>
+									<Text size="B300">Watch</Text>
+								</Button>
+							</Box>
+						</div>
+					) : (
+						<iframe
+							src={iframeSrc}
+							title="YouTube embed"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerPolicy="strict-origin-when-cross-origin"
+							width="640"
+							height="360"
+							allowFullScreen
+						/>
+					)}
+				</div>
+   */}
+				</AttachmentBox>
+			</Attachment>
+		);
+	}
+);
+
+const youtubeUrl = (url: string) => url.match(/(https:\/\/)(www\.|m\.|)(youtube\.com|youtu\.be)\//);
+
+export const ClientPreview = as<'div', { url: string }>(({ url, ...props }, ref) => {
+	const [loadFullPreview, setLoadFullPreview] = useState(false);
+	const [showYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
+	const [showOEmbed] = useSetting(settingsAtom, 'clientPreviewOEmbed');
+
+	const isYoutube = youtubeUrl(url);
+	// const urlMatch = ;
+	const videoId = isYoutube ? url.match(/(?:shorts\/|watch\?v=|youtu\.be\/)(.{11})/)?.[1] : null;
+
+	const fetchUrl =
+		isYoutube && videoId
+			? `https://www.youtube.com/oembed?url=${encodeURIComponent(`https://youtube.com/watch?v=${videoId}`)}`
+			: url;
+
+	const [embedStatus, loadEmbed] = useAsyncCallback(
+		useCallback(() => {
+			return oEmbedData(fetchUrl);
+		}, [fetchUrl])
+	);
+
+	useEffect(() => {
+		const fetchYoutube = isYoutube && showYoutube;
+		const fetchOEmbed = showOEmbed;
+
+		if (fetchYoutube || fetchOEmbed) loadEmbed();
+	}, [fetchUrl, loadEmbed]);
+
+	let previewContent;
+
+	if (isYoutube && videoId) {
+		if (showYoutube) {
+			if (embedStatus.status === AsyncStatus.Error) return null;
+
+			if (embedStatus.status === AsyncStatus.Success) {
+				previewContent = embedStatus.data ? (
+					<YoutubeElement
+						videoId={videoId}
+						embedData={embedStatus.data}
+						loadFullPreview={loadFullPreview}
+						setLoadFullPreview={setLoadFullPreview}
+					/>
+				) : (
+					<UrlPreviewContent>
+						<Text
+							style={linkStyles}
+							truncate
+							as="a"
+							href={url}
+							target="_blank"
+							rel="noreferrer"
+							size="T200"
+							priority="300"
+						>
+							{decodeURIComponent(url)}
+						</Text>
+					</UrlPreviewContent>
+				);
+			} else {
+				previewContent = (
+					<Box grow="Yes" alignItems="Center" justifyContent="Center">
+						<Spinner variant="Secondary" size="400" />
+					</Box>
+				);
+			}
+		} else {
+			previewContent = <Text size="L400">YouTube previews disabled</Text>;
+		}
+	} else {
+		if (showOEmbed) {
+			// generic oembed
+			if (embedStatus.status === AsyncStatus.Error) return null;
+
+			if (embedStatus.status === AsyncStatus.Success) {
+				previewContent = embedStatus.data ? (
+					oEmbedElement(embedStatus.data, loadFullPreview, setLoadFullPreview)
+				) : (
+					<UrlPreviewContent>
+						<Text
+							style={linkStyles}
+							truncate
+							as="a"
+							href={url}
+							target="_blank"
+							rel="noreferrer"
+							size="T200"
+							priority="300"
+						>
+							{decodeURIComponent(url)}
+						</Text>
+					</UrlPreviewContent>
+				);
+			} else {
+				previewContent = (
+					<Box grow="Yes" alignItems="Center" justifyContent="Center">
+						<Spinner variant="Secondary" size="400" />
+					</Box>
+				);
+			}
+		} else {
+			previewContent = <Text size="L400">Generic previews disabled</Text>;
+		}
+	}
+
+	return (
+		<UrlPreview
+			{...props}
+			ref={ref}
+			style={{
+				background: 'transparent',
+				border: 'none',
+				padding: 0,
+				boxShadow: 'none',
+				display: 'inline-block',
+				verticalAlign: 'middle',
+				width: 'max-content',
+				minWidth: 0,
+				maxWidth: '100%',
+				margin: 0,
+			}}
+		>
+			{previewContent}
+		</UrlPreview>
+	);
+});

--- a/src/app/components/url-preview/index.ts
+++ b/src/app/components/url-preview/index.ts
@@ -1,2 +1,3 @@
 export * from './UrlPreview';
 export * from './UrlPreviewCard';
+export * from './ClientPreview';

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -131,6 +131,8 @@ export function RoomTimeline({
   const [mediaAutoLoad] = useSetting(settingsAtom, 'mediaAutoLoad');
   const [urlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [encUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
+  const [clientUrlPreview] = useSetting(settingsAtom, 'clientUrlPreview');
+  const [encClientUrlPreview] = useSetting(settingsAtom, 'encClientUrlPreview');
   const [showHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
   const [showTombstoneEvents] = useSetting(settingsAtom, 'showTombstoneEvents');
   const [showDeveloperTools] = useSetting(settingsAtom, 'developerTools');
@@ -142,6 +144,7 @@ export function RoomTimeline({
   const [hideMemberInReadOnly] = useSetting(settingsAtom, 'hideMembershipInReadOnly');
 
   const showUrlPreview = room.hasEncryptionStateEvent() ? encUrlPreview : urlPreview;
+  const showClientUrlPreview = room.hasEncryptionStateEvent() ? encClientUrlPreview : clientUrlPreview;
 
   const nicknames = useAtomValue(nicknamesAtom);
   const globalProfiles = useAtomValue(profilesCacheAtom);
@@ -483,6 +486,7 @@ export function RoomTimeline({
       dateFormatString,
       mediaAutoLoad,
       showUrlPreview,
+	  showClientUrlPreview,
       autoplayStickers,
       hideMemberInReadOnly,
       isReadOnly,

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -144,7 +144,9 @@ export function RoomTimeline({
   const [hideMemberInReadOnly] = useSetting(settingsAtom, 'hideMembershipInReadOnly');
 
   const showUrlPreview = room.hasEncryptionStateEvent() ? encUrlPreview : urlPreview;
-  const showClientUrlPreview = room.hasEncryptionStateEvent() ? encClientUrlPreview : clientUrlPreview;
+  const showClientUrlPreview = room.hasEncryptionStateEvent()
+    ? encClientUrlPreview
+    : clientUrlPreview;
 
   const nicknames = useAtomValue(nicknamesAtom);
   const globalProfiles = useAtomValue(profilesCacheAtom);
@@ -486,7 +488,7 @@ export function RoomTimeline({
       dateFormatString,
       mediaAutoLoad,
       showUrlPreview,
-	  showClientUrlPreview,
+      showClientUrlPreview,
       autoplayStickers,
       hideMemberInReadOnly,
       isReadOnly,

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -1004,6 +1004,55 @@ function Messages() {
   );
 }
 
+export function Media() {
+  const [clientUrlPreview, setClientUrlPreview] = useSetting(settingsAtom, 'clientUrlPreview');
+  const [encClientUrlPreview, setEncClientUrlPreview] = useSetting(settingsAtom, 'encClientUrlPreview');
+  const [clientPreviewYoutube, setClientPreviewYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
+  const [clientPreviewOEmbed, setClientPreviewOEmbed] = useSetting(settingsAtom, 'clientPreviewOEmbed');
+
+  return (
+	<Box direction="Column" gap="100">
+      <Text size="L400">Client Embeds</Text>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Client Side Embeds"
+		  description={
+			"Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
+		  }
+          after={<Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />}
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Client Side Embeds in Encrypted Room"
+		  description={
+			"Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
+		  }
+          after={<Switch variant="Primary" value={encClientUrlPreview} onChange={setEncClientUrlPreview} />}
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="YouTube"
+		  description={
+			"Embed YouTube links."
+		  }
+          after={<Switch variant="Primary" value={clientPreviewYoutube} onChange={setClientPreviewYoutube} />}
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Generic"
+		  description={
+			"Try other links using the oembed standard."
+		  }
+          after={<Switch variant="Primary" value={clientPreviewOEmbed} onChange={setClientPreviewOEmbed} />}
+        />
+      </SequenceCard>
+	</Box>
+  )
+}
+
 export function Sync() {
   const clientConfig = useClientConfig();
   const sessions = useAtomValue(sessionsAtom);
@@ -1216,6 +1265,7 @@ export function General({ requestClose }: Readonly<GeneralProps>) {
               <Gestures isMobile={mobileOrTablet()} />
               <Editor isMobile={mobileOrTablet()} />
               <Messages />
+			  <Media />
               <Calls />
               <DiagnosticsAndPrivacy />
             </Box>

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -871,8 +871,14 @@ function Messages() {
   const [urlPreview, setUrlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [encUrlPreview, setEncUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
   const [clientUrlPreview, setClientUrlPreview] = useSetting(settingsAtom, 'clientUrlPreview');
-  const [encClientUrlPreview, setEncClientUrlPreview] = useSetting(settingsAtom, 'encClientUrlPreview');
-  const [clientPreviewYoutube, setClientPreviewYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
+  const [encClientUrlPreview, setEncClientUrlPreview] = useSetting(
+    settingsAtom,
+    'encClientUrlPreview'
+  );
+  const [clientPreviewYoutube, setClientPreviewYoutube] = useSetting(
+    settingsAtom,
+    'clientPreviewYoutube'
+  );
   const [showHiddenEvents, setShowHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
   const [showTombstoneEvents, setShowTombstoneEvents] = useSetting(
     settingsAtom,
@@ -960,27 +966,51 @@ function Messages() {
           after={<Switch variant="Primary" value={encUrlPreview} onChange={setEncUrlPreview} />}
         />
       </SequenceCard>
-	  <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-		<SettingTile
-		  title="Client Side Embeds"
-		  description={
-			"Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
-		  }
-		  after={<Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />}
-		/>
-	  </SequenceCard>
-	  <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column" style={clientUrlPreview ? {} : {display: 'none'}}>
-		<SettingTile
-		  title="Client Embeds in Encrypted Rooms"
-		  after={<Switch variant="Primary" value={encClientUrlPreview} onChange={setEncClientUrlPreview} />}
-		/>
-	  </SequenceCard>
-	  <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column" style={clientUrlPreview ? {} : {display: 'none'}}>
-		<SettingTile
-		  title="Embed YouTube Links"
-		  after={<Switch variant="Primary" value={clientPreviewYoutube} onChange={setClientPreviewYoutube} />}
-		/>
-	  </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Client Side Embeds"
+          description={
+            'Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services.'
+          }
+          after={
+            <Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        style={clientUrlPreview ? {} : { display: 'none' }}
+      >
+        <SettingTile
+          title="Client Embeds in Encrypted Rooms"
+          after={
+            <Switch
+              variant="Primary"
+              value={encClientUrlPreview}
+              onChange={setEncClientUrlPreview}
+            />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        style={clientUrlPreview ? {} : { display: 'none' }}
+      >
+        <SettingTile
+          title="Embed YouTube Links"
+          after={
+            <Switch
+              variant="Primary"
+              value={clientPreviewYoutube}
+              onChange={setClientPreviewYoutube}
+            />
+          }
+        />
+      </SequenceCard>
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile
           title="Hide Member Events in Read-Only Rooms"

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -971,7 +971,12 @@ function Messages() {
           title="Client Side Embeds"
           description="Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
           after={
-            <Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />
+            <Switch
+              variant="Primary"
+              value={clientUrlPreview}
+              onChange={setClientUrlPreview}
+              title={clientUrlPreview ? 'Disable client-side embeds' : 'Enable client-side embeds'}
+            />
           }
         />
       </SequenceCard>
@@ -988,6 +993,11 @@ function Messages() {
               variant="Primary"
               value={encClientUrlPreview}
               onChange={setEncClientUrlPreview}
+              title={
+                encClientUrlPreview
+                  ? 'Disable client-side embeds in encrypted rooms'
+                  : 'Enable client-side embeds in encrypted rooms'
+              }
             />
           }
         />
@@ -1005,6 +1015,11 @@ function Messages() {
               variant="Primary"
               value={clientPreviewYoutube}
               onChange={setClientPreviewYoutube}
+              title={
+                clientPreviewYoutube
+                  ? 'Disable client-side Youtube video embeds'
+                  : 'Enable client-side Youtube video embeds'
+              }
             />
           }
         />

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -969,9 +969,7 @@ function Messages() {
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile
           title="Client Side Embeds"
-          description={
-            'Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services.'
-          }
+          description="Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
           after={
             <Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />
           }

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -870,6 +870,9 @@ function Messages() {
   const [mediaAutoLoad, setMediaAutoLoad] = useSetting(settingsAtom, 'mediaAutoLoad');
   const [urlPreview, setUrlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [encUrlPreview, setEncUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
+  const [clientUrlPreview, setClientUrlPreview] = useSetting(settingsAtom, 'clientUrlPreview');
+  const [encClientUrlPreview, setEncClientUrlPreview] = useSetting(settingsAtom, 'encClientUrlPreview');
+  const [clientPreviewYoutube, setClientPreviewYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
   const [showHiddenEvents, setShowHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
   const [showTombstoneEvents, setShowTombstoneEvents] = useSetting(
     settingsAtom,
@@ -957,6 +960,27 @@ function Messages() {
           after={<Switch variant="Primary" value={encUrlPreview} onChange={setEncUrlPreview} />}
         />
       </SequenceCard>
+	  <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+		<SettingTile
+		  title="Client Side Embeds"
+		  description={
+			"Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
+		  }
+		  after={<Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />}
+		/>
+	  </SequenceCard>
+	  <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column" style={clientUrlPreview ? {} : {display: 'none'}}>
+		<SettingTile
+		  title="Client Embeds in Encrypted Rooms"
+		  after={<Switch variant="Primary" value={encClientUrlPreview} onChange={setEncClientUrlPreview} />}
+		/>
+	  </SequenceCard>
+	  <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column" style={clientUrlPreview ? {} : {display: 'none'}}>
+		<SettingTile
+		  title="Embed YouTube Links"
+		  after={<Switch variant="Primary" value={clientPreviewYoutube} onChange={setClientPreviewYoutube} />}
+		/>
+	  </SequenceCard>
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile
           title="Hide Member Events in Read-Only Rooms"
@@ -1002,55 +1026,6 @@ function Messages() {
       </SequenceCard>
     </Box>
   );
-}
-
-export function Media() {
-  const [clientUrlPreview, setClientUrlPreview] = useSetting(settingsAtom, 'clientUrlPreview');
-  const [encClientUrlPreview, setEncClientUrlPreview] = useSetting(settingsAtom, 'encClientUrlPreview');
-  const [clientPreviewYoutube, setClientPreviewYoutube] = useSetting(settingsAtom, 'clientPreviewYoutube');
-  const [clientPreviewOEmbed, setClientPreviewOEmbed] = useSetting(settingsAtom, 'clientPreviewOEmbed');
-
-  return (
-	<Box direction="Column" gap="100">
-      <Text size="L400">Client Embeds</Text>
-      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-        <SettingTile
-          title="Client Side Embeds"
-		  description={
-			"Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
-		  }
-          after={<Switch variant="Primary" value={clientUrlPreview} onChange={setClientUrlPreview} />}
-        />
-      </SequenceCard>
-      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-        <SettingTile
-          title="Client Side Embeds in Encrypted Room"
-		  description={
-			"Attempt to preview unsupported urls (e.g. YouTube) on the client, without involving the homeserver. This will expose your IP Address to third party services."
-		  }
-          after={<Switch variant="Primary" value={encClientUrlPreview} onChange={setEncClientUrlPreview} />}
-        />
-      </SequenceCard>
-      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-        <SettingTile
-          title="YouTube"
-		  description={
-			"Embed YouTube links."
-		  }
-          after={<Switch variant="Primary" value={clientPreviewYoutube} onChange={setClientPreviewYoutube} />}
-        />
-      </SequenceCard>
-      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-        <SettingTile
-          title="Generic"
-		  description={
-			"Try other links using the oembed standard."
-		  }
-          after={<Switch variant="Primary" value={clientPreviewOEmbed} onChange={setClientPreviewOEmbed} />}
-        />
-      </SequenceCard>
-	</Box>
-  )
 }
 
 export function Sync() {
@@ -1265,7 +1240,6 @@ export function General({ requestClose }: Readonly<GeneralProps>) {
               <Gestures isMobile={mobileOrTablet()} />
               <Editor isMobile={mobileOrTablet()} />
               <Messages />
-			  <Media />
               <Calls />
               <DiagnosticsAndPrivacy />
             </Box>

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -251,7 +251,7 @@ export function useTimelineEventRenderer({
     dateFormatString,
     mediaAutoLoad,
     showUrlPreview,
-	showClientUrlPreview,
+    showClientUrlPreview,
     autoplayStickers,
     hideMemberInReadOnly,
     isReadOnly,
@@ -592,7 +592,7 @@ export function useTimelineEventRenderer({
                       getContent={getContent}
                       mediaAutoLoad={mediaAutoLoad}
                       urlPreview={showUrlPreview}
-					  clientUrlPreview={showClientUrlPreview}
+                      clientUrlPreview={showClientUrlPreview}
                       htmlReactParserOptions={htmlReactParserOptions}
                       linkifyOpts={linkifyOpts}
                       outlineAttachment={messageLayout === MessageLayout.Bubble}

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -197,6 +197,7 @@ export interface TimelineEventRendererOptions {
     dateFormatString: string;
     mediaAutoLoad: boolean;
     showUrlPreview: boolean;
+    showClientUrlPreview: boolean;
     autoplayStickers: boolean;
     hideMemberInReadOnly: boolean;
     isReadOnly: boolean;
@@ -250,6 +251,7 @@ export function useTimelineEventRenderer({
     dateFormatString,
     mediaAutoLoad,
     showUrlPreview,
+	showClientUrlPreview,
     autoplayStickers,
     hideMemberInReadOnly,
     isReadOnly,
@@ -427,6 +429,7 @@ export function useTimelineEventRenderer({
                 getContent={getContent}
                 mediaAutoLoad={mediaAutoLoad}
                 urlPreview={showUrlPreview}
+                clientUrlPreview={showClientUrlPreview}
                 htmlReactParserOptions={htmlReactParserOptions}
                 linkifyOpts={linkifyOpts}
                 outlineAttachment={messageLayout === MessageLayout.Bubble}
@@ -589,6 +592,7 @@ export function useTimelineEventRenderer({
                       getContent={getContent}
                       mediaAutoLoad={mediaAutoLoad}
                       urlPreview={showUrlPreview}
+					  clientUrlPreview={showClientUrlPreview}
                       htmlReactParserOptions={htmlReactParserOptions}
                       linkifyOpts={linkifyOpts}
                       outlineAttachment={messageLayout === MessageLayout.Bubble}

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -44,12 +44,18 @@ export interface Settings {
   messageSpacing: MessageSpacing;
   hideMembershipEvents: boolean;
   hideNickAvatarEvents: boolean;
-  mediaAutoLoad: boolean;
-  urlPreview: boolean;
-  encUrlPreview: boolean;
   showHiddenEvents: boolean;
   showTombstoneEvents: boolean;
   legacyUsernameColor: boolean;
+
+  mediaAutoLoad: boolean;
+  urlPreview: boolean;
+  encUrlPreview: boolean;
+  clientUrlPreview: boolean;
+  encClientUrlPreview: boolean;
+  clientPreviewYoutube: boolean;
+  clientPreviewOEmbed: boolean;
+  clientUrlPreviewWhitelist: string[];
 
   usePushNotifications: boolean;
   useInAppNotifications: boolean;

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -54,7 +54,6 @@ export interface Settings {
   clientUrlPreview: boolean;
   encClientUrlPreview: boolean;
   clientPreviewYoutube: boolean;
-  clientPreviewOEmbed: boolean;
   clientUrlPreviewWhitelist: string[];
 
   usePushNotifications: boolean;

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -54,7 +54,6 @@ export interface Settings {
   clientUrlPreview: boolean;
   encClientUrlPreview: boolean;
   clientPreviewYoutube: boolean;
-  clientUrlPreviewWhitelist: string[];
 
   usePushNotifications: boolean;
   useInAppNotifications: boolean;
@@ -136,6 +135,9 @@ const defaultSettings: Settings = {
   mediaAutoLoad: true,
   urlPreview: true,
   encUrlPreview: false,
+  clientUrlPreview: false,
+  encClientUrlPreview: false,
+  clientPreviewYoutube: false,
   showHiddenEvents: false,
   showTombstoneEvents: false,
   legacyUsernameColor: false,


### PR DESCRIPTION
### Description

Adds support for optional client side youtube link embeds. Also includes minimal scaffolding to support more embed types in the future.

Fixes #61 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
