### PR TITLE
Add context aware search menu

### DIFF
--- a/.changeset/add-context-aware-search.md
+++ b/.changeset/add-context-aware-search.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+`Ctrl + K` search menu is now context aware and lists the current space's rooms at the top.

--- a/src/app/features/search/Search.tsx
+++ b/src/app/features/search/Search.tsx
@@ -55,6 +55,7 @@ import { useKeyDown } from '$hooks/useKeyDown';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { KeySymbol } from '$utils/key-symbol';
 import { isMacOS } from '$utils/user-agent';
+import { useSelectedSpace } from '$hooks/router/useSelectedSpace';
 
 enum SearchRoomType {
   Rooms = '#',
@@ -167,7 +168,19 @@ export function Search({ requestClose }: SearchProps) {
   );
 
   const [result, search, resetSearch] = useAsyncSearch(targetRooms, getTargetStr, SEARCH_OPTIONS);
-  const roomsToRender = result ? result.items : topActiveRooms;
+  const selectedSpaceId = useSelectedSpace();
+
+  const roomsToRender = useMemo(() => {
+    const items = result ? result.items : topActiveRooms;
+    if (!selectedSpaceId) return items;
+
+    return [...items].sort((a, b) => {
+      const aInSpace = getAllParents(roomToParents, a)?.has(selectedSpaceId) ? 1 : 0;
+      const bInSpace = getAllParents(roomToParents, b)?.has(selectedSpaceId) ? 1 : 0;
+      return bInSpace - aInSpace;
+    });
+  }, [result, topActiveRooms, selectedSpaceId, roomToParents]);
+
   const listFocus = useListFocusIndex(roomsToRender.length, 0);
 
   const queryHighlighRegex = result?.query


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Makes it so the current space's rooms will appear at the top of the `ctrl + k` search menu. I think it only checks the current space, so likely doesn't work particularly well in nested situations, but good enough to add for now I think.

Fixes #486 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
