### PR TITLE
Feat: added location sharing command

### DIFF
--- a/.changeset/add_location_command.md
+++ b/.changeset/add_location_command.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add /location sharing command, and a /sharemylocation command.

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -1516,8 +1516,7 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
 
           function error(err: any) {
             let response = `Unable to retrieve the location data, Error no. ${err.code}: ${err.message}`;
-            if (err.code === 1)
-              response = 'You have denied access to the location for the website.';
+            if (err.code === 1) response = 'You have denied access to the location for Sable.';
             if (err.code === 2)
               response = 'Your device does not have a gps module, or it may not be turned on.';
             sendFeedback(response, room, mx.getSafeUserId());

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -263,6 +263,9 @@ export enum Command {
   Report = 'bugreport',
   // Experimental
   ShareE2EEHistory = 'sharehistory',
+  // Spec missing from cinny
+  Location = 'location',
+  ShareMyLocation = 'sharemylocation',
 }
 
 export type CommandContent = {
@@ -1443,6 +1446,82 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
         description: 'Report a bug or request a feature',
         exe: async () => {
           openBugReport();
+        },
+      },
+      [Command.Location]: {
+        name: Command.Location,
+        description: 'Share a location as /location <latitude> <longitude>',
+        exe: async (payload) => {
+          const target = payload
+            .replace(',', ' ')
+            .replace('/', ' ')
+            .replace('  ', ' ')
+            .trim()
+            .split(' ');
+
+          const mlat = target[0];
+          const mlon = target[1];
+          const malt = target[2];
+          if (!mlat || !mlat) {
+            sendFeedback(
+              'You need to specify a latitude, a longitude parameter, and optionally an altitude, as for example: /location 43.959971 -59.790623 or use the /sharemylocation to share the current location',
+              room,
+              mx.getSafeUserId()
+            );
+            return;
+          }
+          await mx.sendMessage(room.roomId, {
+            msgtype: 'm.location',
+            geo_uri: `geo:${mlat},${mlon}${malt ? `,${malt}` : ''};u=0`,
+            body: `https://www.openstreetmap.org/?mlat=${mlat}&mlon=${mlon}#map=16/${mlat}/${mlon}"`,
+          } as any);
+        },
+      },
+      [Command.ShareMyLocation]: {
+        name: Command.ShareMyLocation,
+        description:
+          'Share current location. Requires your browser to have location permissions. Add the flag --accurate or -a for enabling the high accuracy option',
+        exe: async (payload) => {
+          const target = payload.trim();
+          const options = {
+            enableHighAccuracy:
+              target === '--accurate' ||
+              target === '-a' ||
+              target === '--high-accuracy' ||
+              target === '-h',
+            timeout: 5000,
+            maximumAge: 0,
+          };
+          function success(pos: any) {
+            const crd = pos.coords;
+
+            const mlat = crd.latitude;
+            const mlon = crd.longitude;
+            const malt = crd.altitude;
+            const macc = crd.accuracy;
+            if (!mlat || !mlat) {
+              sendFeedback(
+                'Unable to retrieve the location data for an unknown reason',
+                room,
+                mx.getSafeUserId()
+              );
+              return;
+            }
+            mx.sendMessage(room.roomId, {
+              msgtype: 'm.location',
+              geo_uri: `geo:${mlat},${mlon}${malt ? `,${malt}` : ''};u=${macc}`,
+              body: `https://www.openstreetmap.org/?mlat=${mlat}&mlon=${mlon}#map=16/${mlat}/${mlon}"`,
+            } as any);
+          }
+
+          function error(err: any) {
+            let response = `Unable to retrieve the location data, Error no. ${err.code}: ${err.message}`;
+            if (err.code === 1) response = `The prompt for sharing your location was denied.`;
+            if (err.code === 2)
+              response = `Your device does not have a gps tracker, or it may not be turned on.`;
+            sendFeedback(response, room, mx.getSafeUserId());
+          }
+          navigator.geolocation.getCurrentPosition(success, error, options);
         },
       },
     }),

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -1516,7 +1516,7 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
 
           function error(err: any) {
             let response = `Unable to retrieve the location data, Error no. ${err.code}: ${err.message}`;
-            if (err.code === 1) response = 'You have denied access to the location for Sable.';
+            if (err.code === 1) response = 'You have denied Sable access to you location services.';
             if (err.code === 2)
               response = 'Your device does not have a gps module, or it may not be turned on.';
             sendFeedback(response, room, mx.getSafeUserId());

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -1516,9 +1516,10 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
 
           function error(err: any) {
             let response = `Unable to retrieve the location data, Error no. ${err.code}: ${err.message}`;
-            if (err.code === 1) response = `The prompt for sharing your location was denied.`;
+            if (err.code === 1)
+              response = 'You have denied access to the location for the website.';
             if (err.code === 2)
-              response = `Your device does not have a gps tracker, or it may not be turned on.`;
+              response = 'Your device does not have a gps module, or it may not be turned on.';
             sendFeedback(response, room, mx.getSafeUserId());
           }
           navigator.geolocation.getCurrentPosition(success, error, options);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Following the spec there needs to be a way to send (as there is a "way" to display already) location messages.

This PR adds 2 commands one could use for that purpose (in preparation of maybe adding a location sharing button in the future)

/location [Latitude] [Longitude] [Altitude?] ← for sending any arbitrary location with its coords
/sharemylocation ← for sharing one's current location using the gps tracker inside all phones nowadays :3

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
I had to set up a proper self host to test this little thing because my laptop doesnt have a tracker :3 so i had to use my phone