### PR TITLE
Feat: add quickreply keybindings

### DIFF
--- a/.changeset/add_quickreply_keybinds.md
+++ b/.changeset/add_quickreply_keybinds.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add quick reply keybinds by using <kbd>ctrl</kbd>+<kbd>up</kbd> / <kbd>ctrl</kbd>+<kbd>down</kbd> you can now cycle through the message you are replying to with keybinds

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -5,10 +5,11 @@
  *   Alt+N              — jump to the highest-priority unread room
  *   Alt+Shift+Down     — cycle forward through unread rooms
  *   Alt+Shift+Up       — cycle backward through unread rooms
+ *   Ctrl+Down / Ctrl+Up: cycle through messages to reply to
  */
 import { useCallback, useRef } from 'react';
 import { useNavigate, useLocation, matchPath } from 'react-router-dom';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { isKeyHotkey } from 'is-hotkey';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { roomToParentsAtom } from '$state/room/roomToParents';
@@ -19,6 +20,8 @@ import { getDirectRoomPath, getHomeRoomPath, getSpaceRoomPath } from '$pages/pat
 import { HOME_ROOM_PATH, DIRECT_ROOM_PATH, SPACE_ROOM_PATH } from '$pages/paths';
 import { getCanonicalAliasOrRoomId } from '$utils/matrix';
 import { announce } from '$utils/announce';
+import { roomIdToReplyDraftAtomFamily } from '$state/room/roomInputDrafts';
+import { Room } from 'matrix-js-sdk';
 
 export function GlobalKeyboardShortcuts() {
   const navigate = useNavigate();
@@ -37,15 +40,17 @@ export function GlobalKeyboardShortcuts() {
   const roomIdOrAlias = roomMatch?.params.roomIdOrAlias
     ? decodeURIComponent(roomMatch.params.roomIdOrAlias)
     : undefined;
-  let currentRoomId: string | null = null;
+  let currentRoom: Room | null = null;
   if (roomIdOrAlias) {
     if (roomIdOrAlias.startsWith('!')) {
-      currentRoomId = roomIdOrAlias;
+      currentRoom = mx.getRoom(roomIdOrAlias);
     } else {
-      currentRoomId =
-        mx.getRooms().find((r) => r.getCanonicalAlias() === roomIdOrAlias)?.roomId ?? null;
+      currentRoom = mx.getRooms().find((r) => r.getCanonicalAlias() === roomIdOrAlias) ?? null;
     }
   }
+  const replyDraftAtomFamily = roomIdToReplyDraftAtomFamily(currentRoom?.roomId ?? '');
+  const replyDraft = useAtomValue(replyDraftAtomFamily);
+  const setReplyDraft = useSetAtom(replyDraftAtomFamily);
 
   /** Navigate to a room by ID and announce it to screen readers. */
   const navigateToRoom = useCallback(
@@ -76,7 +81,7 @@ export function GlobalKeyboardShortcuts() {
     (evt: KeyboardEvent) => {
       if (!isKeyHotkey('alt+n', evt)) return;
       const unreadEntries = Array.from(roomToUnread.entries())
-        .filter(([id, u]) => u.total > 0 && id !== currentRoomId)
+        .filter(([id, u]) => u.total > 0 && id !== currentRoom?.roomId)
         .sort((a, b) => b[1].highlight - a[1].highlight || b[1].total - a[1].total);
       if (unreadEntries.length === 0) return;
       evt.preventDefault();
@@ -84,7 +89,7 @@ export function GlobalKeyboardShortcuts() {
       const [roomId] = unreadEntries[0];
       navigateToRoom(roomId, unreadEntries.length - 1);
     },
-    [roomToUnread, currentRoomId, navigateToRoom]
+    [roomToUnread, currentRoom?.roomId, navigateToRoom]
   );
 
   /** Alt+Shift+Down / Alt+Shift+Up: cycle through unread rooms. */
@@ -110,8 +115,38 @@ export function GlobalKeyboardShortcuts() {
     [roomToUnread, navigateToRoom]
   );
 
+  /** Ctrl+Down / Ctrl+Up: cycle through messages to reply to. */
+  const handleReplyKeyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      const isDown = isKeyHotkey('mod+down', evt);
+      const isUp = isKeyHotkey('mod+up', evt);
+      if (currentRoom === null) return;
+      if (!isDown && !isUp) return;
+
+      const events = currentRoom.getUnfilteredTimelineSet().getLiveTimeline().getEvents();
+
+      // when no message is currently targeted, just target the first one
+      if (replyDraft?.eventId === undefined) {
+        const latestEvent = events.at(-1);
+        if (latestEvent === undefined) return;
+        const eventId = latestEvent.event.event_id;
+        if (eventId === undefined) return;
+        setReplyDraft({ userId: currentRoom.myUserId, eventId, body: '' });
+        return;
+      }
+      const currentReplyIndex = events.findIndex((e) => e.event.event_id === replyDraft.eventId);
+      if (currentReplyIndex === events.length - 1 && isDown) return; // you cant go further down than that idiot
+      const newTargetEvent = isUp ? events[currentReplyIndex - 1] : events[currentReplyIndex + 1];
+      const eventId = newTargetEvent.event.event_id;
+      if (eventId === undefined) return;
+      setReplyDraft({ userId: currentRoom.myUserId, eventId, body: '' });
+    },
+    [currentRoom, replyDraft, setReplyDraft]
+  );
+
   useKeyDown(window, handleNextUnreadKeyDown);
   useKeyDown(window, handleUnreadNavKeyDown);
+  useKeyDown(window, handleReplyKeyDown);
 
   return null;
 }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This adds the keybinds `ctrl+up`/`ctrl+down` to be used to cycle what message you are replying to. This is inspired by [the vencord plugin QuickReply](https://vencord.dev/plugins/QuickReply)

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

I couldn't get `pnpm dev ` to run so I used an llm to help me figure that out so I could test my changes, but no code in this pr has been touched by an llm