### PR TITLE
Fix sending messages with attachments and stickers while using PMP

### DIFF
--- a/.changeset/fix-pmp-sending-message-with-attachments.md
+++ b/.changeset/fix-pmp-sending-message-with-attachments.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fixed sending sticker and attachments while having a persona selected

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -493,6 +493,26 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));
 
+      /**
+       * the currently with the room associated per-message profile, if any, so that it can be included in the message content when sending.
+       * This allows the server to apply the correct profile-based transformations (e.g. font size adjustments) when processing the message,
+       * and also allows clients to display an accurate preview of how the message will look with the profile applied while it's being composed.
+       */
+      const perMessageProfile = await getCurrentlyUsedPerMessageProfileForRoom(mx, roomId);
+
+      if (perMessageProfile) {
+        contents.forEach((c) => {
+          // We intentionally mutate the objects here to avoid unnecessary copying
+          // mutating should be unproblematic here, since contents isn't a react component,
+          // or used for rendering
+          // eslint-disable-next-line no-param-reassign
+          c['com.beeper.per_message_profile'] = convertPerMessageProfileToBeeperFormat(
+            perMessageProfile,
+            false
+          );
+        });
+      }
+
       if (contents.length > 0) {
         const replyContent =
           plainText?.length === 0 ? getReplyContent(replyDraft, room) : undefined;
@@ -1033,11 +1053,26 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         await getImageUrlBlob(stickerUrl)
       );
 
-      const content: StickerEventContent & ReplyEventContent = {
+      const content: StickerEventContent & ReplyEventContent & IContent = {
         body: label,
         url: mxc,
         info,
       };
+
+      /**
+       * the currently with the room associated per-message profile, if any, so that it can be included in the message content when sending.
+       * This allows the server to apply the correct profile-based transformations (e.g. font size adjustments) when processing the message,
+       * and also allows clients to display an accurate preview of how the message will look with the profile applied while it's being composed.
+       */
+      const perMessageProfile = await getCurrentlyUsedPerMessageProfileForRoom(mx, roomId);
+
+      if (perMessageProfile) {
+        content['com.beeper.per_message_profile'] = convertPerMessageProfileToBeeperFormat(
+          perMessageProfile,
+          false
+        );
+      }
+
       if (replyDraft) {
         content['m.relates_to'] = getReplyContent(replyDraft, room);
         if (threadRootId) {


### PR DESCRIPTION
### Description

fixes falling back to your non-pmp sender info when sending a sticker or a attachment

Fixes https://github.com/SableClient/Sable/issues/513

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
No ai was used for this PR