### PR TITLE
Fix encrypted pmp message rendering issues

### DIFF
--- a/.changeset/fix-pmp-encrypted.md
+++ b/.changeset/fix-pmp-encrypted.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixes the most recent pmp message in encrypted rooms not consistently rendering the pmp and not grouping with previous pmps.

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -384,6 +384,11 @@ function MessageInternal(
 
   useEffect(() => {
     const onUpdate = () => setContentVersion((v) => v + 1);
+
+    if (mEvent.getClearContent()) {
+      setContentVersion((v) => (v === 0 ? 1 : v));
+    }
+
     mEvent.on(MatrixEventEvent.Decrypted, onUpdate);
     mEvent.on(MatrixEventEvent.Replaced, onUpdate);
     return () => {

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -35,6 +35,8 @@ import {
   Relations,
   RoomPinnedEventsEventContent,
   MatrixEventEvent,
+  RoomEvent,
+  IRoomTimelineData,
 } from '$types/matrix-sdk';
 import classNames from 'classnames';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -383,10 +385,20 @@ function MessageInternal(
   const [contentVersion, setContentVersion] = useState(0);
 
   useEffect(() => {
-    const onUpdate = () => setContentVersion((v) => v + 1);
+    const triggerTimelineRegroup = () => {
+      room.emit(RoomEvent.Timeline, mEvent, room, false, false, {
+        liveEvent: true,
+      } as IRoomTimelineData);
+    };
+
+    const onUpdate = () => {
+      setContentVersion((v) => v + 1);
+      triggerTimelineRegroup();
+    };
 
     if (mEvent.getClearContent()) {
       setContentVersion((v) => (v === 0 ? 1 : v));
+      triggerTimelineRegroup();
     }
 
     mEvent.on(MatrixEventEvent.Decrypted, onUpdate);
@@ -395,7 +407,7 @@ function MessageInternal(
       mEvent.off(MatrixEventEvent.Decrypted, onUpdate);
       mEvent.off(MatrixEventEvent.Replaced, onUpdate);
     };
-  }, [mEvent]);
+  }, [mEvent, room]);
 
   /**
    * We read the per-message profile from the event content here.


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Should fix the last of the bugs with per-message profile rendering in encrypted rooms.

Ensures that pmp's are always updated on decryption and gets the timeline to refresh whenever pmps are unencrypted to make sure they get grouped together properly.

Vibes are telling me this isn't the best way to do this for some reason, but it does seem to be working and I can't think of any other method that doesn't involve creating a billion more event listeners in other files.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
