### PR TITLE
fix jumbo emojis for messages sent with a per-message-profile

### DIFF
--- a/.changeset/fix_pmp_jumbo_emoji_display.md
+++ b/.changeset/fix_pmp_jumbo_emoji_display.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix the display of jumbo emojis on messages sent with a persona

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -121,6 +121,12 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
 
   const isJumbo = useMemo(() => {
     if (!trimmedBody || trimmedBody.length >= 500) return false;
+    if (
+      (unwrappedPerMessageProfileMessage ?? safeCustomBody)?.match(
+        /^(<img[^>]*data-mx-emoticon[^>]*\/>){1,20}$/i
+      )
+    )
+      return true;
     if (!JUMBO_EMOJI_REG.test(trimmedBody)) return false;
 
     if (trimmedBody.includes(':')) {
@@ -129,7 +135,7 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
     }
 
     return true;
-  }, [trimmedBody, safeCustomBody]);
+  }, [unwrappedPerMessageProfileMessage, trimmedBody, safeCustomBody]);
 
   if (!body && !customBody) return <BrokenContent body={customBody ?? body} />;
 
@@ -139,7 +145,11 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
   if ((content['com.beeper.per_message_profile'] as PerMessageProfileBeeperFormat)?.has_fallback) {
     // unwrap per-message profile fallback if present
     return (
-      <MessageTextBody preWrap={typeof customBody !== 'string'} style={style}>
+      <MessageTextBody
+        preWrap={typeof customBody !== 'string'}
+        style={style}
+        jumboEmoji={isJumbo ? jumboEmojiSize : 'none'}
+      >
         {renderBody({
           body: trimmedBody,
           customBody: unwrappedPerMessageProfileMessage,


### PR DESCRIPTION
### Description

added a regex to the rendering of messages to detect jumbo emojis. the regex used is:

```
^(<img[^>]*data-mx-emoticon[^>]*\/>){1,20}$
```

Fixes https://github.com/SableClient/Sable/issues/458

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

no AI was used in the creation of this PR