### PR TITLE
fix(sentry): scrub percent-encoded Matrix IDs and opaque base64url tokens from URLs

### DIFF
--- a/.changeset/sentry-scrub-opaque-matrix-ids.md
+++ b/.changeset/sentry-scrub-opaque-matrix-ids.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix(sentry): scrub percent-encoded Matrix IDs and opaque base64url tokens from Sentry URLs

--- a/src/app/utils/sentryScrubbers.ts
+++ b/src/app/utils/sentryScrubbers.ts
@@ -92,7 +92,7 @@ export function scrubMatrixUrl(url: string): string {
       .replace(/\/%23[^/?#\s]*/gi, '/[ROOM_ALIAS]')
       // URL-encoded event IDs as bare path segments: /%24eventId  (%24 = $)
       .replace(/\/%24[^/?#\s]*/gi, '/[EVENT_ID]')
-      // ── Opaque Matrix IDs with percent-encoded colon (%3A) ─────────────────────────
+      //  Opaque Matrix IDs with percent-encoded colon (%3A)
       // Catches device IDs, filter tokens, and other bare Matrix IDs that lack a sigil
       // prefix but still follow the localpart%3Aserver pattern in URL paths.
       // e.g. /Gj3Wy2D8gAi8jTIyR%3Asable.moe  (decoded: Gj3Wy2D8gAi8jTIyR:sable.moe)

--- a/src/app/utils/sentryScrubbers.ts
+++ b/src/app/utils/sentryScrubbers.ts
@@ -92,6 +92,17 @@ export function scrubMatrixUrl(url: string): string {
       .replace(/\/%23[^/?#\s]*/gi, '/[ROOM_ALIAS]')
       // URL-encoded event IDs as bare path segments: /%24eventId  (%24 = $)
       .replace(/\/%24[^/?#\s]*/gi, '/[EVENT_ID]')
+      // ── Opaque Matrix IDs with percent-encoded colon (%3A) ─────────────────────────
+      // Catches device IDs, filter tokens, and other bare Matrix IDs that lack a sigil
+      // prefix but still follow the localpart%3Aserver pattern in URL paths.
+      // e.g. /Gj3Wy2D8gAi8jTIyR%3Asable.moe  (decoded: Gj3Wy2D8gAi8jTIyR:sable.moe)
+      .replace(/\/[A-Za-z0-9+_-]{5,}%3A[A-Za-z0-9._-]+[^/?#\s]*/gi, '/[MATRIX_ID]')
+      // ── Long opaque base64url path segments (access tokens, crypto keys, push tokens) ─
+      // Catches 30+ character base64url strings that appear as standalone path segments.
+      // These are typically Curve25519 keys, MSC3575 session tokens, or push endpoints.
+      // e.g. /vI02CuiDNpaYEhUIVLbqE8vdKqm2ZwqIR5Y6NwNY_Rg/
+      // Runs last so earlier patterns already replaced known Matrix IDs.
+      .replace(/\/[A-Za-z0-9+_-]{30,}(\/|$)/g, '/[REDACTED]$1')
       // ── Preview URL endpoint ────────────────────────────────────────────────────────
       // The ?url= query parameter on preview_url contains the full external URL being
       // previewed — strip the entire query string so browsing habits cannot be inferred.


### PR DESCRIPTION
### Description

Extends `scrubMatrixUrl` with two additional patterns that were leaking through the existing scrubber.

**1. Opaque Matrix IDs with percent-encoded colon (`%3A`)**

Device IDs, filter tokens, and other Matrix IDs that lack a sigil prefix but follow the `localpart%3Aserver` pattern were not matched by the existing sigil-based patterns. For example:

```
/Gj3Wy2D8gAi8jTIyR%3Asable.moe  →  /[MATRIX_ID]
```

**2. Long opaque base64url path segments**

Access tokens, Curve25519 keys, MSC3575 session tokens, and push endpoints appear as 30+ character base64url strings in URL path segments. These were passing through unscrubbed. For example:

```
/vI02CuiDNpaYEhUIVLbqE8vdKqm2ZwqIR5Y6NwNY_Rg/  →  /[REDACTED]/
```

The new pattern runs last so the earlier sigil-based patterns already handle known Matrix IDs first.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted
- [x] Fully AI generated

Two regex patterns added to `scrubMatrixUrl` in `sentryScrubbers.ts`. The first matches path segments containing a bare `localpart%3Aserver` form (no sigil) and replaces with `[MATRIX_ID]`. The second matches any path segment of 30 or more base64url characters and replaces with `[REDACTED]`, covering access tokens, crypto keys, and opaque session identifiers. Both are appended after the existing patterns so known sigil-prefixed IDs are handled first.