### PR TITLE
fix confusing ui for client side embed settings

### DIFF
--- a/.changeset/fix_confusing_ui_with_client_side_embeds_setting.md
+++ b/.changeset/fix_confusing_ui_with_client_side_embeds_setting.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix confusing ui with `Client Side Embeds in Encrypted Rooms` setting

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -145,7 +145,7 @@ export function RoomTimeline({
 
   const showUrlPreview = room.hasEncryptionStateEvent() ? encUrlPreview : urlPreview;
   const showClientUrlPreview = room.hasEncryptionStateEvent()
-    ? encClientUrlPreview
+    ? clientUrlPreview && encClientUrlPreview
     : clientUrlPreview;
 
   const nicknames = useAtomValue(nicknamesAtom);


### PR DESCRIPTION
### Description

this is a tiny fix to a potentially confusing "problem" that i thought of when going to sleep last night, previously if you enabled client side embeds in both unencrypted and encrypted rooms, and then turned off the main client side embeds toggle, the encrypted rooms setting would remain on, even though it would be hidden in the setting ui

feel free to just close if this is stupid

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
