### PR TITLE
add ability to show user info in member and state event messages

### DIFF
--- a/.changeset/add_ability_to_click_on_usernames_in_member_and_state_events_to_view_user_info.md
+++ b/.changeset/add_ability_to_click_on_usernames_in_member_and_state_events_to_view_user_info.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add ability to click on usernames in member and state events to view user info

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useMemo } from 'react';
+import { MouseEventHandler, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue } from 'jotai';
 import {
@@ -20,6 +20,7 @@ import { useMemberEventParser } from '$hooks/useMemberEventParser';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { useMatrixEventRenderer } from '$hooks/useMatrixEventRenderer';
+import { useOpenUserRoomProfile } from '$state/hooks/userRoomProfile';
 import {
   EventContent,
   ImageContent,
@@ -58,9 +59,25 @@ import { useSableCosmetics } from '$hooks/useSableCosmetics';
 
 function DecoratedUser({ room, userId, userName }: DecoratedUserProps) {
   const { color, font } = useSableCosmetics(userId, room ?? ({} as Room));
+
+  const openUserRoomProfile = useOpenUserRoomProfile();
+  const handleUserClick: MouseEventHandler = useCallback(
+    (evt) => {
+      evt.preventDefault();
+      evt.stopPropagation();
+      openUserRoomProfile(
+        room.roomId,
+        undefined,
+        userId,
+        evt.currentTarget.getBoundingClientRect()
+      );
+    },
+    [room, userId, openUserRoomProfile]
+  );
+
   return (
-    <Text truncate>
-      <b style={{ color, font }}> {userName ?? userId} </b>
+    <Text as="a" onClick={handleUserClick} truncate>
+      <b style={{ color, font }}>{userName ?? userId} </b>
     </Text>
   );
 }

--- a/src/app/hooks/useMemberEventParser.tsx
+++ b/src/app/hooks/useMemberEventParser.tsx
@@ -1,9 +1,10 @@
-import { ReactNode } from 'react';
+import { MouseEventHandler, useCallback, ReactNode } from 'react';
 import { IconSrc, Icons, Text } from 'folds';
 import { MatrixEvent, Room } from '$types/matrix-sdk';
 import { IMemberContent, Membership } from '$types/matrix/room';
 import { getMxIdLocalPart } from '$utils/matrix';
 import { isMembershipChanged } from '$utils/room';
+import { useOpenUserRoomProfile } from '$state/hooks/userRoomProfile';
 import { useSableCosmetics } from './useSableCosmetics';
 import { useMatrixClient } from './useMatrixClient';
 
@@ -17,8 +18,19 @@ function DecoratedUser({ roomId, userId, userName }: DecoratedUserProps) {
   const mx = useMatrixClient();
   const room = mx.getRoom(roomId);
   const { color, font } = useSableCosmetics(userId, room ?? ({} as Room));
+
+  const openUserRoomProfile = useOpenUserRoomProfile();
+  const handleUserClick: MouseEventHandler = useCallback(
+    (evt) => {
+      evt.preventDefault();
+      evt.stopPropagation();
+      openUserRoomProfile(roomId, undefined, userId, evt.currentTarget.getBoundingClientRect());
+    },
+    [roomId, userId, openUserRoomProfile]
+  );
+
   return (
-    <Text truncate>
+    <Text as="a" onClick={handleUserClick} truncate>
       <b style={{ color, font }}>{userName ?? userId} </b>
     </Text>
   );


### PR DESCRIPTION
### Description

Add ability to open the user hero by clicking on the usernames shown in member and state events (e.g. user joins room, room name changed). I expected this behavior based on previous usage of discord, it wasn't doing anything previously so I think this is a useful addition.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).