### PR TITLE
Remove null value from message forwarding metadata

### DIFF
--- a/.changeset/fix_forwarding_metadata.md
+++ b/.changeset/fix_forwarding_metadata.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix forwarding metadata by removing the `null` value

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -93,9 +93,9 @@ type ForwardMeta = {
 
 // see https://github.com/hummlbach/matrix-doc/blob/acea0854a1c9489599295a858b068ce02a6b2b20/proposals/2723-add-forward-info.md
 type MSC2723ForwardMeta = {
-  event_id: string;
-  room_id: string;
-  sender: string | null; // we won't set this field
+  event_id?: string;
+  room_id?: string;
+  sender?: string; // we won't set this field
   origin_server_ts: number;
 };
 
@@ -205,9 +205,9 @@ export function MessageForwardInternal({
       newBodyPlain = originalBody.length > 0 ? `${bodyModifText}\n\n${quotedBody}` : bodyModifText;
 
       const safeHtml =
-        originalFormattedBody !== undefined
-          ? sanitizeCustomHtml(originalFormattedBody)
-          : sanitizeCustomHtml(originalBody).replaceAll('\n', '<br>');
+        originalFormattedBody === undefined
+          ? sanitizeCustomHtml(originalBody).replaceAll('\n', '<br>')
+          : sanitizeCustomHtml(originalFormattedBody);
 
       newBodyHtml =
         `<div data-forward-marker>` +
@@ -241,6 +241,9 @@ export function MessageForwardInternal({
           original_timestamp: mEvent.getTs(),
           original_event_private: true,
         } satisfies ForwardMeta,
+        'com.famedly.app.forwarded': {
+          origin_server_ts: mEvent.getTs(),
+        } satisfies MSC2723ForwardMeta,
       };
     } else {
       content = {
@@ -261,7 +264,6 @@ export function MessageForwardInternal({
         'com.famedly.app.forwarded': {
           event_id: eventId,
           room_id: room.roomId,
-          sender: null, // we won't set this field, as a design decision to avoid potential privacy issues and since the sender can be inferred from the event_id and room_id if needed
           origin_server_ts: mEvent.getTs(),
         } satisfies MSC2723ForwardMeta,
       };


### PR DESCRIPTION
### Description

not setting `sender` to `null` anymore but just not setting it.

Fixes #539 (hopefully)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

no AI was used for this PR