### PR TITLE
Feat: Add preventing urlPreviewing by surrounding a link in angle brackets

### DIFF
--- a/.changeset/add_hide_urlPreview.md
+++ b/.changeset/add_hide_urlPreview.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add preventing urlPreviewing by surrounding a link in angle brackets

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -139,16 +139,22 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
 
   if (!body && !customBody) return <BrokenContent body={customBody ?? body} />;
 
+  // move the < > inside of the []() in order to make the matching easier
+  trimmedBody = trimmedBody?.replace(/(<|&lt;)\[(.+)\]\((https?:\/\/(.+))\)(>|&gt;)/, '[$2](<$3>)');
   const urlsMatch = renderUrlsPreview && trimmedBody.match(URL_REG);
-  let urls = urlsMatch ? [...new Set(urlsMatch)] : undefined;
-  if (urls != null && urls !== undefined && urls.length > 0) {
-    // remove < > tagged urls from the preview list
-    urls = urls.filter((url) => !url.match(/(<|&lt;)(.+)(>|$gt;)/));
-    // remove the < > tags from links that are meant to be hidden from urls that are not to be shown
-    trimmedBody = trimmedBody?.replace(/(<|&lt;)http(s?):\/\/(.+)(>|&gt;)/, 'http$2://$3');
+  const urlStrings = urlsMatch ? [...new Set(urlsMatch)] : undefined;
+  const urls = urlStrings?.filter((url) => !url.startsWith('<') && !url.endsWith('>'));
+  // strip the < > tags visually if needed
+  if (urlStrings?.length !== urls?.length) {
+    trimmedBody = trimmedBody?.replace(/<http(s?):\/\/(.+?)>/g, 'http$1://$2');
+    trimmedBody = trimmedBody?.replace(/<\[(.+?)\]\(http(s?):\/\/(.+)\)>/g, '[$1](http$2://$3)');
     safeCustomBody = safeCustomBody?.replace(
-      /<a data-md href="(<|&lt;)(.+)(>|&gt;)">(.+)<\/a>/,
-      '<a data-md href="$2">$4</a>'
+      /<<a data-md href="(.+?)">(.+?)<\/a>>/g,
+      '<a data-md href="$1">$2</a>'
+    );
+    safeCustomBody = safeCustomBody?.replace(
+      /<a data-md href="&lt;(.+?)&gt;">(.+?)<\/a>/g,
+      '<a data-md href="$1">$2</a>'
     );
   }
 

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -140,16 +140,15 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
   if (!body && !customBody) return <BrokenContent body={customBody ?? body} />;
 
   const urlsMatch = renderUrlsPreview && trimmedBody.match(URL_REG);
-  const urls = urlsMatch ? [...new Set(urlsMatch)] : undefined;
+  let urls = urlsMatch ? [...new Set(urlsMatch)] : undefined;
   if (urls != null && urls !== undefined && urls.length > 0) {
+    // remove < > tagged urls from the preview list
+    urls = urls.filter((url) => !url.match(/(<|&lt;)(.+)(>|$gt;)/));
+    // remove the < > tags from links that are meant to be hidden from urls that are not to be shown
     trimmedBody = trimmedBody?.replace(/(<|&lt;)http(s?):\/\/(.+)(>|&gt;)/, 'http$2://$3');
-    trimmedBody = trimmedBody?.replace(
-      /(<|&lt;)\[(.+)?\]\(http(s?):\/\/(.+)\)(>|&gt;)/,
-      '[$2](http$3://$4)'
-    );
     safeCustomBody = safeCustomBody?.replace(
-      /(<|&lt;)<a data-md href="(.+)">(.+)<\/a>(>|&gt;)/,
-      '<a data-md href="$2">$3</a>'
+      /<a data-md href="(<|&lt;)(.+)(>|&gt;)">(.+)<\/a>/,
+      '<a data-md href="$2">$4</a>'
     );
   }
 

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -91,7 +91,7 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
   const customBody =
     typeof content.formatted_body === 'string' ? content.formatted_body : undefined;
 
-  const trimmedBody = useMemo(() => trimReplyFromBody(body), [body]);
+  let trimmedBody = useMemo(() => trimReplyFromBody(body), [body]);
   const unwrappedForwardedContent = useMemo(
     () => unwrapForwardedContent(customBody ?? body),
     [customBody, body]
@@ -141,11 +141,17 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
 
   const urlsMatch = renderUrlsPreview && trimmedBody.match(URL_REG);
   const urls = urlsMatch ? [...new Set(urlsMatch)] : undefined;
-
-  safeCustomBody = safeCustomBody?.replace(
-    /(<|&lt;)<a data-md href="(.+)">(.+)<\/a>(>|&gt;)/g,
-    '<a data-md href="$2">$3</a>'
-  );
+  if (urls != null && urls !== undefined && urls.length > 0) {
+    trimmedBody = trimmedBody?.replace(/(<|&lt;)http(s?):\/\/(.+)(>|&gt;)/, 'http$2://$3');
+    trimmedBody = trimmedBody?.replace(
+      /(<|&lt;)\[(.+)?\]\(http(s?):\/\/(.+)\)(>|&gt;)/,
+      '[$2](http$3://$4)'
+    );
+    safeCustomBody = safeCustomBody?.replace(
+      /(<|&lt;)<a data-md href="(.+)">(.+)<\/a>(>|&gt;)/,
+      '<a data-md href="$2">$3</a>'
+    );
+  }
 
   if ((content['com.beeper.per_message_profile'] as PerMessageProfileBeeperFormat)?.has_fallback) {
     // unwrap per-message profile fallback if present

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -97,7 +97,7 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
     [customBody, body]
   );
 
-  const safeCustomBody = useMemo(() => {
+  let safeCustomBody = useMemo(() => {
     if (!customBody) return undefined;
     if (customBody.length > 8000) {
       const imageTags = customBody.match(/<img[^>]*>/g);
@@ -141,6 +141,11 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
 
   const urlsMatch = renderUrlsPreview && trimmedBody.match(URL_REG);
   const urls = urlsMatch ? [...new Set(urlsMatch)] : undefined;
+
+  safeCustomBody = safeCustomBody?.replace(
+    /(<|&lt;)<a data-md href="(.+)">(.+)<\/a>(>|&gt;)/g,
+    '<a data-md href="$2">$3</a>'
+  );
 
   if ((content['com.beeper.per_message_profile'] as PerMessageProfileBeeperFormat)?.has_fallback) {
     // unwrap per-message profile fallback if present

--- a/src/app/plugins/markdown/inline/rules.ts
+++ b/src/app/plugins/markdown/inline/rules.ts
@@ -109,7 +109,7 @@ export const LinkRule: InlineMDRule = {
     const [, g1, g2] = match;
     // Checks for < and > since text comes sanitized to the parser
     if (g2.startsWith('&lt;') && g2.endsWith('&gt;'))
-      return `<<a data-md href="${g2.substring(4, g2.length - 5)}">${parse(g1)}</a>>`;
+      return `<<a data-md href="${g2.substring(4, g2.lastIndexOf('&gt;'))}">${parse(g1)}</a>>`;
     return `<a data-md href="${g2}">${parse(g1)}</a>`;
   },
 };

--- a/src/app/plugins/markdown/inline/rules.ts
+++ b/src/app/plugins/markdown/inline/rules.ts
@@ -107,9 +107,6 @@ export const LinkRule: InlineMDRule = {
   match: (text) => text.match(LINK_REG_1),
   html: (parse, match) => {
     const [, g1, g2] = match;
-    // Checks for < and > since text comes sanitized to the parser
-    if (g2.startsWith('&lt;') && g2.endsWith('&gt;'))
-      return `<<a data-md href="${g2.substring(4, g2.lastIndexOf('&gt;'))}">${parse(g1)}</a>>`;
     return `<a data-md href="${g2}">${parse(g1)}</a>`;
   },
 };

--- a/src/app/plugins/markdown/inline/rules.ts
+++ b/src/app/plugins/markdown/inline/rules.ts
@@ -107,6 +107,10 @@ export const LinkRule: InlineMDRule = {
   match: (text) => text.match(LINK_REG_1),
   html: (parse, match) => {
     const [, g1, g2] = match;
+    // Checks for < and > since text comes sanitized to the parser
+    // Puts the < > outside of the object for client compatibility purposes
+    if (g2.startsWith('&lt;') && g2.endsWith('&gt;'))
+      return `<<a data-md href="${g2.substring(4, g2.lastIndexOf('&gt;'))}">${parse(g1)}</a>>`;
     return `<a data-md href="${g2}">${parse(g1)}</a>`;
   },
 };

--- a/src/app/plugins/markdown/inline/rules.ts
+++ b/src/app/plugins/markdown/inline/rules.ts
@@ -101,12 +101,15 @@ export const SpoilerRule: InlineMDRule = {
 };
 
 const LINK_ALT = `\\[${MIN_ANY}\\]`;
-const LINK_URL = `\\((https?:\\/\\/.+?)\\)`;
+const LINK_URL = `\\(((&lt;)?https?:\\/\\/.+?(&gt;)?)\\)`;
 const LINK_REG_1 = new RegExp(`${LINK_ALT}${LINK_URL}`);
 export const LinkRule: InlineMDRule = {
   match: (text) => text.match(LINK_REG_1),
   html: (parse, match) => {
     const [, g1, g2] = match;
+    // Checks for < and > since text comes sanitized to the parser
+    if (g2.startsWith('&lt;') && g2.endsWith('&gt;'))
+      return `<<a data-md href="${g2.substring(4, g2.length - 5)}">${parse(g1)}</a>>`;
     return `<a data-md href="${g2}">${parse(g1)}</a>`;
   },
 };

--- a/src/app/utils/regex.ts
+++ b/src/app/utils/regex.ts
@@ -4,7 +4,7 @@
 export const sanitizeForRegex = (unsafeText: string): string =>
   unsafeText.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 
-export const HTTP_URL_PATTERN = `<?https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
+export const HTTP_URL_PATTERN = `(<|&lt;)?https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
 
 export const URL_REG = new RegExp(HTTP_URL_PATTERN, 'g');
 

--- a/src/app/utils/regex.ts
+++ b/src/app/utils/regex.ts
@@ -4,7 +4,7 @@
 export const sanitizeForRegex = (unsafeText: string): string =>
   unsafeText.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 
-export const HTTP_URL_PATTERN = `(<|&lt;)?https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
+export const HTTP_URL_PATTERN = `https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
 
 export const URL_REG = new RegExp(HTTP_URL_PATTERN, 'g');
 

--- a/src/app/utils/regex.ts
+++ b/src/app/utils/regex.ts
@@ -4,7 +4,7 @@
 export const sanitizeForRegex = (unsafeText: string): string =>
   unsafeText.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 
-export const HTTP_URL_PATTERN = `https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
+export const HTTP_URL_PATTERN = `<?https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
 
 export const URL_REG = new RegExp(HTTP_URL_PATTERN, 'g');
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This is an implementation with the main purpose to serve as a proposal.

Currently there is no way to tell the client to not display a urlPreview if they are enabled, this PR proposes adding it by surrounding the link in angle brackets such as `<https://app.sable.moe>`, `[Sable!](<https://app.sable.moe>)`, or `<[Sable!](https://app.sable.moe)>`
The message saves the angle brackets outside of the link tag regardless to not break the links on any other client that does not have the regular hide preview mode (so regardless of whether you type `[foo](<https://bar>)` or `<[foo](https://bar)>` it will save it as `<<a data-md href='https://bar'>foo</a>>` as formatted text and `<(foo)[https://bar]>` as regular text)

I am not sure if this would count as proper markdown but it is a very useful feature on discord and order platforms that have urlPreviews in order to prevent irrelevant previews intruding in the timeline.

Additionally, the implementation is working for me in all the cases i have tested but i am not a regex person by any means so if anyone could doublecheck my work it would be greatly appreciated.

Lastly, in this implementation the angle brackets get hidden regardless of whether it is rendering the formatted_body or the body, but i am not 100% sure if the regular body should get this type of formatting.

(normal look)
<img width="828" height="699" alt="image" src="https://github.com/user-attachments/assets/9d6e0281-c4ca-4a18-aca7-ba6f3e1fa1cf" />

(new look)
<img width="817" height="256" alt="image" src="https://github.com/user-attachments/assets/ad7c4ab5-c62d-46fa-a350-1615591a0e15" />

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
A demon whispered the implementation in my ears.