### PR TITLE
Fix message forwarding by removing relation to avoid issues

### DIFF
--- a/.changeset/fix_forwarding_relations.md
+++ b/.changeset/fix_forwarding_relations.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+fix forwarding issue for users on synapse homeservers, by removing the relation

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -224,6 +224,8 @@ export function MessageForwardInternal({
         }
       : {};
     const baseContent = { ...mEvent.getContent() };
+    delete baseContent['m.relates_to']; // remove relations from the forwarded message
+    delete baseContent['m.mentions']; // remove mentions from forwarded message
     delete baseContent['com.beeper.per_message_profile']; // remove per-message profile as that could confuse clients in the target room
     let content;
     // handle privacy stuff
@@ -232,8 +234,6 @@ export function MessageForwardInternal({
       // we can still include the original message content in the body of the message, so we'll just use a fallback text/plain content with the original message body
       content = {
         ...baseContent,
-        'm.relates_to': null, // remove any relations to avoid confusion in the target room
-        'm.mentions': null, // remove mentions to avoid leaking information about users in the original room
         ...forwardedTextContent,
         'moe.sable.message.forward': {
           v: 1,
@@ -246,10 +246,6 @@ export function MessageForwardInternal({
       content = {
         ...baseContent,
         ...forwardedTextContent,
-        'm.relates_to': {
-          rel_type: 'm.reference',
-          event_id: eventId,
-        },
         'moe.sable.message.forward': {
           v: 1,
           is_forwarded: true,


### PR DESCRIPTION
### Description

This pull request fixes an issue with forwarding messages for users on Synapse homeservers by ensuring that relations and mentions are properly removed from forwarded messages. The changes focus on improving privacy and preventing confusion when messages are forwarded to other rooms.

#### Forwarding and privacy improvements

- Removed the `m.relates_to` and `m.mentions` fields from the forwarded message content to avoid leaking relations or mentions from the original message.
- Removed the addition of a new `m.relates_to` relation when constructing the forwarded message, preventing references to the original event in the forwarded message.

Fixes #539 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

no AI was used in the creation of this PR