### PR TITLE
Implement initial MSC4440 Bios with extensible events formatting

### DIFF
--- a/.changeset/feat-msc4440-bio-compat.md
+++ b/.changeset/feat-msc4440-bio-compat.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+new/changed bios will now also be saved in the format MSC4440 expects

--- a/src/app/features/settings/account/BioEditor.tsx
+++ b/src/app/features/settings/account/BioEditor.tsx
@@ -44,7 +44,7 @@ type BioEditorProps = {
   value?: string | any;
   isSaving?: boolean;
   imagePackRooms?: any[];
-  onSave: (htmlContent: string) => void;
+  onSave: (htmlContent: string, plainText: string) => void;
 };
 
 const BIO_LIMIT = 1024;
@@ -81,7 +81,7 @@ export function BioEditor({ value, isSaving, imagePackRooms, onSave }: BioEditor
       })
     );
 
-    onSave(customHtml || plainText);
+    onSave(customHtml || plainText, plainText);
     setHasChanged(false);
   }, [editor, isMarkdown, onSave]);
 

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -46,13 +46,13 @@ import { useCapabilities } from '$hooks/useCapabilities';
 import { profilesCacheAtom } from '$state/userRoomProfile';
 import { SequenceCardStyle } from '$features/settings/styles.css';
 import { useUserPresence } from '$hooks/useUserPresence';
+import { MSC1767Text } from '$types/matrix/common';
 import { TimezoneEditor } from './TimezoneEditor';
 import { PronounEditor } from './PronounEditor';
 import { BioEditor } from './BioEditor';
 import { NameColorEditor } from './NameColorEditor';
 import { StatusEditor } from './StatusEditor';
 import { AnimalCosmetics } from './AnimalCosmetics';
-import { toPlainText } from '$components/editor';
 
 type PronounSet = {
   summary: string;
@@ -582,17 +582,20 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
             profile.extended?.['chat.commet.profile_bio'] ||
             profile.bio
           }
-          onSave={(htmlBio) => {
+          onSave={(htmlBio, plainTextBio) => {
             handleSaveField('moe.sable.app.bio', htmlBio);
 
             // MSC4440
             handleSaveField('gay.fomx.biography', {
-              body: htmlBio
-                .replaceAll('<br>', '\n')
-                .replaceAll('<li>', '\n- ')
-                .replaceAll(/<[^>]*>/g, ''),
-              format: 'org.matrix.custom.html',
-              formatted_body: htmlBio,
+              'm.text': [
+                {
+                  body: htmlBio,
+                  mimetype: 'text/html',
+                } satisfies MSC1767Text,
+                {
+                  body: plainTextBio,
+                } satisfies MSC1767Text,
+              ],
             } satisfies MSC4440Bio);
 
             const cleanedHtml = htmlBio.replaceAll('<br/></blockquote>', '</blockquote>');

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -29,7 +29,7 @@ import { useSetAtom } from 'jotai';
 import { SequenceCard } from '$components/sequence-card';
 import { SettingTile } from '$components/setting-tile';
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import { UserProfile, useUserProfile } from '$hooks/useUserProfile';
+import { UserProfile, useUserProfile, MSC4440Bio } from '$hooks/useUserProfile';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
 import { UserAvatar } from '$components/user-avatar';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
@@ -52,6 +52,7 @@ import { BioEditor } from './BioEditor';
 import { NameColorEditor } from './NameColorEditor';
 import { StatusEditor } from './StatusEditor';
 import { AnimalCosmetics } from './AnimalCosmetics';
+import { toPlainText } from '$components/editor';
 
 type PronounSet = {
   summary: string;
@@ -576,12 +577,23 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
       >
         <BioEditor
           value={
+            (profile.extended?.['gay.fomx.biography'] satisfies MSC4440Bio)?.formatted_body ||
             profile.extended?.['moe.sable.app.bio'] ||
             profile.extended?.['chat.commet.profile_bio'] ||
             profile.bio
           }
           onSave={(htmlBio) => {
             handleSaveField('moe.sable.app.bio', htmlBio);
+
+            // MSC4440
+            handleSaveField('gay.fomx.biography', {
+              body: htmlBio
+                .replaceAll('<br>', '\n')
+                .replaceAll('<li>', '\n- ')
+                .replaceAll(/<[^>]*>/g, ''),
+              format: 'org.matrix.custom.html',
+              formatted_body: htmlBio,
+            } satisfies MSC4440Bio);
 
             const cleanedHtml = htmlBio.replaceAll('<br/></blockquote>', '</blockquote>');
             handleSaveField('chat.commet.profile_bio', {

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -7,14 +7,13 @@ import colorMXID from '$utils/colorMXID';
 import { profilesCacheAtom } from '$state/userRoomProfile';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
+import { MSC1767Text } from '$types/matrix/common';
 import { useMatrixClient } from './useMatrixClient';
 
 const inFlightProfiles = new Map<string, Promise<any>>();
 
 export type MSC4440Bio = {
-  body: string;
-  format: string;
-  formatted_body: string;
+  'm.text': Array<MSC1767Text>;
 };
 
 export type UserProfile = {
@@ -62,7 +61,7 @@ const normalizeInfo = (info: any): UserProfile => {
     pronouns: info['io.fsky.nyx.pronouns'],
     timezone: info['us.cloke.msc4175.tz'] || info['m.tz'],
     bio:
-      (info['gay.fomx.biography'] satisfies MSC4440Bio).formatted_body ||
+      (info['gay.fomx.biography'] satisfies MSC4440Bio)['m.text'][0].body ||
       info['moe.sable.app.bio'] ||
       info['chat.commet.profile_bio'],
     status: info['chat.commet.profile_status'],

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -11,6 +11,12 @@ import { useMatrixClient } from './useMatrixClient';
 
 const inFlightProfiles = new Map<string, Promise<any>>();
 
+export type MSC4440Bio = {
+  body: string;
+  format: string;
+  formatted_body: string;
+};
+
 export type UserProfile = {
   avatarUrl?: string;
   displayName?: string;
@@ -35,6 +41,7 @@ const normalizeInfo = (info: any): UserProfile => {
     'm.tz',
     'moe.sable.app.bio',
     'chat.commet.profile_bio',
+    'gay.fomx.biography',
     'chat.commet.profile_banner',
     'chat.commet.profile_status',
     'moe.sable.app.name_color',
@@ -54,7 +61,10 @@ const normalizeInfo = (info: any): UserProfile => {
     displayName: info.displayname,
     pronouns: info['io.fsky.nyx.pronouns'],
     timezone: info['us.cloke.msc4175.tz'] || info['m.tz'],
-    bio: info['moe.sable.app.bio'] || info['chat.commet.profile_bio'],
+    bio:
+      (info['gay.fomx.biography'] satisfies MSC4440Bio).formatted_body ||
+      info['moe.sable.app.bio'] ||
+      info['chat.commet.profile_bio'],
     status: info['chat.commet.profile_status'],
     bannerUrl: info['chat.commet.profile_banner'],
     nameColor: info['moe.sable.app.name_color'],

--- a/src/types/matrix/common.ts
+++ b/src/types/matrix/common.ts
@@ -14,6 +14,11 @@ export type IImageInfo = {
   [MATRIX_BLUR_HASH_PROPERTY_NAME]?: string;
 };
 
+export type MSC1767Text = {
+  body: string;
+  mimetype?: string;
+};
+
 export type IVideoInfo = {
   w?: number;
   h?: number;


### PR DESCRIPTION
### Description

This pull request adds support for saving and reading user bios in the MSC4440 format, improving compatibility with the MSC4440 specification for Matrix user profiles. The changes ensure that bios are now stored and retrieved in both the legacy and MSC4440-compliant formats, and introduce new types to support this functionality.

#### MSC4440 Bio Compatibility

- User bios are now saved in the MSC4440 format (`gay.fomx.biography`) in addition to existing formats, ensuring forward compatibility with the MSC4440 spec. When saving, both HTML and plain text representations are stored.
- The user profile normalization logic now reads bios from the MSC4440 field first, falling back to legacy fields if necessary.
- The fields handled by the normalization function are updated to include the MSC4440 bio key.

#### Type and Import Updates

- New types `MSC1767Text` and `MSC4440Bio` are introduced to represent the MSC4440 bio format, and relevant imports are updated throughout the codebase.

implements https://github.com/matrix-org/matrix-spec-proposals/pull/4440

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

No AI was used in the creation of this PR