### PR TITLE
Fix unsanitized HTML in reply renderer

### DIFF
--- a/.changeset/fix-reply-renderer-sanitizer.md
+++ b/.changeset/fix-reply-renderer-sanitizer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Sanitize formatted reply previews before rendering to prevent unsafe HTML from being parsed in reply snippets.

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -25,6 +25,7 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useMemberEventParser } from '$hooks/useMemberEventParser';
 import { StateEvent, MessageEvent } from '$types/matrix/room';
 import { useMentionClickHandler } from '$hooks/useMentionClickHandler';
+import { sanitizeCustomHtml } from '$utils/sanitize';
 import { useTranslation } from 'react-i18next';
 import * as customHtmlCss from '$styles/CustomHtml.css';
 import {
@@ -89,6 +90,18 @@ type ReplyProps = {
   mentions?: IMentions;
   onClick?: MouseEventHandler;
   replyIcon?: JSX.Element;
+};
+
+export const sanitizeReplyFormattedPreview = (formattedBody: string): string => {
+  const strippedHtml = trimReplyFromFormattedBody(formattedBody)
+    .replaceAll(/<br\s*\/?>/gi, ' ')
+    .replaceAll(/<\/p>\s*<p[^>]*>/gi, ' ')
+    .replaceAll(/<\/?p[^>]*>/gi, '')
+    .replaceAll(/<\/li>\s*<li[^>]*>/gi, ' ')
+    .replaceAll(/<\/?(ul|ol|li|blockquote|h[1-6]|pre|div)[^>]*>/gi, '')
+    .replaceAll(/(?:\r\n|\r|\n)/g, ' ');
+
+  return sanitizeCustomHtml(strippedHtml);
 };
 
 export const Reply = as<'div', ReplyProps>(
@@ -158,20 +171,14 @@ export const Reply = as<'div', ReplyProps>(
     );
 
     if (format === 'org.matrix.custom.html' && formattedBody) {
-      const strippedHtml = trimReplyFromFormattedBody(formattedBody)
-        .replaceAll(/<br\s*\/?>/gi, ' ')
-        .replaceAll(/<\/p>\s*<p[^>]*>/gi, ' ')
-        .replaceAll(/<\/?p[^>]*>/gi, '')
-        .replaceAll(/<\/li>\s*<li[^>]*>/gi, ' ')
-        .replaceAll(/<\/?(ul|ol|li|blockquote|h[1-6]|pre|div)[^>]*>/gi, '')
-        .replaceAll(/(?:\r\n|\r|\n)/g, ' ');
+      const sanitizedHtml = sanitizeReplyFormattedPreview(formattedBody);
       const parserOpts = getReactCustomHtmlParser(mx, room.roomId, {
         linkifyOpts: replyLinkifyOpts,
         useAuthentication,
         nicknames,
         handleMentionClick: mentionClickHandler,
       });
-      bodyJSX = parse(strippedHtml, parserOpts) as JSX.Element;
+      bodyJSX = parse(sanitizedHtml, parserOpts) as JSX.Element;
     } else if (body) {
       const strippedBody = trimReplyFromBody(body).replaceAll(/(?:\r\n|\r|\n)/g, ' ');
       bodyJSX = scaleSystemEmoji(strippedBody);

--- a/src/app/components/message/ThreadIndicator.test.tsx
+++ b/src/app/components/message/ThreadIndicator.test.tsx
@@ -14,7 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { RelationType } from '$types/matrix-sdk';
-import { ThreadIndicator } from './Reply';
+import { sanitizeReplyFormattedPreview, ThreadIndicator } from './Reply';
 
 function Subject({ relType, threadRootId }: { relType?: string; threadRootId?: string }) {
   return <>{relType === RelationType.Thread && !threadRootId && <ThreadIndicator />}</>;
@@ -39,5 +39,29 @@ describe('ThreadIndicator visibility in compose strip', () => {
   it('is hidden for a non-thread relation type', () => {
     render(<Subject relType="m.in_reply_to" />);
     expect(screen.queryByText('Thread')).not.toBeInTheDocument();
+  });
+});
+
+describe('sanitizeReplyFormattedPreview', () => {
+  it('removes mx-reply quote block content and keeps message text', () => {
+    const html =
+      '<mx-reply><blockquote>quoted</blockquote></mx-reply><p>Visible message</p>';
+
+    const result = sanitizeReplyFormattedPreview(html);
+
+    expect(result).not.toContain('quoted');
+    expect(result).toContain('Visible message');
+  });
+
+  it('sanitizes dangerous HTML before parse', () => {
+    const html =
+      '<mx-reply><blockquote>old</blockquote></mx-reply><p>safe<script>alert(1)</script></p><a href="javascript:alert(1)">x</a>';
+
+    const result = sanitizeReplyFormattedPreview(html);
+
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('alert(1)');
+    expect(result).not.toContain('javascript:');
+    expect(result).toContain('safe');
   });
 });

--- a/src/app/components/message/ThreadIndicator.test.tsx
+++ b/src/app/components/message/ThreadIndicator.test.tsx
@@ -44,8 +44,7 @@ describe('ThreadIndicator visibility in compose strip', () => {
 
 describe('sanitizeReplyFormattedPreview', () => {
   it('removes mx-reply quote block content and keeps message text', () => {
-    const html =
-      '<mx-reply><blockquote>quoted</blockquote></mx-reply><p>Visible message</p>';
+    const html = '<mx-reply><blockquote>quoted</blockquote></mx-reply><p>Visible message</p>';
 
     const result = sanitizeReplyFormattedPreview(html);
 
@@ -55,13 +54,13 @@ describe('sanitizeReplyFormattedPreview', () => {
 
   it('sanitizes dangerous HTML before parse', () => {
     const html =
-      '<mx-reply><blockquote>old</blockquote></mx-reply><p>safe<script>alert(1)</script></p><a href="javascript:alert(1)">x</a>';
+      '<mx-reply><blockquote>old</blockquote></mx-reply><p>safe<script>alert(1)</script></p><a href="https://example.org" onclick="alert(1)">x</a>';
 
     const result = sanitizeReplyFormattedPreview(html);
 
     expect(result).not.toContain('<script');
     expect(result).not.toContain('alert(1)');
-    expect(result).not.toContain('javascript:');
+    expect(result).not.toContain('onclick=');
     expect(result).toContain('safe');
   });
 });


### PR DESCRIPTION
### Description

Fix reply preview rendering so formatted reply content is sanitized before React HTML parsing.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI-assisted parts:
- Extracted `sanitizeReplyFormattedPreview()` in `Reply.tsx` so formatted reply previews are always sanitized before parsing.
- Added regression tests in `ThreadIndicator.test.tsx` for quote stripping and sanitizer behavior.
- Adjusted the test payload and formatting to satisfy lint and prettier checks.
