### PR TITLE
feat(flags): build-time client config overrides via Feature Flags

### DIFF
--- a/.changeset/feature-flag-env-vars.md
+++ b/.changeset/feature-flag-env-vars.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add build-time client config overrides via environment variables, with typed deterministic experiment bucketing helpers for progressive feature rollout and A/B testing.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -34,6 +34,36 @@ runs:
       env:
         INPUTS_INSTALL_COMMAND: ${{ inputs.install-command }}
 
+    - name: Inject runtime config overrides
+      if: ${{ env.CLIENT_CONFIG_OVERRIDES_JSON != '' }}
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: node scripts/inject-client-config.js
+      env:
+        CLIENT_CONFIG_OVERRIDES_JSON: ${{ env.CLIENT_CONFIG_OVERRIDES_JSON }}
+        CLIENT_CONFIG_OVERRIDES_STRICT: ${{ env.CLIENT_CONFIG_OVERRIDES_STRICT }}
+
+    - name: Display injected config
+      if: ${{ env.CLIENT_CONFIG_OVERRIDES_JSON != '' }}
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        summary_file="${GITHUB_STEP_SUMMARY:-}"
+        echo "::group::Injected Client Config"
+        experiments_json="$(jq -c '.experiments // "No experiments configured"' config.json 2>/dev/null || echo 'config.json not readable')"
+        echo "$experiments_json"
+        echo "::endgroup::"
+
+        if [[ -n "$summary_file" ]]; then
+          {
+            echo "### Injected client config"
+            echo
+            echo "\`\`\`json"
+            echo "$experiments_json"
+            echo "\`\`\`"
+          } >> "$summary_file"
+        fi
+
     - name: Build app
       if: ${{ inputs.build == 'true' }}
       shell: bash

--- a/.github/workflows/cloudflare-web-deploy.yml
+++ b/.github/workflows/cloudflare-web-deploy.yml
@@ -40,6 +40,10 @@ jobs:
   plan:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    environment: preview
+    env:
+      CLIENT_CONFIG_OVERRIDES_JSON: ${{ vars.CLIENT_CONFIG_OVERRIDES_JSON }}
+      CLIENT_CONFIG_OVERRIDES_STRICT: ${{ vars.CLIENT_CONFIG_OVERRIDES_STRICT || 'false' }}
     permissions:
       contents: read
       pull-requests: write
@@ -73,6 +77,10 @@ jobs:
   apply:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLIENT_CONFIG_OVERRIDES_JSON: ${{ vars.CLIENT_CONFIG_OVERRIDES_JSON }}
+      CLIENT_CONFIG_OVERRIDES_STRICT: ${{ vars.CLIENT_CONFIG_OVERRIDES_STRICT || 'false' }}
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/cloudflare-web-preview.yml
+++ b/.github/workflows/cloudflare-web-preview.yml
@@ -32,9 +32,13 @@ jobs:
   deploy:
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: preview
     permissions:
       contents: read
       pull-requests: write
+    env:
+      CLIENT_CONFIG_OVERRIDES_JSON: ${{ vars.CLIENT_CONFIG_OVERRIDES_JSON }}
+      CLIENT_CONFIG_OVERRIDES_STRICT: ${{ vars.CLIENT_CONFIG_OVERRIDES_STRICT || 'false' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/sw.ts", "scripts/normalize-imports.js"],
+  "entry": ["src/sw.ts", "scripts/normalize-imports.js", "scripts/inject-client-config.js"],
   "ignoreExportsUsedInFile": {
     "interface": true,
     "type": true

--- a/scripts/inject-client-config.js
+++ b/scripts/inject-client-config.js
@@ -1,0 +1,71 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+import { PrefixedLogger } from './utils/console-style.js';
+
+const CONFIG_PATH = 'config.json';
+const OVERRIDES_ENV = 'CLIENT_CONFIG_OVERRIDES_JSON';
+const STRICT_ENV = 'CLIENT_CONFIG_OVERRIDES_STRICT';
+const logger = new PrefixedLogger('[config-inject]');
+
+const formatError = (error) => {
+  if (error instanceof Error) return error.stack ?? error.message;
+  return String(error);
+};
+
+const isPlainObject = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const deepMerge = (target, source) => {
+  if (!isPlainObject(target) || !isPlainObject(source)) return source;
+
+  const merged = { ...target };
+  Object.entries(source).forEach(([key, value]) => {
+    const targetValue = merged[key];
+    merged[key] =
+      isPlainObject(targetValue) && isPlainObject(value) ? deepMerge(targetValue, value) : value;
+  });
+  return merged;
+};
+
+const failOnError = process.env[STRICT_ENV] === 'true';
+const overridesRaw = process.env[OVERRIDES_ENV];
+
+if (!overridesRaw) {
+  logger.info(`No ${OVERRIDES_ENV} provided; leaving ${CONFIG_PATH} unchanged.`);
+  process.exit(0);
+}
+
+let fileConfig;
+let overrides;
+
+try {
+  const file = await readFile(CONFIG_PATH, 'utf8');
+  fileConfig = JSON.parse(file);
+} catch (error) {
+  logger.error(`Failed reading ${CONFIG_PATH}: ${formatError(error)}`);
+  process.exit(1);
+}
+
+try {
+  overrides = JSON.parse(overridesRaw);
+  if (!isPlainObject(overrides)) {
+    throw new Error(`${OVERRIDES_ENV} must be a JSON object.`);
+  }
+} catch (error) {
+  const message = `[config-inject] Invalid ${OVERRIDES_ENV}; ${
+    failOnError ? 'failing build' : 'skipping overrides'
+  }.`;
+  if (failOnError) {
+    logger.error(`${message} ${formatError(error)}`);
+    process.exit(1);
+  }
+  logger.info(`[warning] ${message} ${formatError(error)}`);
+  process.exit(0);
+}
+
+const mergedConfig = deepMerge(fileConfig, overrides);
+
+await writeFile(CONFIG_PATH, `${JSON.stringify(mergedConfig, null, 2)}\n`, 'utf8');
+logger.info(
+  `Applied overrides to ${CONFIG_PATH}. Top-level keys: ${Object.keys(overrides).join(', ')}`
+);

--- a/scripts/inject-client-config.js
+++ b/scripts/inject-client-config.js
@@ -15,11 +15,15 @@ const formatError = (error) => {
 const isPlainObject = (value) =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+// Keys that could trigger prototype pollution via bracket assignment.
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 const deepMerge = (target, source) => {
   if (!isPlainObject(target) || !isPlainObject(source)) return source;
 
   const merged = { ...target };
   Object.entries(source).forEach(([key, value]) => {
+    if (UNSAFE_KEYS.has(key)) return;
     const targetValue = merged[key];
     merged[key] =
       isPlainObject(targetValue) && isPlainObject(value) ? deepMerge(targetValue, value) : value;

--- a/src/app/features/settings/developer-tools/DevelopTools.tsx
+++ b/src/app/features/settings/developer-tools/DevelopTools.tsx
@@ -12,6 +12,7 @@ import { SequenceCardStyle } from '$features/settings/styles.css';
 import { SettingsSectionPage } from '../SettingsSectionPage';
 import { AccountData } from './AccountData';
 import { SyncDiagnostics } from './SyncDiagnostics';
+import { ExperimentsPanel } from './ExperimentsPanel';
 import { DebugLogViewer } from './DebugLogViewer';
 import { SentrySettings } from './SentrySettings';
 
@@ -109,6 +110,7 @@ export function DeveloperTools({ requestBack, requestClose }: DeveloperToolsProp
                 )}
               </Box>
               {developerTools && <SyncDiagnostics />}
+              {developerTools && <ExperimentsPanel />}
               {developerTools && (
                 <AccountData
                   expand={expand}

--- a/src/app/features/settings/developer-tools/ExperimentsPanel.tsx
+++ b/src/app/features/settings/developer-tools/ExperimentsPanel.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { Box, Text, color } from 'folds';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useClientConfig, selectExperimentVariant } from '$hooks/useClientConfig';
+import { SequenceCard } from '$components/sequence-card';
+import { SettingTile } from '$components/setting-tile';
+import { SequenceCardStyle } from '$features/settings/styles.css';
+
+export function ExperimentsPanel() {
+  const mx = useMatrixClient();
+  const config = useClientConfig();
+  const userId = mx.getUserId() ?? undefined;
+
+  const experiments = useMemo(() => {
+    if (!config.experiments) return [];
+    return Object.entries(config.experiments).map(([key, experimentConfig]) => ({
+      key,
+      config: experimentConfig,
+      selection: selectExperimentVariant(key, experimentConfig, userId),
+    }));
+  }, [config.experiments, userId]);
+
+  if (experiments.length === 0) {
+    return (
+      <Box direction="Column" gap="100">
+        <Text size="L400">Features & Experiments</Text>
+        <Text size="T200" style={{ color: color.Secondary.Main }}>
+          No experiments configured
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box direction="Column" gap="100">
+      <Text size="L400">Features & Experiments</Text>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        {experiments.map(({ key, config: experimentConfig, selection }) => (
+          <SettingTile key={key} title={key}>
+            <Box direction="Column" gap="200">
+              <Box direction="Row" gap="300">
+                <Text size="T200">
+                  <strong>Enabled:</strong>
+                </Text>
+                <Text
+                  size="T200"
+                  style={{
+                    color: selection.enabled ? color.Success.Main : color.Secondary.Main,
+                  }}
+                >
+                  {selection.enabled ? 'Yes' : 'No'}
+                </Text>
+              </Box>
+              {selection.enabled && (
+                <>
+                  <Box direction="Row" gap="300">
+                    <Text size="T200">
+                      <strong>Rollout:</strong>
+                    </Text>
+                    <Text size="T200">{selection.rolloutPercentage}%</Text>
+                  </Box>
+                  <Box direction="Row" gap="300">
+                    <Text size="T200">
+                      <strong>Your Variant:</strong>
+                    </Text>
+                    <Text
+                      size="T200"
+                      style={{
+                        color: selection.inExperiment ? color.Success.Main : color.Secondary.Main,
+                      }}
+                    >
+                      {selection.variant}
+                      {selection.inExperiment && ' (in experiment)'}
+                      {!selection.inExperiment && ' (control)'}
+                    </Text>
+                  </Box>
+                  {experimentConfig.variants && experimentConfig.variants.length > 0 && (
+                    <Box direction="Row" gap="300">
+                      <Text size="T200">
+                        <strong>Treatment Variants:</strong>
+                      </Text>
+                      <Text size="T200">
+                        {experimentConfig.variants
+                          .filter((v) => v !== experimentConfig.controlVariant)
+                          .join(', ')}
+                      </Text>
+                    </Box>
+                  )}
+                </>
+              )}
+            </Box>
+          </SettingTile>
+        ))}
+      </SequenceCard>
+    </Box>
+  );
+}

--- a/src/app/features/settings/developer-tools/ExperimentsPanel.tsx
+++ b/src/app/features/settings/developer-tools/ExperimentsPanel.tsx
@@ -41,7 +41,7 @@ export function ExperimentsPanel() {
         gap="400"
       >
         {experiments.map(({ key, config: experimentConfig, selection }) => (
-          <SettingTile key={key} title={key}>
+          <SettingTile key={key} focusId={`experiment-${key}`} title={key}>
             <Box direction="Column" gap="200">
               <Box direction="Row" gap="300">
                 <Text size="T200">

--- a/src/app/hooks/useClientConfig.test.ts
+++ b/src/app/hooks/useClientConfig.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { selectExperimentVariant, type ExperimentConfig } from './useClientConfig';
+
+const baseExperiment: ExperimentConfig = {
+  enabled: true,
+  rolloutPercentage: 100,
+  controlVariant: 'control',
+  variants: ['alpha', 'beta'],
+};
+
+describe('selectExperimentVariant', () => {
+  it('returns control when experiment is disabled', () => {
+    const result = selectExperimentVariant(
+      'threadUI',
+      { ...baseExperiment, enabled: false },
+      '@alice:example.org'
+    );
+
+    expect(result.inExperiment).toBe(false);
+    expect(result.variant).toBe('control');
+  });
+
+  it('returns control when subject id is missing', () => {
+    const result = selectExperimentVariant('threadUI', baseExperiment, undefined);
+
+    expect(result.inExperiment).toBe(false);
+    expect(result.variant).toBe('control');
+  });
+
+  it('returns control when rollout is 0', () => {
+    const result = selectExperimentVariant(
+      'threadUI',
+      { ...baseExperiment, rolloutPercentage: 0 },
+      '@alice:example.org'
+    );
+
+    expect(result.inExperiment).toBe(false);
+    expect(result.variant).toBe('control');
+    expect(result.rolloutPercentage).toBe(0);
+  });
+
+  it('normalizes rollout less than 0 to 0', () => {
+    const result = selectExperimentVariant(
+      'threadUI',
+      { ...baseExperiment, rolloutPercentage: -10 },
+      '@alice:example.org'
+    );
+
+    expect(result.inExperiment).toBe(false);
+    expect(result.variant).toBe('control');
+    expect(result.rolloutPercentage).toBe(0);
+  });
+
+  it('normalizes rollout greater than 100 to 100', () => {
+    const result = selectExperimentVariant(
+      'threadUI',
+      { ...baseExperiment, rolloutPercentage: 999 },
+      '@alice:example.org'
+    );
+
+    expect(result.inExperiment).toBe(true);
+    expect(result.rolloutPercentage).toBe(100);
+    expect(['alpha', 'beta']).toContain(result.variant);
+  });
+
+  it('falls back to control when variants are missing after filtering', () => {
+    const result = selectExperimentVariant(
+      'threadUI',
+      {
+        ...baseExperiment,
+        variants: ['', 'control'],
+      },
+      '@alice:example.org'
+    );
+
+    expect(result.inExperiment).toBe(false);
+    expect(result.variant).toBe('control');
+  });
+
+  it('is deterministic for the same key and subject', () => {
+    const first = selectExperimentVariant('threadUI', baseExperiment, '@alice:example.org');
+    const second = selectExperimentVariant('threadUI', baseExperiment, '@alice:example.org');
+
+    expect(second).toEqual(first);
+  });
+
+  it('uses default control variant when none is provided', () => {
+    const result = selectExperimentVariant(
+      'threadUI',
+      {
+        enabled: true,
+        rolloutPercentage: 100,
+        variants: ['alpha'],
+      },
+      '@alice:example.org'
+    );
+
+    expect(result.inExperiment).toBe(true);
+    expect(result.variant).toBe('alpha');
+  });
+});

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -5,6 +5,21 @@ export type HashRouterConfig = {
   basename?: string;
 };
 
+export type ExperimentConfig = {
+  enabled?: boolean;
+  rolloutPercentage?: number;
+  variants?: string[];
+  controlVariant?: string;
+};
+
+export type ExperimentSelection = {
+  key: string;
+  enabled: boolean;
+  rolloutPercentage: number;
+  variant: string;
+  inExperiment: boolean;
+};
+
 export type ClientConfig = {
   defaultHomeserver?: number;
   homeserverList?: string[];
@@ -13,6 +28,8 @@ export type ClientConfig = {
 
   disableAccountSwitcher?: boolean;
   hideUsernamePasswordFields?: boolean;
+
+  experiments?: Record<string, ExperimentConfig>;
 
   pushNotificationDetails?: {
     pushNotifyUrl?: string;
@@ -54,6 +71,74 @@ export function useClientConfig(): ClientConfig {
   if (!config) throw new Error('Client config are not provided!');
   return config;
 }
+
+const DEFAULT_CONTROL_VARIANT = 'control';
+
+const normalizeRolloutPercentage = (value?: number): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 100;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+};
+
+const hashToUInt32 = (input: string): number => {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 131 + input.charCodeAt(index)) % 4294967291;
+  }
+  return hash;
+};
+
+export const selectExperimentVariant = (
+  key: string,
+  experiment: ExperimentConfig | undefined,
+  subjectId: string | undefined
+): ExperimentSelection => {
+  const controlVariant = experiment?.controlVariant ?? DEFAULT_CONTROL_VARIANT;
+  const variants = (experiment?.variants?.filter((variant) => variant.length > 0) ?? []).filter(
+    (variant) => variant !== controlVariant
+  );
+
+  const enabled = Boolean(experiment?.enabled);
+  const rolloutPercentage = normalizeRolloutPercentage(experiment?.rolloutPercentage);
+
+  if (!enabled || !subjectId || variants.length === 0 || rolloutPercentage === 0) {
+    return {
+      key,
+      enabled,
+      rolloutPercentage,
+      variant: controlVariant,
+      inExperiment: false,
+    };
+  }
+
+  // Two independent hashes keep rollout and variant assignment stable but decorrelated.
+  const rolloutBucket = hashToUInt32(`${key}:rollout:${subjectId}`) % 10000;
+  const rolloutCutoff = Math.floor(rolloutPercentage * 100);
+  if (rolloutBucket >= rolloutCutoff) {
+    return {
+      key,
+      enabled,
+      rolloutPercentage,
+      variant: controlVariant,
+      inExperiment: false,
+    };
+  }
+
+  const variantIndex = hashToUInt32(`${key}:variant:${subjectId}`) % variants.length;
+  return {
+    key,
+    enabled,
+    rolloutPercentage,
+    variant: variants[variantIndex],
+    inExperiment: true,
+  };
+};
+
+export const useExperimentVariant = (key: string, subjectId?: string): ExperimentSelection => {
+  const clientConfig = useClientConfig();
+  return selectExperimentVariant(key, clientConfig.experiments?.[key], subjectId);
+};
 
 export const clientDefaultServer = (clientConfig: ClientConfig): string =>
   clientConfig.homeserverList?.[clientConfig.defaultHomeserver ?? 0] ?? 'matrix.org';


### PR DESCRIPTION
📝 **Docs PR:** SableClient/docs#8 — merge that when merging this.

---

### Description

Adds build-time runtime-config override support so config.json can be controlled per GitHub Environment without source edits. This is the shared infrastructure for staged rollout experiments.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
The injector script and workflow wiring were partially AI assisted. I reviewed deep-merge behavior, failure modes, and no-op safety when vars are absent.

### What this PR adds

- Build-time config injector script that merges environment overrides into config.json
- Workflow wiring so preview and production use their own GitHub Environment variables
- Typed experiment selection helpers for deterministic bucketing
- Safe fallback behavior when environment variables are missing

### Why this implementation is useful

- Removes code-change churn for rollout changes. Product/ops can adjust percentages and experiment toggles by environment variables instead of opening code PRs for every percentage change.
- Enables safer progressive delivery. Preview can run at 100% while production starts low and ramps gradually.
- Supports consistent experiment assignment. Deterministic bucketing keeps users stable in control/treatment cohorts across sessions.
- Reduces deployment risk. If override variables are missing, malformed, or intentionally disabled, builds still fall back to checked-in defaults.
- Improves incident response. Feature rollbacks become a config operation rather than a code revert/redeploy cycle.
- Keeps app code and release controls separated. The app reads typed config while CI/environment owns operational rollout state.

### Environment variables and what they do

Required variable:

- `CLIENT_CONFIG_OVERRIDES_JSON` — JSON object deep-merged into config.json at build time
- `CLIENT_CONFIG_OVERRIDES_STRICT` — set to `"true"` to fail the build on malformed JSON rather than warn