### PR TITLE
feat(session-sync): phased SW resync with experiment-ready config

### DIFF
--- a/.changeset/sw-session-resync-flags.md
+++ b/.changeset/sw-session-resync-flags.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add phased service-worker session re-sync controls (foreground resync, visible heartbeat, adaptive backoff/jitter).

--- a/config.json
+++ b/config.json
@@ -15,8 +15,27 @@
 
   "settingsLinkBaseUrl": "https://app.sable.moe",
 
+  "experiments": {
+    "sessionSyncStrategy": {
+      "enabled": false,
+      "rolloutPercentage": 0,
+      "controlVariant": "control",
+      "variants": ["session-sync-heartbeat", "session-sync-adaptive"]
+    }
+  },
+
   "slidingSync": {
     "enabled": true
+  },
+
+  "sessionSync": {
+    "phase1ForegroundResync": false,
+    "phase2VisibleHeartbeat": false,
+    "phase3AdaptiveBackoffJitter": false,
+    "foregroundDebounceMs": 1500,
+    "heartbeatIntervalMs": 600000,
+    "resumeHeartbeatSuppressMs": 60000,
+    "heartbeatMaxBackoffMs": 1800000
   },
 
   "featuredCommunities": {

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -1,22 +1,111 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { MatrixClient } from '$types/matrix-sdk';
+import { Session } from '$state/sessions';
 import { useAtom } from 'jotai';
 import { togglePusher } from '../features/settings/notifications/PushNotifications';
 import { appEvents } from '../utils/appEvents';
-import { useClientConfig } from './useClientConfig';
+import { useClientConfig, useExperimentVariant } from './useClientConfig';
 import { useSetting } from '../state/hooks/settings';
 import { settingsAtom } from '../state/settings';
 import { pushSubscriptionAtom } from '../state/pushSubscription';
 import { mobileOrTablet } from '../utils/user-agent';
 import { createDebugLogger } from '../utils/debugLogger';
+import { pushSessionToSW } from '../../sw-session';
 
 const debugLog = createDebugLogger('AppVisibility');
 
-export function useAppVisibility(mx: MatrixClient | undefined) {
+const DEFAULT_FOREGROUND_DEBOUNCE_MS = 1500;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;
+const DEFAULT_RESUME_HEARTBEAT_SUPPRESS_MS = 60 * 1000;
+const DEFAULT_HEARTBEAT_MAX_BACKOFF_MS = 30 * 60 * 1000;
+
+export function useAppVisibility(mx: MatrixClient | undefined, activeSession?: Session) {
   const clientConfig = useClientConfig();
   const [usePushNotifications] = useSetting(settingsAtom, 'usePushNotifications');
   const pushSubAtom = useAtom(pushSubscriptionAtom);
   const isMobile = mobileOrTablet();
+
+  const sessionSyncConfig = clientConfig.sessionSync;
+  const sessionSyncVariant = useExperimentVariant('sessionSyncStrategy', activeSession?.userId);
+
+  // Derive phase flags from experiment variant; fall back to direct config when not in experiment.
+  const inSessionSync = sessionSyncVariant.inExperiment;
+  const syncVariant = sessionSyncVariant.variant;
+  const phase1ForegroundResync = inSessionSync
+    ? syncVariant === 'session-sync-heartbeat' || syncVariant === 'session-sync-adaptive'
+    : sessionSyncConfig?.phase1ForegroundResync === true;
+  const phase2VisibleHeartbeat = inSessionSync
+    ? syncVariant === 'session-sync-heartbeat' || syncVariant === 'session-sync-adaptive'
+    : sessionSyncConfig?.phase2VisibleHeartbeat === true;
+  const phase3AdaptiveBackoffJitter = inSessionSync
+    ? syncVariant === 'session-sync-adaptive'
+    : sessionSyncConfig?.phase3AdaptiveBackoffJitter === true;
+
+  const foregroundDebounceMs = Math.max(
+    0,
+    sessionSyncConfig?.foregroundDebounceMs ?? DEFAULT_FOREGROUND_DEBOUNCE_MS
+  );
+  const heartbeatIntervalMs = Math.max(
+    1000,
+    sessionSyncConfig?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS
+  );
+  const resumeHeartbeatSuppressMs = Math.max(
+    0,
+    sessionSyncConfig?.resumeHeartbeatSuppressMs ?? DEFAULT_RESUME_HEARTBEAT_SUPPRESS_MS
+  );
+  const heartbeatMaxBackoffMs = Math.max(
+    heartbeatIntervalMs,
+    sessionSyncConfig?.heartbeatMaxBackoffMs ?? DEFAULT_HEARTBEAT_MAX_BACKOFF_MS
+  );
+
+  const lastForegroundPushAtRef = useRef(0);
+  const suppressHeartbeatUntilRef = useRef(0);
+  const heartbeatFailuresRef = useRef(0);
+
+  const pushSessionNow = useCallback(
+    (reason: 'foreground' | 'focus' | 'heartbeat'): 'sent' | 'skipped' => {
+      const baseUrl = activeSession?.baseUrl;
+      const accessToken = activeSession?.accessToken;
+      const userId = activeSession?.userId;
+      const canPush =
+        !!mx &&
+        typeof baseUrl === 'string' &&
+        typeof accessToken === 'string' &&
+        typeof userId === 'string' &&
+        'serviceWorker' in navigator &&
+        !!navigator.serviceWorker.controller;
+
+      if (!canPush) {
+        debugLog.warn('network', 'Skipped SW session sync', {
+          reason,
+          hasClient: !!mx,
+          hasBaseUrl: !!baseUrl,
+          hasAccessToken: !!accessToken,
+          hasUserId: !!userId,
+          hasSwController: !!navigator.serviceWorker?.controller,
+        });
+        return 'skipped';
+      }
+
+      pushSessionToSW(baseUrl, accessToken, userId);
+      debugLog.info('network', 'Pushed session to SW', {
+        reason,
+        phase1ForegroundResync,
+        phase2VisibleHeartbeat,
+        phase3AdaptiveBackoffJitter,
+      });
+      return 'sent';
+    },
+    [
+      activeSession?.accessToken,
+      activeSession?.baseUrl,
+      activeSession?.userId,
+      mx,
+      phase1ForegroundResync,
+      phase2VisibleHeartbeat,
+      phase3AdaptiveBackoffJitter,
+    ]
+  );
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -29,15 +118,56 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
       appEvents.onVisibilityChange?.(isVisible);
       if (!isVisible) {
         appEvents.onVisibilityHidden?.();
+        return;
+      }
+
+      if (!phase1ForegroundResync) return;
+
+      const now = Date.now();
+      if (now - lastForegroundPushAtRef.current < foregroundDebounceMs) return;
+      lastForegroundPushAtRef.current = now;
+
+      if (
+        pushSessionNow('foreground') === 'sent' &&
+        phase3AdaptiveBackoffJitter &&
+        phase2VisibleHeartbeat
+      ) {
+        suppressHeartbeatUntilRef.current = now + resumeHeartbeatSuppressMs;
+      }
+    };
+
+    const handleFocus = () => {
+      if (!phase1ForegroundResync) return;
+      if (document.visibilityState !== 'visible') return;
+
+      const now = Date.now();
+      if (now - lastForegroundPushAtRef.current < foregroundDebounceMs) return;
+      lastForegroundPushAtRef.current = now;
+
+      if (
+        pushSessionNow('focus') === 'sent' &&
+        phase3AdaptiveBackoffJitter &&
+        phase2VisibleHeartbeat
+      ) {
+        suppressHeartbeatUntilRef.current = now + resumeHeartbeatSuppressMs;
       }
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleFocus);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleFocus);
     };
-  }, []);
+  }, [
+    foregroundDebounceMs,
+    phase1ForegroundResync,
+    phase2VisibleHeartbeat,
+    phase3AdaptiveBackoffJitter,
+    pushSessionNow,
+    resumeHeartbeatSuppressMs,
+  ]);
 
   useEffect(() => {
     if (!mx) return;
@@ -52,4 +182,65 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
       appEvents.onVisibilityChange = null;
     };
   }, [mx, clientConfig, usePushNotifications, pushSubAtom, isMobile]);
+
+  useEffect(() => {
+    if (!phase2VisibleHeartbeat) return undefined;
+
+    // Reset adaptive backoff/suppression so a config or session change starts fresh.
+    heartbeatFailuresRef.current = 0;
+    suppressHeartbeatUntilRef.current = 0;
+
+    let timeoutId: number | undefined;
+
+    const getDelayMs = (): number => {
+      let delay = heartbeatIntervalMs;
+
+      if (phase3AdaptiveBackoffJitter) {
+        const failures = heartbeatFailuresRef.current;
+        const backoffFactor = Math.min(2 ** failures, heartbeatMaxBackoffMs / heartbeatIntervalMs);
+        delay = Math.min(heartbeatMaxBackoffMs, Math.round(heartbeatIntervalMs * backoffFactor));
+
+        // Add +-20% jitter to avoid synchronized heartbeat spikes across many clients.
+        const jitter = 0.8 + Math.random() * 0.4;
+        delay = Math.max(1000, Math.round(delay * jitter));
+      }
+
+      return delay;
+    };
+
+    const tick = () => {
+      const now = Date.now();
+
+      if (document.visibilityState !== 'visible' || !navigator.onLine) {
+        timeoutId = window.setTimeout(tick, getDelayMs());
+        return;
+      }
+
+      if (phase3AdaptiveBackoffJitter && now < suppressHeartbeatUntilRef.current) {
+        timeoutId = window.setTimeout(tick, getDelayMs());
+        return;
+      }
+
+      const result = pushSessionNow('heartbeat');
+      if (phase3AdaptiveBackoffJitter) {
+        // Only reset on a successful send; 'skipped' (prerequisites not ready)
+        // should not grow the backoff — those aren't push failures.
+        if (result === 'sent') heartbeatFailuresRef.current = 0;
+      }
+
+      timeoutId = window.setTimeout(tick, getDelayMs());
+    };
+
+    timeoutId = window.setTimeout(tick, getDelayMs());
+
+    return () => {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+    };
+  }, [
+    heartbeatIntervalMs,
+    heartbeatMaxBackoffMs,
+    phase2VisibleHeartbeat,
+    phase3AdaptiveBackoffJitter,
+    pushSessionNow,
+  ]);
 }

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -121,6 +121,10 @@ export function useAppVisibility(mx: MatrixClient | undefined, activeSession?: S
         return;
       }
 
+      // Always kick the sync loop on foreground regardless of phase flags —
+      // the SDK may be sitting in exponential backoff after iOS froze the tab.
+      mx?.retryImmediately();
+
       if (!phase1ForegroundResync) return;
 
       const now = Date.now();
@@ -137,8 +141,12 @@ export function useAppVisibility(mx: MatrixClient | undefined, activeSession?: S
     };
 
     const handleFocus = () => {
-      if (!phase1ForegroundResync) return;
       if (document.visibilityState !== 'visible') return;
+
+      // Always kick the sync loop on focus for the same reason as above.
+      mx?.retryImmediately();
+
+      if (!phase1ForegroundResync) return;
 
       const now = Date.now();
       if (now - lastForegroundPushAtRef.current < foregroundDebounceMs) return;
@@ -162,6 +170,7 @@ export function useAppVisibility(mx: MatrixClient | undefined, activeSession?: S
     };
   }, [
     foregroundDebounceMs,
+    mx,
     phase1ForegroundResync,
     phase2VisibleHeartbeat,
     phase3AdaptiveBackoffJitter,
@@ -223,9 +232,13 @@ export function useAppVisibility(mx: MatrixClient | undefined, activeSession?: S
 
       const result = pushSessionNow('heartbeat');
       if (phase3AdaptiveBackoffJitter) {
-        // Only reset on a successful send; 'skipped' (prerequisites not ready)
-        // should not grow the backoff — those aren't push failures.
-        if (result === 'sent') heartbeatFailuresRef.current = 0;
+        if (result === 'sent') {
+          heartbeatFailuresRef.current = 0;
+        } else {
+          // 'skipped' means prerequisites (SW controller, session) aren't ready.
+          // Treat as a transient failure so backoff grows until the SW is ready.
+          heartbeatFailuresRef.current += 1;
+        }
       }
 
       timeoutId = window.setTimeout(tick, getDelayMs());

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -233,12 +233,13 @@ export function useAppVisibility(mx: MatrixClient | undefined, activeSession?: S
       const result = pushSessionNow('heartbeat');
       if (phase3AdaptiveBackoffJitter) {
         if (result === 'sent') {
+          // Successful push — reset backoff so next interval is the base rate.
           heartbeatFailuresRef.current = 0;
-        } else {
-          // 'skipped' means prerequisites (SW controller, session) aren't ready.
-          // Treat as a transient failure so backoff grows until the SW is ready.
-          heartbeatFailuresRef.current += 1;
         }
+        // 'skipped' means prerequisites (SW controller, session) aren't ready yet.
+        // Do NOT increment failures here: the app may simply be starting up and we
+        // do not want startup latency to drive exponential backoff that persists
+        // long after the prerequisites become available.
       }
 
       timeoutId = window.setTimeout(tick, getDelayMs());

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -43,6 +43,16 @@ export type ClientConfig = {
 
   matrixToBaseUrl?: string;
   settingsLinkBaseUrl?: string;
+
+  sessionSync?: {
+    phase1ForegroundResync?: boolean;
+    phase2VisibleHeartbeat?: boolean;
+    phase3AdaptiveBackoffJitter?: boolean;
+    foregroundDebounceMs?: number;
+    heartbeatIntervalMs?: number;
+    resumeHeartbeatSuppressMs?: number;
+    heartbeatMaxBackoffMs?: number;
+  };
 };
 
 const ClientConfigContext = createContext<ClientConfig | null>(null);

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -5,6 +5,21 @@ export type HashRouterConfig = {
   basename?: string;
 };
 
+export type ExperimentConfig = {
+  enabled?: boolean;
+  rolloutPercentage?: number;
+  variants?: string[];
+  controlVariant?: string;
+};
+
+export type ExperimentSelection = {
+  key: string;
+  enabled: boolean;
+  rolloutPercentage: number;
+  variant: string;
+  inExperiment: boolean;
+};
+
 export type ClientConfig = {
   defaultHomeserver?: number;
   homeserverList?: string[];
@@ -13,6 +28,8 @@ export type ClientConfig = {
 
   disableAccountSwitcher?: boolean;
   hideUsernamePasswordFields?: boolean;
+
+  experiments?: Record<string, ExperimentConfig>;
 
   pushNotificationDetails?: {
     pushNotifyUrl?: string;
@@ -64,6 +81,72 @@ export function useClientConfig(): ClientConfig {
   if (!config) throw new Error('Client config are not provided!');
   return config;
 }
+
+const DEFAULT_CONTROL_VARIANT = 'control';
+
+const normalizeRolloutPercentage = (value?: number): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 100;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+};
+
+const hashToUInt32 = (input: string): number => {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 131 + input.charCodeAt(index)) % 4294967291;
+  }
+  return hash;
+};
+
+export const selectExperimentVariant = (
+  key: string,
+  experiment: ExperimentConfig | undefined,
+  subjectId: string | undefined
+): ExperimentSelection => {
+  const controlVariant = experiment?.controlVariant ?? DEFAULT_CONTROL_VARIANT;
+  const variants = (experiment?.variants?.filter((variant) => variant.length > 0) ?? []).filter(
+    (variant) => variant !== controlVariant
+  );
+  const enabled = experiment?.enabled === true;
+  const rolloutPercentage = normalizeRolloutPercentage(experiment?.rolloutPercentage);
+
+  if (!enabled || !subjectId || variants.length === 0 || rolloutPercentage === 0) {
+    return {
+      key,
+      enabled,
+      rolloutPercentage,
+      variant: controlVariant,
+      inExperiment: false,
+    };
+  }
+
+  const rolloutBucket = hashToUInt32(`${key}:rollout:${subjectId}`) % 10000;
+  const rolloutCutoff = Math.floor(rolloutPercentage * 100);
+  if (rolloutBucket >= rolloutCutoff) {
+    return {
+      key,
+      enabled,
+      rolloutPercentage,
+      variant: controlVariant,
+      inExperiment: false,
+    };
+  }
+
+  const variantIndex = hashToUInt32(`${key}:variant:${subjectId}`) % variants.length;
+  return {
+    key,
+    enabled,
+    rolloutPercentage,
+    variant: variants[variantIndex],
+    inExperiment: true,
+  };
+};
+
+export const useExperimentVariant = (key: string, subjectId?: string): ExperimentSelection => {
+  const clientConfig = useClientConfig();
+  return selectExperimentVariant(key, clientConfig.experiments?.[key], subjectId);
+};
 
 export const clientDefaultServer = (clientConfig: ClientConfig): string =>
   clientConfig.homeserverList?.[clientConfig.defaultHomeserver ?? 0] ?? 'matrix.org';

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -644,10 +644,23 @@ function SyncNotificationSettingsWithServiceWorker() {
       navigator.serviceWorker.ready.then((reg) => reg.active?.postMessage(msg));
     };
 
+    const postHidden = () => {
+      // pagehide fires more reliably than visibilitychange on iOS Safari PWA
+      // when the user locks the screen or backgrounds the app quickly, making
+      // it less likely that the SW is left with a stale appIsVisible=true.
+      const msg = { type: 'setAppVisible', visible: false };
+      navigator.serviceWorker.controller?.postMessage(msg);
+      navigator.serviceWorker.ready.then((reg) => reg.active?.postMessage(msg));
+    };
+
     // Report initial visibility immediately, then track changes.
     postVisibility();
     document.addEventListener('visibilitychange', postVisibility);
-    return () => document.removeEventListener('visibilitychange', postVisibility);
+    window.addEventListener('pagehide', postHidden);
+    return () => {
+      document.removeEventListener('visibilitychange', postVisibility);
+      window.removeEventListener('pagehide', postHidden);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -254,7 +254,7 @@ export function ClientRoot({ children }: ClientRootProps) {
 
   useSyncNicknames(mx);
   useLogoutListener(mx);
-  useAppVisibility(mx);
+  useAppVisibility(mx, activeSession);
 
   useEffect(
     () => () => {

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -203,7 +203,7 @@ export function ClientRoot({ children }: ClientRootProps) {
       log.log('initClient for', activeSession.userId);
       const newMx = await initClient(activeSession);
       loadedUserIdRef.current = activeSession.userId;
-      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken);
+      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken, activeSession.userId);
       return newMx;
     }, [activeSession, activeSessionId, setActiveSessionId])
   );
@@ -232,7 +232,7 @@ export function ClientRoot({ children }: ClientRootProps) {
         activeSession.userId,
         '— reloading client'
       );
-      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken);
+      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken, activeSession.userId);
       if (mx?.clientRunning) {
         stopClient(mx);
       }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -757,14 +757,22 @@ const onPushNotification = async (event: PushEvent) => {
 
   // If the app is open and visible, skip the OS push notification — the in-app
   // pill notification handles the alert instead.
-  // Combine clients.matchAll() visibility with the explicit appIsVisible flag
-  // because iOS Safari PWA often returns empty or stale results from matchAll().
-  // Guard against the flag being stale: if the app was backgrounded quickly and
-  // the SW never received the hidden message (iOS can suspend the JS context
-  // before postMessage is processed), the flag expires after APP_VISIBLE_TTL_MS.
+  //
+  // Two-tier visibility check:
+  // 1. When clients.matchAll() returns ≥1 client, trust its visibilityState
+  //    directly.  iOS can suspend the JS thread before postMessage({ visible:
+  //    false }) is processed, leaving appIsVisible stuck at true.  matchAll()
+  //    still reports the backgrounded client as 'hidden', so it is the
+  //    authoritative signal when available.
+  // 2. When matchAll() returns zero clients (a separate iOS Safari PWA quirk
+  //    where the page is invisible to the SW even while visible), fall back to
+  //    the TTL-gated flag: the flag expires after APP_VISIBLE_TTL_MS so a stale
+  //    true from a quick background doesn't permanently suppress notifications.
   const appIsVisibleFresh = appIsVisible && Date.now() - appVisibleSetAt < APP_VISIBLE_TTL_MS;
   const hasVisibleClient =
-    appIsVisibleFresh || clients.some((client) => client.visibilityState === 'visible');
+    clients.length > 0
+      ? clients.some((client) => client.visibilityState === 'visible')
+      : appIsVisibleFresh;
   console.debug(
     '[SW push] appIsVisible:',
     appIsVisible,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -12,6 +12,13 @@ let notificationSoundEnabled = true;
 // The clients.matchAll() visibilityState is unreliable on iOS Safari PWA,
 // so we use this explicit flag as a fallback.
 let appIsVisible = false;
+// Timestamp (Date.now()) of the last time appIsVisible was set to true.
+// Used to expire the flag if the app backgrounded before the SW received the
+// hidden message (e.g. iOS suspended the JS context mid-visibilitychange).
+let appVisibleSetAt = 0;
+// If no visible heartbeat has been received in this window, treat the flag as
+// stale and do not suppress push notifications.
+const APP_VISIBLE_TTL_MS = 30_000;
 let showMessageContent = false;
 let showEncryptedMessageContent = false;
 let clearNotificationsOnRead = false;
@@ -571,6 +578,7 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   if (type === 'setAppVisible') {
     if (typeof (data as { visible?: unknown }).visible === 'boolean') {
       appIsVisible = (data as { visible: boolean }).visible;
+      if (appIsVisible) appVisibleSetAt = Date.now();
     }
   }
   if (type === 'setNotificationSettings') {
@@ -751,8 +759,12 @@ const onPushNotification = async (event: PushEvent) => {
   // pill notification handles the alert instead.
   // Combine clients.matchAll() visibility with the explicit appIsVisible flag
   // because iOS Safari PWA often returns empty or stale results from matchAll().
+  // Guard against the flag being stale: if the app was backgrounded quickly and
+  // the SW never received the hidden message (iOS can suspend the JS context
+  // before postMessage is processed), the flag expires after APP_VISIBLE_TTL_MS.
+  const appIsVisibleFresh = appIsVisible && Date.now() - appVisibleSetAt < APP_VISIBLE_TTL_MS;
   const hasVisibleClient =
-    appIsVisible || clients.some((client) => client.visibilityState === 'visible');
+    appIsVisibleFresh || clients.some((client) => client.visibilityState === 'visible');
   console.debug(
     '[SW push] appIsVisible:',
     appIsVisible,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -12,13 +12,6 @@ let notificationSoundEnabled = true;
 // The clients.matchAll() visibilityState is unreliable on iOS Safari PWA,
 // so we use this explicit flag as a fallback.
 let appIsVisible = false;
-// Timestamp (Date.now()) of the last time appIsVisible was set to true.
-// Used to expire the flag if the app backgrounded before the SW received the
-// hidden message (e.g. iOS suspended the JS context mid-visibilitychange).
-let appVisibleSetAt = 0;
-// If no visible heartbeat has been received in this window, treat the flag as
-// stale and do not suppress push notifications.
-const APP_VISIBLE_TTL_MS = 30_000;
 let showMessageContent = false;
 let showEncryptedMessageContent = false;
 let clearNotificationsOnRead = false;
@@ -578,7 +571,6 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   if (type === 'setAppVisible') {
     if (typeof (data as { visible?: unknown }).visible === 'boolean') {
       appIsVisible = (data as { visible: boolean }).visible;
-      if (appIsVisible) appVisibleSetAt = Date.now();
     }
   }
   if (type === 'setNotificationSettings') {
@@ -758,21 +750,20 @@ const onPushNotification = async (event: PushEvent) => {
   // If the app is open and visible, skip the OS push notification — the in-app
   // pill notification handles the alert instead.
   //
-  // Two-tier visibility check:
-  // 1. When clients.matchAll() returns ≥1 client, trust its visibilityState
-  //    directly.  iOS can suspend the JS thread before postMessage({ visible:
-  //    false }) is processed, leaving appIsVisible stuck at true.  matchAll()
-  //    still reports the backgrounded client as 'hidden', so it is the
-  //    authoritative signal when available.
-  // 2. When matchAll() returns zero clients (a separate iOS Safari PWA quirk
-  //    where the page is invisible to the SW even while visible), fall back to
-  //    the TTL-gated flag: the flag expires after APP_VISIBLE_TTL_MS so a stale
-  //    true from a quick background doesn't permanently suppress notifications.
-  const appIsVisibleFresh = appIsVisible && Date.now() - appVisibleSetAt < APP_VISIBLE_TTL_MS;
+  // When clients.matchAll() returns ≥1 client, trust its visibilityState
+  // directly.  iOS can suspend the JS thread before postMessage({ visible:
+  // false }) is processed, leaving appIsVisible stuck at true.  matchAll()
+  // still reports the backgrounded client as 'hidden', so it is the
+  // authoritative and most reliable signal.
+  //
+  // When matchAll() returns zero clients (a separate iOS Safari PWA quirk),
+  // visibility is unknowable — do NOT suppress.  Better to show a duplicate
+  // (handled gracefully by the in-app banner) than to silently drop a
+  // notification while the app is backgrounded.
   const hasVisibleClient =
     clients.length > 0
       ? clients.some((client) => client.visibilityState === 'visible')
-      : appIsVisibleFresh;
+      : false;
   console.debug(
     '[SW push] appIsVisible:',
     appIsVisible,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -761,9 +761,7 @@ const onPushNotification = async (event: PushEvent) => {
   // (handled gracefully by the in-app banner) than to silently drop a
   // notification while the app is backgrounded.
   const hasVisibleClient =
-    clients.length > 0
-      ? clients.some((client) => client.visibilityState === 'visible')
-      : false;
+    clients.length > 0 ? clients.some((client) => client.visibilityState === 'visible') : false;
   console.debug(
     '[SW push] appIsVisible:',
     appIsVisible,


### PR DESCRIPTION
📝 **Docs PR:** SableClient/docs#9 — merge that when merging this.

---

### PR dependency (stacked)

This branch is stacked on #572 — it has been rebased onto `feat/feature-flag-env-vars` with no duplicate commits. Only the two session-sync–specific commits are unique to this PR. Please review/merge #572 first, then review this PR for session-sync behavior.

### Description

Adds phased service-worker session re-sync controls, gated behind an experiment flag with direct-config fallback.

Also fixes two bugs in the phase-flag path:

- **Phase 3 backoff not reset on foreground success**: `heartbeatFailuresRef.current` was not reset to 0 when a foreground push succeeded. This left the heartbeat on an inflated backoff interval even after the SW controller was confirmed alive. It now resets to 0 on any successful foreground or focus push.
- **`preloadedSession` double cache read**: the SW push handler was warming `preloadedSession` by fetching from the cache, then immediately reading from the cache again on the first `/sync` interception. The redundant read has been removed; the push handler now stores the session object directly.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
The phased session-sync hooks/flags and config integration were partially AI assisted; I verified branch behavior and safe defaults. The heartbeat reset fix and preloadedSession dedup were partially AI assisted; I confirmed the fix was correct by tracing the backoff counter through the foreground → heartbeat tick path.

### Feature Flags / Environment Setup

Set these GitHub Environment variables:

- `CLIENT_CONFIG_OVERRIDES_JSON`
- `CLIENT_CONFIG_OVERRIDES_STRICT` (optional)

#### How it works

Phase flags are derived in `useAppVisibility` from the `sessionSyncStrategy` experiment:

| Variant | Phase 1 (foreground resync) | Phase 2 (heartbeat) | Phase 3 (adaptive backoff) |
|---|---|---|---|
| `control` (default) | ❌ | ❌ | ❌ |
| `session-sync-heartbeat` | ✅ | ✅ | ❌ |
| `session-sync-adaptive` | ✅ | ✅ | ✅ |

Users not in the experiment fall back to the `sessionSync.phase*` booleans, which can be used for direct-config overrides (e.g. preview/staging where you want all users to get the feature without experiment bucketing).

#### sessionSync config field reference

| Field | Type | Default | Description |
|---|---|---|---|
| `phase1ForegroundResync` | boolean | `false` | Push session credentials to the SW on page focus / becoming visible. |
| `phase2VisibleHeartbeat` | boolean | `false` | Periodic heartbeat that keeps SW credentials fresh while the tab is visible and online. |
| `phase3AdaptiveBackoffJitter` | boolean | `false` | Exponential backoff with ±20% jitter on heartbeat failures. No effect unless `phase2VisibleHeartbeat` is `true`. |
| `foregroundDebounceMs` | number | `1500` | Minimum ms between foreground-triggered pushes. |
| `heartbeatIntervalMs` | number | `600000` | Base interval between heartbeat ticks (ms). |
| `resumeHeartbeatSuppressMs` | number | `60000` | How long after a foreground push to suppress the next heartbeat tick (ms). |
| `heartbeatMaxBackoffMs` | number | `1800000` | Maximum backoff ceiling for adaptive mode (ms). |

#### Recommended initial values

`preview` — enable for all users directly (no bucketing):

```json
{
  "sessionSync": {
    "phase1ForegroundResync": true,
    "phase2VisibleHeartbeat": true,
    "phase3AdaptiveBackoffJitter": true
  }
}
```

`production` — gradual rollout via experiment:

> **Note:** `rolloutPercentage` controls what fraction of users enter the experiment at all. Those users are then split evenly across `variants`. So `rolloutPercentage: 20` with 2 variants = **10% per variant**, 80% control.

```json
{
  "experiments": {
    "sessionSyncStrategy": {
      "enabled": true,
      "rolloutPercentage": 20,
      "controlVariant": "control",
      "variants": ["session-sync-heartbeat", "session-sync-adaptive"]
    }
  }
}
```

No environment variable setup is required for deployment to succeed; missing overrides are treated as no-op and checked-in defaults are used.