### PR TITLE
Fix Youtube Previewing Crashing by adding shorts support

### DIFF
--- a/.changeset/add_shorts_support_to_fix_crash.md
+++ b/.changeset/add_shorts_support_to_fix_crash.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add youtube shorts support to stop it from crashing sable.

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -171,10 +171,10 @@ function parseYoutubeLink(url: string): YoutubeLink | null {
     const split = path.split('/shorts/');
     [videoId] = split;
     params = split[1]?.split('shorts');
-  } else {
+  } else if (url.includes('youtube.com')) {
     params = path.split('?')[1].split('&');
     videoId = params.find((s) => s.startsWith('v='), params)?.split('v=')[1];
-  }
+  } else return null;
 
   if (!videoId) return null;
 

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -167,6 +167,10 @@ function parseYoutubeLink(url: string): YoutubeLink | null {
     const split = path.split('?');
     [videoId] = split;
     params = split[1]?.split('&');
+  } else if (url.includes('/shorts/')) {
+    const split = path.split('/shorts/');
+    [videoId] = split;
+    params = split[1]?.split('shorts');
   } else {
     params = path.split('?')[1].split('&');
     videoId = params.find((s) => s.startsWith('v='), params)?.split('v=')[1];


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Added basic shorts support and a fallback to fix it from crashing on shorts.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Athena has cursed me with the wisdom to fix this.