### PR TITLE
Fix keyboard shortcut modifiers (removing redundant identity replacement)

### DIFF
--- a/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
+++ b/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
@@ -23,8 +23,7 @@ function formatKey(key: string): string {
   return key
     .replace(/\bmod\b/g, isMac ? '⌘' : 'Ctrl')
     .replace(/\balt\b/gi, isMac ? '⌥' : 'Alt')
-    .replace(/\bshift\b/gi, '⇧')
-    .replace(/\+/g, '+');
+    .replace(/\bshift\b/gi, '⇧');
 }
 
 const SHORTCUT_CATEGORIES: ShortcutCategory[] = [


### PR DESCRIPTION
fix for https://github.com/SableClient/Sable/security/code-scanning/1
removed the redundant replacement with it self.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

codeql was used, if that counts, but it was a one line change, so no AI was used