### PR TITLE
fix(caddy): add cache-control headers for static assets, service worker, and index.html

### DIFF
--- a/.changeset/caddy-cache-headers.md
+++ b/.changeset/caddy-cache-headers.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add cache-control headers in Caddyfile for assets, service worker, and index.html

--- a/Caddyfile
+++ b/Caddyfile
@@ -16,6 +16,13 @@
 
 	try_files {path} /index.html
 
+	# Content-hashed assets can be cached indefinitely — the filename changes on every build.
+	header /assets/* Cache-Control "public, max-age=31536000, immutable"
+	# Workbox SW must be revalidated on every load so the browser picks up updates.
+	header /sw.js Cache-Control "no-cache"
+	# index.html must not be cached so the browser always gets the latest app shell.
+	header /index.html Cache-Control "no-cache"
+
         # Required for Sentry browser profiling (JS Self-Profiling API)
         header Document-Policy "js-profiling"
 }


### PR DESCRIPTION
> Related to closed PR #548 (`fix/media-error-handling`), which was split into smaller focused PRs.

### Description

Without explicit `Cache-Control` headers, browsers apply heuristic caching to all responses — including `sw.js` and `index.html`. This causes stale service workers and stale app shells to persist after a deploy. Three header rules added to the Caddyfile:

- `/assets/*` — `public, max-age=31536000, immutable`: content-hashed filenames change on every build, so these are safe to cache permanently.
- `/sw.js` — `no-cache`: must always be revalidated so the browser picks up SW updates promptly.
- `/index.html` — `no-cache`: must always be revalidated so the browser gets the latest asset hashes on load.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The cache header rules were partially AI assisted. I verified the `immutable` directive is appropriate for content-hashed assets and that `no-cache` (revalidate-always, not no-store) is correct for `sw.js` and `index.html`.