### PR TITLE
fix(pwa): re-enable Workbox precaching (remove injectionPoint override)

### DIFF
--- a/.changeset/workbox-precaching.md
+++ b/.changeset/workbox-precaching.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Workbox precaching by removing injectionPoint override that was silently disabling all precache entries

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -902,7 +902,5 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
   );
 });
 
-if (self.__WB_MANIFEST) {
-  precacheAndRoute(self.__WB_MANIFEST);
-}
+precacheAndRoute(self.__WB_MANIFEST);
 cleanupOutdatedCaches();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -176,7 +176,11 @@ export default defineConfig(({ command }) => ({
       injectRegister: false,
       manifest: false,
       injectManifest: {
-        injectionPoint: undefined,
+        // element-call is a self-contained embedded app; exclude its large assets
+        // from the SW precache manifest (they are not part of the Sable shell).
+        globIgnores: ['public/element-call/**'],
+        // The app's own crypto WASM and main bundle exceed the 2 MiB default.
+        maximumFileSizeToCacheInBytes: 10 * 1024 * 1024, // 10 MiB
       },
       devOptions: {
         enabled: true,


### PR DESCRIPTION
> Related to closed PR #548 (`fix/media-error-handling`), which was split into smaller focused PRs.

### Description

`injectionPoint: undefined` was set in `vite.config.ts` to silence a Workbox `AssertionError` about multiple `self.__WB_MANIFEST` occurrences (an `if` guard in `sw.ts` plus the `precacheAndRoute()` call = two matches; Workbox requires exactly one). The unintended consequence: Workbox never injected the precache manifest, so **no assets were precached** — every cold start hit the network instead of serving from cache, and offline use was broken entirely.

Fix: remove the `if` guard in `sw.ts` (leaving exactly one `self.__WB_MANIFEST` reference) then remove `injectionPoint: undefined` from `vite.config.ts` to restore normal precaching behaviour.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The root cause diagnosis (two `self.__WB_MANIFEST` references causing Workbox to silently skip injection) was identified with AI assistance. I verified the fix by checking Workbox's `injectionPoint` behaviour and confirming precaching was restored.