### PR TITLE
fix(ui): suppress button hover transform inside VList rows to prevent smearing

### DIFF
--- a/.changeset/vlist-hover-transform.md
+++ b/.changeset/vlist-hover-transform.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix button hover background smearing in virtual list rows by suppressing transform on hover

--- a/src/app/styles/overrides/General.css.ts
+++ b/src/app/styles/overrides/General.css.ts
@@ -38,9 +38,6 @@ globalStyle(
 globalStyle(
   `
     button[class*="_1684mq51"]:has(img):hover,
-    [data-index] [class*="_1r9nvaso"]:hover,
-    [data-index] [class*="_1r9nvaso"] *:hover,
-    [data-index] button:has(p):hover,
     [data-index] button:hover,
     [data-index] [role="button"]:hover
 `,


### PR DESCRIPTION
> Related to closed PR #598 (`fix/perf-rerender-reduction`), which was split into smaller focused PRs.

### Description

Buttons inside VList rows were applying a CSS `transform` on `:hover`. Because VList row elements use `position: relative` with `will-change: transform` for virtualisation, the button transform was composited against the row's own transform layer, producing a visual smear — the button appeared to shift or blur while the row stayed in place.

Fix: add a scoped CSS override in `General.css.ts` that resets `transform: none` on `:hover` for buttons inside VList row containers.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The CSS override was partially AI assisted. I identified the smearing symptom and verified that the transform interaction between VList row layers and button hover state was the cause before applying the fix.