### PR TITLE
fix: Make right clicking no longer drag images in the image viewer

### DIFF
--- a/.changeset/remove-right-click-drag.md
+++ b/.changeset/remove-right-click-drag.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Right clicks no longer drag images in the viewer.

--- a/src/app/hooks/useImageGestures.ts
+++ b/src/app/hooks/useImageGestures.ts
@@ -74,7 +74,7 @@ export const useImageGestures = (active: boolean, step = 0.2, min = 0.1, max = 5
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
-      if (!active) return;
+      if (!active || (e.pointerType === 'mouse' && e.button === 2)) return;
 
       e.stopPropagation();
       const target = e.target as HTMLElement;


### PR DESCRIPTION
### Description

As per typical UX conventions, right clicking no longer drags images in the image preview.

Fixes #555 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
