### PR TITLE
Fix focus when replying to messages

### DIFF
--- a/.changeset/fix-focus-capture-reply.md
+++ b/.changeset/fix-focus-capture-reply.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix reply button not capturing editor focus.

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -419,6 +419,24 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       }
     }, [mentionInReplies, mx, replyDraft]);
 
+    const prevReplyEventId = useRef(replyDraft?.eventId);
+    useEffect(() => {
+      if (replyDraft?.eventId !== prevReplyEventId.current) {
+        prevReplyEventId.current = replyDraft?.eventId;
+
+        if (replyDraft?.eventId) {
+          requestAnimationFrame(() => {
+            try {
+              ReactEditor.focus(editor);
+              moveCursor(editor);
+            } catch {
+              // Ignore focus errors
+            }
+          });
+        }
+      }
+    }, [replyDraft?.eventId, editor]);
+
     const handleFileMetadata = useCallback(
       (fileItem: TUploadItem, metadata: TUploadMetadata) => {
         setSelectedFiles({


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Recaptures input box focus when replying to a message.

Fixes #621

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
