### PR TITLE
Add setting to collapse folders by default

### DIFF
--- a/.changeset/feat-collpase-folder-setting.md
+++ b/.changeset/feat-collpase-folder-setting.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a setting to collapse sidebar folders by default.

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -468,6 +468,10 @@ function PageZoomInput() {
 export function Appearance() {
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
   const [showEasterEggs, setShowEasterEggs] = useSetting(settingsAtom, 'showEasterEggs');
+  const [closeFoldersByDefault, setCloseFoldersByDefault] = useSetting(
+    settingsAtom,
+    'closeFoldersByDefault'
+  );
 
   return (
     <Box direction="Column" gap="700">
@@ -482,6 +486,20 @@ export function Appearance() {
             title="Twitter Emoji"
             description="Use Twitter-style emojis instead of system native ones."
             after={<Switch variant="Primary" value={twitterEmoji} onChange={setTwitterEmoji} />}
+          />
+        </SequenceCard>
+
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Close Space Folders by Default"
+            description="Collapse sidebar folders upon loading."
+            after={
+              <Switch
+                variant="Primary"
+                value={closeFoldersByDefault}
+                onChange={setCloseFoldersByDefault}
+              />
+            }
           />
         </SequenceCard>
 

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -507,6 +507,7 @@ export function Appearance() {
         <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
           <SettingTile
             title="Close Space Folders by Default"
+            focusId="collapse-folders-by-default"
             description="Collapse sidebar folders upon loading."
             after={
               <Switch

--- a/src/app/state/openedSidebarFolder.ts
+++ b/src/app/state/openedSidebarFolder.ts
@@ -5,6 +5,7 @@ import {
   getLocalStorageItem,
   setLocalStorageItem,
 } from './utils/atomWithLocalStorage';
+import { getSettings } from './settings';
 
 const OPENED_SIDEBAR_FOLDER = 'openedSidebarFolder';
 
@@ -30,6 +31,10 @@ export const makeOpenedSidebarFolderAtom = (userId: string): OpenedSidebarFolder
   const baseOpenedSidebarFolderAtom = atomWithLocalStorage<Set<string>>(
     storeKey,
     (key) => {
+      const settings = getSettings();
+      if (settings.closeFoldersByDefault) {
+        return new Set<string>();
+      }
       const arrayValue = getLocalStorageItem<string[]>(key, []);
       return new Set(arrayValue);
     },

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -110,13 +110,11 @@ export interface Settings {
   alwaysShowCallButton: boolean;
   faviconForMentionsOnly: boolean;
   highlightMentions: boolean;
-  /**
-   * whether to enable pk compat
-   */
   pkCompat: boolean;
   pmpProxying: boolean;
   mentionInReplies: boolean;
   showPersonaSetting: boolean;
+  closeFoldersByDefault: boolean;
 
   // furry stuff
   renderAnimals: boolean;
@@ -214,6 +212,7 @@ const defaultSettings: Settings = {
   pmpProxying: false,
   mentionInReplies: true,
   showPersonaSetting: false,
+  closeFoldersByDefault: false,
 
   // furry stuff
   renderAnimals: true,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a setting to visual tweaks that allows collapsing folders by default instead of the current behavior of saving the state of opened/closed folders

Fixes #616

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
