### PR TITLE
Add a dismiss button to command messages

### DIFF
--- a/.changeset/feat-dismiss-local-echo.md
+++ b/.changeset/feat-dismiss-local-echo.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a "Dismiss" button to command response messages.

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -679,6 +679,7 @@ function MessageInternal(
   );
 
   const MSG_CONTENT_STYLE = { maxWidth: '100%' };
+  const isSableFeedback = mEvent.getId()?.startsWith('~sable-feedback-');
 
   const msgContentJSX = (
     <Box
@@ -755,6 +756,31 @@ function MessageInternal(
               <Text size="B300">Delete</Text>
             </Chip>
           )}
+        </Box>
+      )}
+      {isSableFeedback && (
+        <Box className={css.SendStatusRow} alignItems="Center" gap="100">
+          <Icon src={Icons.Info} size="100" />
+          <Text size="T200" priority="300" as="span">
+            Only you can see this.
+          </Text>
+          <Chip
+            type="button"
+            variant="SurfaceVariant"
+            radii="Pill"
+            outlined
+            onClick={(evt: any) => {
+              evt.preventDefault();
+              evt.stopPropagation();
+              const eventId = mEvent.getId();
+              if (eventId) {
+                room.removeEvent(eventId);
+                room.emit(RoomEvent.LocalEchoUpdated, mEvent, room);
+              }
+            }}
+          >
+            <Text size="B300">Dismiss</Text>
+          </Chip>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a dismiss button to command feedback messages and clarifies that they're client side

Fixes #594

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
