### PR TITLE
Fix "sticky scrolling" issue in encrypted rooms with many PMP messages

### DIFF
--- a/.changeset/fix-pmp-encrypted-sticky-scrolling.md
+++ b/.changeset/fix-pmp-encrypted-sticky-scrolling.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed the "sticky scrolling" issue in encrypted rooms with many PMP messages.

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -396,11 +396,6 @@ function MessageInternal(
       triggerTimelineRegroup();
     };
 
-    if (mEvent.getClearContent()) {
-      setContentVersion((v) => (v === 0 ? 1 : v));
-      triggerTimelineRegroup();
-    }
-
     mEvent.on(MatrixEventEvent.Decrypted, onUpdate);
     mEvent.on(MatrixEventEvent.Replaced, onUpdate);
     return () => {


### PR DESCRIPTION
### Description

Previously, in encrypted rooms with many PMP messages, scrolling to the bottom of the page resulted in the view "sticking"; you would need to scroll either very quickly or manually with the scrollbar to get "unstuck".

This stemmed from a part of the logic for grouping PMP messages together in encrypted rooms; a timeline update seemed to be erroneously triggered, re-rendering the timeline repeatedly (effectively sending you back to the bottom).

I've removed the offending line, and the original functionality of the change (i.e. PMP messages continuing to be grouped both as they are sent, edited, and re-rendered) seems to still be present.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).