### PR TITLE
fix(ui): Ensure splash screen scales to viewport height

### DIFF
--- a/src/app/components/splash-screen/SplashScreen.css.ts
+++ b/src/app/components/splash-screen/SplashScreen.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { color, config } from 'folds';
 
 export const SplashScreen = style({
-  minHeight: '100%',
+  minHeight: '100vh',
   backgroundColor: color.Background.Container,
   color: color.Background.OnContainer,
 });


### PR DESCRIPTION
## Summary

The bug reporting screen, which uses the `SplashScreen` component, was not scaling correctly to the browser's viewport height, causing content to be cropped. This was due to the component using `minHeight: '100%'`, which relies on parent elements having a defined height. The fix changes this to `minHeight: '100vh'`, which correctly sizes the component based on the viewport's height, resolving the scaling issue.

## Changes

- **src/app/components/splash-screen/SplashScreen.css.ts**: Changed `minHeight` from `100%` to `100vh` in the `SplashScreen` style. Using the viewport height unit (`vh`) ensures the component's minimum height is always equal to the browser's viewport height, fixing the vertical scaling issue that caused content to be cropped.

## Related Issue

Closes #629

