### PR TITLE
Fix invisible names

### DIFF
--- a/.changeset/fix-hidden-names.md
+++ b/.changeset/fix-hidden-names.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix some zero-width (invisible) names

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -529,6 +529,11 @@ export const getMemberDisplayName = (
   const member = room.getMember(userId);
   const name = member?.rawDisplayName;
   if (name === userId) return undefined;
+  if (
+    name?.replace(/[\p{Cc}\p{Cf}\u180B-\u180F\uFE00-\uFE0F\uE0100-\uE01EF\u200B-\u200D]/gu, '')
+      .length === 0
+  )
+    return undefined;
   return name;
 };
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Small change to attempt to default to the right name so that they do not show as being blank

Had to be a hard list because there does not seem to be a list of characters that are supposed to be blank within the \p type

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
A million monkeys spent a million years typing out the implementation