### PR TITLE
Re-introduce custom HTML formatting for long messages

### DIFF
--- a/.changeset/fix-html-formatting-on-long-messages.md
+++ b/.changeset/fix-html-formatting-on-long-messages.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Re-introduced custom HTML formatting for long messages

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -97,15 +97,6 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
     [customBody, body]
   );
 
-  const safeCustomBody = useMemo(() => {
-    if (!customBody) return undefined;
-    if (customBody.length > 8000) {
-      const imageTags = customBody.match(/<img[^>]*>/g);
-      return imageTags ? imageTags.join(' ') : undefined;
-    }
-    return customBody;
-  }, [customBody]);
-
   const isForwarded = useMemo(() => {
     const forwardMeta = content['moe.sable.message.forward'];
     return typeof forwardMeta === 'object';
@@ -122,7 +113,7 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
   const isJumbo = useMemo(() => {
     if (!trimmedBody || trimmedBody.length >= 500) return false;
     if (
-      (unwrappedPerMessageProfileMessage ?? safeCustomBody)?.match(
+      (unwrappedPerMessageProfileMessage ?? customBody)?.match(
         /^(<img[^>]*data-mx-emoticon[^>]*\/>){1,20}$/i
       )
     )
@@ -130,12 +121,12 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
     if (!JUMBO_EMOJI_REG.test(trimmedBody)) return false;
 
     if (trimmedBody.includes(':')) {
-      const hasImage = safeCustomBody && /<img[^>]*>/i.test(safeCustomBody);
+      const hasImage = customBody && /<img[^>]*>/i.test(customBody);
       if (!hasImage) return false;
     }
 
     return true;
-  }, [unwrappedPerMessageProfileMessage, trimmedBody, safeCustomBody]);
+  }, [unwrappedPerMessageProfileMessage, trimmedBody, customBody]);
 
   if (!body && !customBody) return <BrokenContent body={customBody ?? body} />;
 
@@ -175,13 +166,13 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
   return (
     <>
       <MessageTextBody
-        preWrap={typeof safeCustomBody !== 'string'}
+        preWrap={typeof customBody !== 'string'}
         jumboEmoji={isJumbo ? jumboEmojiSize : 'none'}
         style={style}
       >
         {renderBody({
           body: trimmedBody,
-          customBody: safeCustomBody,
+          customBody: typeof customBody === 'string' ? customBody : undefined,
         })}
         {edited && <MessageEditedContent />}
       </MessageTextBody>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

For long formatted messages (specifically, messages with over 8000 characters in their internal source), styles are disabled. I personally noticed this when trying to use `/rainbow` messages.

I noticed that this regression was caused by [this commit](https://github.com/7w1/sable/commit/d97a6c6cc345c58b4c21813560951595bb708e32); while sanitizing the formatted body of a long message was safe for the specific message in the channel that was linked in the issue, it ended up disabling _all_ HTML formatting for longer messages.

Here, you can see the result of my fix:
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/a5ed26b4-bf55-492a-83d1-93c747226d74" /><img width="50%" height="877" alt="image" src="https://github.com/user-attachments/assets/84312b48-c426-4508-8341-6445fb9460ec" />

Specifically, I've determined that the cause of the original crash was specifically only related to jumbo emojis; as I've kept the safeguard regarding jumbo emojis, this still prevents the crash, as well as keeping any spacing or line breaks in a message with many emojis. Here's the difference:
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/35dbd824-f14a-4a61-9dfa-93593e01a1e1" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/873429bb-1166-418d-b7fd-b0c9f102e285" />

_(I'm considering this a breaking change because, as far as I can tell, this does _technically_ make emojis no longer jumbo in longer messages. I could be wrong, though.)_

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
