### PR TITLE
fix: Safely re-introduce timeline regrouping for PMP messages after sticky scroll fix

### DIFF
--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -386,15 +386,20 @@ function MessageInternal(
 
   useEffect(() => {
     const triggerTimelineRegroup = () => {
-      room.emit(RoomEvent.Timeline, mEvent, room, false, false, {
-        liveEvent: true,
-      } as IRoomTimelineData);
+      // A Local Echo update seems to trigger a visual refresh without
+      // scrolling the viewport.
+      room.emit(RoomEvent.LocalEchoUpdated, mEvent, room);
     };
 
     const onUpdate = () => {
       setContentVersion((v) => v + 1);
       triggerTimelineRegroup();
     };
+
+    if (mEvent.getClearContent()) {
+      setContentVersion((v) => (v === 0 ? 1 : v));
+      triggerTimelineRegroup();
+    }
 
     mEvent.on(MatrixEventEvent.Decrypted, onUpdate);
     mEvent.on(MatrixEventEvent.Replaced, onUpdate);

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -36,7 +36,6 @@ import {
   RoomPinnedEventsEventContent,
   MatrixEventEvent,
   RoomEvent,
-  IRoomTimelineData,
 } from '$types/matrix-sdk';
 import classNames from 'classnames';
 import { useAtomValue, useSetAtom } from 'jotai';


### PR DESCRIPTION
### Description

In [this PR](https://github.com/SableClient/Sable/pull/626), I fixed the sticky scrolling issue by disabling the automatic timeline regroup for PMP messages, since this event repeatedly scrolled the user to the bottom of the page in encrypted rooms with many PMP messages.

However, this change _did_ end up regressing the functionality of that fix: Albeit extremely irregularly, some PMP messages will fail to be grouped together or will otherwise not have their profile picture load.

To fix this, I've reintroduced the timeline regroup logic, but I've replaced the regroup function to a different room event that still provides a visual refresh without doing any scrolling.

As the previous PR hasn't made it to a public release yet, I'm not including a changeset, as it serves the same purpose as and would have ideally been included in the original PR.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
I used AI to quickly trace exactly what each event type does and format the new `room.emit` line. As opposed to the Timeline event from before, the LocalEchoUpdated event should refresh the timeline without any automatic scrolling. This should make sure that PMP messages are properly regrouped automatically, and my testing confirms this.