### PR TITLE
fix: prevent iOS overscroll on root element

### DIFF
--- a/.changeset/fix-ios-overscroll.md
+++ b/.changeset/fix-ios-overscroll.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix iOS elastic bounce-back overscroll on the root element.

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,7 @@
 html {
   height: 100%;
   overflow: hidden;
+  overscroll-behavior: none;
 }
 
 body {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds `overscroll-behavior: none` to the `html` element to prevent the elastic bounce-back scroll on iOS from competing with the timeline scroll.

Fixes #500

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The CSS property addition (`overscroll-behavior: none` on the `html` selector) was suggested by an AI tool. It sets the browser's overscroll behavior to prevent the elastic bounce effect on iOS from propagating to the root element, which was causing the timeline scroll to fight with the page-level bounce-back.