### PR TITLE
fix: use file name instead of 'a voice message' for non-voice audio

### DIFF
--- a/.changeset/fix-audio-file-description.md
+++ b/.changeset/fix-audio-file-description.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Use file name instead of "a voice message" for non-voice audio files.

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -147,10 +147,12 @@ export type AudioMsgContent = IContent & {
 export const getAudioMsgContent = (item: TUploadItem, mxc: string): AudioMsgContent => {
   const { file, encInfo, metadata } = item;
   const { waveform, audioDuration, markedAsSpoiler } = metadata;
+  const isVoice = waveform !== undefined && waveform.length > 0;
+  const fallbackBody = isVoice ? 'a voice message' : file.name;
   let content: IContent = {
     msgtype: MsgType.Audio,
     filename: file.name,
-    body: item.body && item.body.length > 0 ? item.body : 'a voice message',
+    body: item.body && item.body.length > 0 ? item.body : fallbackBody,
     info: {
       mimetype: file.type,
       size: file.size,
@@ -162,7 +164,7 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string): AudioMsgCont
       waveform: waveform?.map((v) => Math.round(v * 1024)),
       duration: markedAsSpoiler || !audioDuration ? 0 : audioDuration * 1000,
     },
-    'org.matrix.msc1767.text': item.body && item.body.length > 0 ? item.body : 'a voice message',
+    'org.matrix.msc1767.text': item.body && item.body.length > 0 ? item.body : fallbackBody,
     'org.matrix.msc3245.voice.v2': {
       duration: markedAsSpoiler || !audioDuration ? 0 : audioDuration,
       waveform: waveform?.map((v) => Math.round(v * 1024)),


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Only labels audio files as "a voice message" when they actually are voice messages (have waveform data). Regular audio files (music, podcasts) now use the file name as the body text instead.

Fixes #543

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The `isVoice` check logic was written alongside an AI tool. It checks whether the audio message event contains `waveform` data in `content.info` to distinguish voice messages from regular audio file uploads. If waveform data is absent, the message body falls back to the file name from `content.body` instead of the hardcoded "a voice message" string.