### PR TITLE
fix: constrain bug report modal to viewport height

### DIFF
--- a/.changeset/fix-bug-report-modal-overflow.md
+++ b/.changeset/fix-bug-report-modal-overflow.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Constrain bug report modal to viewport height to prevent overflow.

--- a/src/app/features/bug-report/BugReportModal.tsx
+++ b/src/app/features/bug-report/BugReportModal.tsx
@@ -233,8 +233,8 @@ function BugReportModal() {
             escapeDeactivates: stopPropagation,
           }}
         >
-          <Modal size="500" flexHeight variant="Surface">
-            <Box direction="Column">
+          <Modal size="500" flexHeight variant="Surface" style={{ maxHeight: '90vh' }}>
+            <Box direction="Column" style={{ maxHeight: '90vh', overflow: 'hidden' }}>
               <Header
                 size="500"
                 style={{ padding: config.space.S200, paddingLeft: config.space.S400 }}


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Constrains the bug report modal to 90vh max height so it doesn't overflow the viewport, which was cropping the close button and header text.

Fixes #629

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The `maxHeight` and `overflow` style additions to `BugReportModal.tsx` were written alongside an AI tool. The changes add `maxHeight: '90vh'` to the MUI Modal component and its inner Box container, with `overflow: 'hidden'` on the Box to prevent the modal from growing beyond the viewport. The inner content area uses `overflowY: 'auto'` so the form fields remain scrollable within the constrained modal.