### PR TITLE
Fix dm navigation breaking

### DIFF
--- a/.changeset/fix-dms-nav-not-naving.dm
+++ b/.changeset/fix-dms-nav-not-naving.dm
@@ -1,5 +1,0 @@
----
-default: patch
----
-
-Fix dms navigation not navigating to dms when local storage is messed up.

--- a/.changeset/fix-dms-nav-not-naving.dm
+++ b/.changeset/fix-dms-nav-not-naving.dm
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix dms navigation not navigating to dms when local storage is messed up.

--- a/.changeset/fix-dms-nav-not-naving.md
+++ b/.changeset/fix-dms-nav-not-naving.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix dms navigation not navigating to dms when local storage is messed up.

--- a/src/app/pages/client/sidebar/DirectTab.tsx
+++ b/src/app/pages/client/sidebar/DirectTab.tsx
@@ -83,7 +83,8 @@ export function DirectTab() {
   const handleDirectClick = () => {
     const activePath = navToActivePath.get('direct');
     const activePathname = activePath?.pathname;
-    const isValidDirectPath = typeof activePathname === 'string' && activePathname.startsWith('/direct/');
+    const isValidDirectPath =
+      typeof activePathname === 'string' && activePathname.startsWith('/direct/');
     if (activePath && isValidDirectPath && screenSize !== ScreenSize.Mobile) {
       navigate(joinPathComponent(activePath));
       return;

--- a/src/app/pages/client/sidebar/DirectTab.tsx
+++ b/src/app/pages/client/sidebar/DirectTab.tsx
@@ -82,7 +82,9 @@ export function DirectTab() {
 
   const handleDirectClick = () => {
     const activePath = navToActivePath.get('direct');
-    if (activePath && screenSize !== ScreenSize.Mobile) {
+    const activePathname = activePath?.pathname;
+    const isValidDirectPath = typeof activePathname === 'string' && activePathname.startsWith('/direct/');
+    if (activePath && isValidDirectPath && screenSize !== ScreenSize.Mobile) {
       navigate(joinPathComponent(activePath));
       return;
     }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the DMs button in the side bar taking you to a page than isn't a dm.
The DM button just restores a page navigation from local storage, so if that local storage is messed up somehow, then you can't get to dms. This adds a check to ensure you always go to dms.

How this happened to me? I have no idea.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
