### PR TITLE
Feat: Add the ability to set Global Name Colors dependent on the theme (dark/light) 

### DIFF
--- a/.changeset/feat-add-theme-specific-colors.md
+++ b/.changeset/feat-add-theme-specific-colors.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add the ability to set Global Name Colors dependent on the theme (dark/light)

--- a/src/app/features/settings/account/NameColorEditor.tsx
+++ b/src/app/features/settings/account/NameColorEditor.tsx
@@ -75,6 +75,17 @@ export function NameColorEditor({
             }}
           >
             <Box alignItems="Center" gap="300" grow="Yes">
+              {hasChanged && (
+                <Button
+                  variant="Primary"
+                  size="300"
+                  radii="Pill"
+                  onClick={handleSave}
+                  disabled={!/^#[0-9A-F]{6}$/i.test(tempColor)}
+                >
+                  <Text size="B300">Save</Text>
+                </Button>
+              )}
               <HexColorPickerPopOut
                 picker={<HexColorPicker color={tempColor} onChange={handleUpdate} />}
               >
@@ -133,18 +144,6 @@ export function NameColorEditor({
                 )}
               </Box>
             </Box>
-
-            {hasChanged && (
-              <Button
-                variant="Primary"
-                size="300"
-                radii="Pill"
-                onClick={handleSave}
-                disabled={!/^#[0-9A-F]{6}$/i.test(tempColor)}
-              >
-                <Text size="B300">Save</Text>
-              </Button>
-            )}
           </Box>
         }
       />

--- a/src/app/features/settings/account/NameColorEditor.tsx
+++ b/src/app/features/settings/account/NameColorEditor.tsx
@@ -7,6 +7,7 @@ import { HexColorPickerPopOut } from '$components/HexColorPickerPopOut';
 type NameColorEditorProps = {
   title: string;
   description?: string;
+  focusId?: string;
   current?: string;
   onSave: (color: string | null) => void;
   disabled?: boolean;
@@ -15,6 +16,7 @@ type NameColorEditorProps = {
 export function NameColorEditor({
   title,
   description,
+  focusId,
   current,
   onSave,
   disabled,
@@ -57,89 +59,95 @@ export function NameColorEditor({
 
   return (
     <Box direction="Column" gap="100">
-      <SettingTile title={title} focusId="name-color" description={description} />
-      <Box
-        alignItems="Center"
-        justifyContent="SpaceBetween"
-        gap="300"
-        style={{
-          padding: config.space.S400,
-          backgroundColor: 'var(--sable-surface-container)',
-          borderRadius: config.radii.R400,
-        }}
-      >
-        <Box alignItems="Center" gap="300" grow="Yes">
-          <HexColorPickerPopOut
-            picker={<HexColorPicker color={tempColor} onChange={handleUpdate} />}
+      <SettingTile
+        title={title}
+        focusId={focusId}
+        description={description}
+        after={
+          <Box
+            alignItems="Center"
+            justifyContent="SpaceBetween"
+            gap="300"
+            style={{
+              padding: config.space.S100,
+              backgroundColor: 'var(--sable-surface-container)',
+              borderRadius: config.radii.R400,
+            }}
           >
-            {(onOpen, opened) => (
-              <Button
-                onClick={onOpen}
-                size="400"
-                variant="Secondary"
-                fill="None"
-                radii="300"
-                disabled={disabled ?? false}
-                style={{
-                  padding: config.space.S100,
-                  border: `2px solid ${opened ? 'var(--sable-primary-main)' : 'var(--sable-border-focus)'}`,
-                }}
+            <Box alignItems="Center" gap="300" grow="Yes">
+              <HexColorPickerPopOut
+                picker={<HexColorPicker color={tempColor} onChange={handleUpdate} />}
               >
-                <Box
+                {(onOpen, opened) => (
+                  <Button
+                    onClick={onOpen}
+                    size="400"
+                    variant="Secondary"
+                    fill="None"
+                    radii="300"
+                    disabled={disabled ?? false}
+                    style={{
+                      padding: config.space.S100,
+                      border: `2px solid ${opened ? 'var(--sable-primary-main)' : 'var(--sable-border-focus)'}`,
+                    }}
+                  >
+                    <Box
+                      style={{
+                        width: '32px',
+                        height: '32px',
+                        borderRadius: '50%',
+                        backgroundColor: tempColor,
+                        boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.1)',
+                      }}
+                    />
+                  </Button>
+                )}
+              </HexColorPickerPopOut>
+
+              <Box direction="Row" alignItems="Center" gap="100">
+                <Input
+                  value={tempColor}
+                  onChange={(e) => handleUpdate(e.currentTarget.value)}
+                  placeholder="#FFFFFF"
+                  variant="Background"
+                  size="300"
+                  radii="300"
+                  disabled={disabled ?? false}
                   style={{
-                    width: '32px',
-                    height: '32px',
-                    borderRadius: '50%',
-                    backgroundColor: tempColor,
-                    boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.1)',
+                    textTransform: 'uppercase',
+                    fontFamily: 'monospace',
+                    width: '100px',
                   }}
                 />
+                {current && (
+                  <IconButton
+                    variant="Secondary"
+                    size="300"
+                    radii="300"
+                    disabled={disabled ?? false}
+                    onClick={handleReset}
+                    title="Reset to default"
+                  >
+                    <Icon src={Icons.Cross} size="100" />
+                  </IconButton>
+                )}
+              </Box>
+            </Box>
+
+            {hasChanged && (
+              <Button
+                variant="Primary"
+                size="300"
+                radii="Pill"
+                onClick={handleSave}
+                disabled={!/^#[0-9A-F]{6}$/i.test(tempColor)}
+              >
+                <Text size="B300">Save</Text>
               </Button>
             )}
-          </HexColorPickerPopOut>
-
-          <Box direction="Row" alignItems="Center" gap="100">
-            <Input
-              value={tempColor}
-              onChange={(e) => handleUpdate(e.currentTarget.value)}
-              placeholder="#FFFFFF"
-              variant="Background"
-              size="300"
-              radii="300"
-              disabled={disabled ?? false}
-              style={{
-                textTransform: 'uppercase',
-                fontFamily: 'monospace',
-                width: '100px',
-              }}
-            />
-            {current && (
-              <IconButton
-                variant="Secondary"
-                size="300"
-                radii="300"
-                disabled={disabled ?? false}
-                onClick={handleReset}
-                title="Reset to default"
-              >
-                <Icon src={Icons.Cross} size="100" />
-              </IconButton>
-            )}
           </Box>
-        </Box>
-
-        {hasChanged && (
-          <Button
-            variant="Primary"
-            size="300"
-            radii="Pill"
-            onClick={handleSave}
-            disabled={!/^#[0-9A-F]{6}$/i.test(tempColor)}
-          >
-            <Text size="B300">Save</Text>
-          </Button>
-        )}
-      </Box>
+        }
+      />
     </Box>
   );
 }

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -539,10 +539,29 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
         gap="400"
       >
         <NameColorEditor
-          title="Global Name Color"
+          title="General Global Name Color"
           description="Custom name color everywhere names have color!"
+          focusId="name-color"
           current={profile.nameColor || profile.extended?.['moe.sable.app.name_color']}
           onSave={(color) => handleSaveField('moe.sable.app.name_color', color)}
+        />
+        <NameColorEditor
+          title="Dark theme Global Name Color"
+          description="Your name's color when using a dark theme"
+          focusId="name-color-dark-theme"
+          current={
+            profile.nameColorDark || profile.extended?.['moe.sable.app.name_color_dark_theme']
+          }
+          onSave={(color) => handleSaveField('moe.sable.app.name_color_dark_theme', color)}
+        />
+        <NameColorEditor
+          title="Light theme Global Name Color"
+          description="Your name's color when using a light theme"
+          focusId="name-color-light-theme"
+          current={
+            profile.nameColorLight || profile.extended?.['moe.sable.app.name_color_light_theme']
+          }
+          onSave={(color) => handleSaveField('moe.sable.app.name_color_light_theme', color)}
         />
       </SequenceCard>
       <SequenceCard
@@ -658,7 +677,6 @@ export function Profile() {
   const mx = useMatrixClient();
   const userId = mx.getUserId()!;
   const profile = useUserProfile(userId);
-
   return (
     <Box direction="Column" gap="700">
       <Box direction="Column" gap="100">

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -547,7 +547,7 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
         />
         <NameColorEditor
           title="Dark theme Global Name Color"
-          description="Your name's color when using a dark theme"
+          description="Your name's color for a dark theme user."
           focusId="name-color-dark-theme"
           current={
             profile.nameColorDark || profile.extended?.['moe.sable.app.name_color_dark_theme']
@@ -556,7 +556,7 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
         />
         <NameColorEditor
           title="Light theme Global Name Color"
-          description="Your name's color when using a light theme"
+          description="Your name's color for a light theme user."
           focusId="name-color-light-theme"
           current={
             profile.nameColorLight || profile.extended?.['moe.sable.app.name_color_light_theme']

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -9,6 +9,7 @@ import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { MSC1767Text } from '$types/matrix/common';
 import { useMatrixClient } from './useMatrixClient';
+import { ThemeKind, useActiveTheme } from './useTheme';
 
 const inFlightProfiles = new Map<string, Promise<any>>();
 
@@ -25,6 +26,8 @@ export type UserProfile = {
   status?: string;
   bannerUrl?: string;
   nameColor?: string;
+  nameColorDark?: string;
+  nameColorLight?: string;
   isCat?: boolean;
   hasCats?: boolean;
   extended?: Record<string, any>;
@@ -45,6 +48,8 @@ const normalizeInfo = (info: any): UserProfile => {
     'chat.commet.profile_banner',
     'chat.commet.profile_status',
     'moe.sable.app.name_color',
+    'moe.sable.app.name_color_dark_theme',
+    'moe.sable.app.name_color_light_theme',
     'kitty.meow.has_cats',
     'kitty.meow.is_cat',
   ]);
@@ -68,6 +73,8 @@ const normalizeInfo = (info: any): UserProfile => {
     status: info['chat.commet.profile_status'],
     bannerUrl: info['chat.commet.profile_banner'],
     nameColor: info['moe.sable.app.name_color'],
+    nameColorDark: info['moe.sable.app.name_color_dark_theme'],
+    nameColorLight: info['moe.sable.app.name_color_light_theme'],
     isCat: info['kitty.meow.is_cat'] === true,
     hasCats: info['kitty.meow.has_cats'] === true,
     extended,
@@ -98,6 +105,7 @@ export const useUserProfile = (
   const [renderGlobalColors] = useSetting(settingsAtom, 'renderGlobalNameColors');
   const [renderRoomColors] = useSetting(settingsAtom, 'renderRoomColors');
   const [renderRoomFonts] = useSetting(settingsAtom, 'renderRoomFonts');
+  const themeKind = useActiveTheme().kind;
 
   const userSelector = useMemo(() => selectAtom(profilesCacheAtom, (db) => db[userId]), [userId]);
 
@@ -202,12 +210,26 @@ export const useUserProfile = (
       }
     }
     const validGlobalVal = isValidHex(data?.nameColor);
+    const validGlobalValDark = isValidHex(data?.nameColorDark);
+    const validGlobalValLight = isValidHex(data?.nameColorLight);
 
-    const hasGlobalColor = !!validGlobalVal;
-    const validGlobal =
-      (renderGlobalColors || userId === mx.getUserId()) && hasGlobalColor
+    const validGlobalGeneral =
+      (renderGlobalColors || userId === mx.getUserId()) && !!validGlobalVal
         ? validGlobalVal
         : undefined;
+    const validGlobalDark =
+      (renderGlobalColors || userId === mx.getUserId()) &&
+      themeKind === ThemeKind.Dark &&
+      !!validGlobalValDark
+        ? validGlobalValDark
+        : undefined;
+    const validGlobalLight =
+      (renderGlobalColors || userId === mx.getUserId()) &&
+      themeKind === ThemeKind.Light &&
+      !!validGlobalValLight
+        ? validGlobalValLight
+        : undefined;
+    const validGlobal = validGlobalDark ?? validGlobalLight ?? validGlobalGeneral;
     const validLocal = localColor && isValidHex(localColor) ? localColor : undefined;
     const validSpace = spaceColor && isValidHex(spaceColor) ? spaceColor : undefined;
 
@@ -237,13 +259,14 @@ export const useUserProfile = (
     };
   }, [
     cached,
+    initialProfile,
+    mx,
     userId,
     room,
-    mx,
-    legacyUsernameColor,
-    renderGlobalColors,
-    initialProfile,
     renderRoomColors,
     renderRoomFonts,
+    renderGlobalColors,
+    themeKind,
+    legacyUsernameColor,
   ]);
 };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR proposes the ability to set up different Global Name Colors with the purpose of making names easier to read for everyone independent on which theme they might choose to use.

The Global Name Colors options are the General for legacy puroses, Dark and Light Theme.

(example of the issue)
<img width="620" height="565" alt="image" src="https://github.com/user-attachments/assets/ba3e5abd-b390-4fea-864d-ff290507efd3" />
Here the names of 7w1, Shea, Lunia and potentially Haz are hard to read if one chooses to use a Light theme.

(example of the name Shea being corrected for using this PR)
<img width="619" height="568" alt="image" src="https://github.com/user-attachments/assets/11720d83-573d-442f-9ee6-139e294089ab" />

This PR also reorganizes the setting for the Global Name Colors location in order to align it more to the style of the other settings:
<img width="817" height="696" alt="image" src="https://github.com/user-attachments/assets/ef25c513-9503-4a05-bed9-0ba81a10e188" />

And puts the Save button to the left as to not move the text box and the selector button when it appears:
<img width="816" height="699" alt="image" src="https://github.com/user-attachments/assets/9df3e1bc-1951-4d7a-a931-44a05e9156b1" />

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
My anxiety about the future helped me overthink the solution into existence