### PR TITLE
fix(timeline): fix blank room timeline when app returns from background

### DIFF
--- a/.changeset/fix-timeline-blank-on-foreground.md
+++ b/.changeset/fix-timeline-blank-on-foreground.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix blank room timeline when app returns from background. When sliding sync delivers an `initial: true` response for the open room, a `TimelineReset` event now correctly shows skeleton placeholders while events reload instead of leaving an empty view.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -328,6 +328,17 @@ export function RoomTimeline({
     []
   );
 
+  // If the timeline was blanked while content was already visible — e.g. a
+  // TimelineReset fired by mx.retryImmediately() when the app comes back from
+  // background — hide the timeline (opacity 0) and re-arm the initial-scroll so
+  // it runs again once events refill the live timeline.
+  useLayoutEffect(() => {
+    if (!isReady) return;
+    if (timelineSync.eventsLength > 0) return;
+    setIsReady(false);
+    hasInitialScrolledRef.current = false;
+  }, [isReady, timelineSync.eventsLength]);
+
   const recalcTopSpacer = useCallback(() => {
     const v = vListRef.current;
     if (!v) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -651,7 +651,7 @@ export function RoomTimeline({
 
   const showLoadingPlaceholders =
     timelineSync.eventsLength === 0 &&
-    (timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading');
+    (!isReady || timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading');
 
   let backPaginationJSX: ReactNode | undefined;
   if (timelineSync.canPaginateBack || timelineSync.backwardStatus !== 'idle') {
@@ -719,7 +719,7 @@ export function RoomTimeline({
 
   const vListItemCount =
     timelineSync.eventsLength === 0 &&
-    (timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading')
+    (!isReady || timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading')
       ? 3
       : timelineSync.eventsLength;
   const vListIndices = useMemo(
@@ -851,7 +851,7 @@ export function RoomTimeline({
           minHeight: 0,
           overflow: 'hidden',
           position: 'relative',
-          opacity: isReady ? 1 : 0,
+          opacity: isReady || showLoadingPlaceholders ? 1 : 0,
         }}
       >
         <VList<ProcessedEvent>


### PR DESCRIPTION
## Description

When the app returns from background, `retryImmediately()` triggers a fresh sliding sync response. If the server includes `initial: true` for the currently open room, the SDK emits `RoomEvent.TimelineReset`, replacing the live timeline with a new empty one. `eventsLength` drops to 0 but `isReady` stays `true`, leaving the message list visually blank for ~500 ms until events re-arrive from the server.

### Changes

**`RoomTimeline.tsx`**

- Added a `useLayoutEffect` that detects `eventsLength` dropping to 0 while the timeline is already visible (`isReady === true`). It immediately sets `isReady = false` and resets `hasInitialScrolledRef`, re-arming the existing initial-scroll logic. Uses `useLayoutEffect` so the transition happens before the browser paints — the blank frame is never shown.

- Expanded `showLoadingPlaceholders`, `vListItemCount`, and the container `opacity` to include the `!isReady` case, so skeleton placeholders are shown immediately during the reload rather than leaving an invisible list.

### Before / After

| Before | After |
|--------|-------|
| Room goes blank for ~500 ms on foreground return | Skeleton placeholders appear instantly, then content fades in |

Fixes #

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## AI disclosure:

Fully AI generated (explain what all the generated code does in moderate detail).

The `useLayoutEffect` guard and the three `!isReady` condition expansions were fully AI generated. The effect fires synchronously before paint when `eventsLength` drops to 0 on an already-visible timeline, hides content and resets the initial-scroll flag. The existing 80 ms scroll timer then re-runs once events refill and calls `setIsReady(true)`. The `showLoadingPlaceholders` / `vListItemCount` changes ensure VList renders 3 placeholder skeleton rows (matching the existing pagination-loading behaviour) while events are absent.