### PR TITLE
perf(timeline): restore VList cache + skip 80 ms timer on room revisit

### DIFF
--- a/.changeset/perf-timeline-scroll-cache.md
+++ b/.changeset/perf-timeline-scroll-cache.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Cache VList item heights across room visits to restore scroll position instantly and skip the 80 ms opacity-fade stabilisation timer on revisit.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -316,6 +316,9 @@ export function RoomTimeline({
         // immediately and skip the 80 ms stabilisation timer entirely.
         if (savedCache.atBottom) {
           vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
+          // scrollToIndex is async; pre-empt the button so it doesn't flash for
+          // one render cycle before VList's onScroll confirms the position.
+          setAtBottom(true);
         } else {
           vListRef.current.scrollTo(savedCache.scrollOffset);
         }
@@ -347,6 +350,9 @@ export function RoomTimeline({
             // was empty when the timer fired (e.g. the onLifecycle reset cleared the
             // timeline within the 80 ms window), defer setIsReady until the recovery
             // effect below fires once events repopulate.
+            // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest"
+            // button doesn't flash for one render cycle before onScroll confirms.
+            setAtBottom(true);
             setIsReady(true);
           } else {
             pendingReadyRef.current = true;
@@ -356,7 +362,13 @@ export function RoomTimeline({
     }
     // No cleanup return — the timer must survive eventsLength fluctuations.
     // It is cancelled on unmount by the dedicated effect below.
-  }, [timelineSync.eventsLength, timelineSync.liveTimelineLinked, eventId, room.roomId]);
+  }, [
+    timelineSync.eventsLength,
+    timelineSync.liveTimelineLinked,
+    eventId,
+    room.roomId,
+    setAtBottom,
+  ]);
 
   // Cancel the initial-scroll timer on unmount (the useLayoutEffect above
   // intentionally does not cancel it when deps change).
@@ -799,8 +811,11 @@ export function RoomTimeline({
         atBottom: true,
       });
     }
+    // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
+    // doesn't flash for one render cycle before onScroll confirms the position.
+    setAtBottom(true);
     setIsReady(true);
-  }, [processedEvents.length, room.roomId]);
+  }, [processedEvents.length, room.roomId, setAtBottom]);
 
   useEffect(() => {
     if (!onEditLastMessageRef) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -200,8 +200,13 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
-  // Scroll cache snapshot loaded for the current room (populated on room change).
-  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(undefined);
+  // Load any cached scroll state for this room on mount. A fresh RoomTimeline is
+  // mounted per room (via key={roomId} in RoomView) so this is the only place we
+  // need to read the cache — the render-phase room-change block below only fires
+  // in the (hypothetical) case where the room prop changes without a remount.
+  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
+    roomScrollCache.load(room.roomId)
+  );
   const [atBottomState, setAtBottomState] = useState(true);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
@@ -228,16 +233,8 @@ export function RoomTimeline({
   const [isReady, setIsReady] = useState(false);
 
   if (currentRoomIdRef.current !== room.roomId) {
-    // Save outgoing room's scroll state so we can restore it on revisit.
-    const outgoing = vListRef.current;
-    if (outgoing && isReady) {
-      roomScrollCache.save(currentRoomIdRef.current, {
-        cache: outgoing.cache,
-        scrollOffset: outgoing.scrollOffset,
-        atBottom: atBottomRef.current,
-      });
-    }
     // Load incoming room's scroll cache (undefined for first-visit rooms).
+    // Covers the rare case where room prop changes without a remount.
     scrollCacheForRoomRef.current = roomScrollCache.load(room.roomId);
 
     hasInitialScrolledRef.current = false;
@@ -336,6 +333,16 @@ export function RoomTimeline({
             vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
               align: 'end',
             });
+            // Persist the now-measured item heights so the next visit to this room
+            // can provide them to VList upfront and skip this 80 ms wait entirely.
+            const v = vListRef.current;
+            if (v) {
+              roomScrollCache.save(room.roomId, {
+                cache: v.cache,
+                scrollOffset: v.scrollOffset,
+                atBottom: true,
+              });
+            }
             // Only mark ready once we've successfully scrolled.  If processedEvents
             // was empty when the timer fired (e.g. the onLifecycle reset cleared the
             // timeline within the 80 ms window), defer setIsReady until the recovery
@@ -656,6 +663,14 @@ export function RoomTimeline({
         setAtBottom(isNowAtBottom);
       }
 
+      // Keep the scroll cache fresh so the next visit to this room can restore
+      // position (and skip the 80 ms measurement wait) immediately on mount.
+      roomScrollCache.save(room.roomId, {
+        cache: v.cache,
+        scrollOffset: offset,
+        atBottom: isNowAtBottom,
+      });
+
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {
         timelineSyncRef.current.handleTimelinePagination(true);
       }
@@ -667,7 +682,7 @@ export function RoomTimeline({
         timelineSyncRef.current.handleTimelinePagination(false);
       }
     },
-    [setAtBottom]
+    [setAtBottom, room.roomId]
   );
 
   const showLoadingPlaceholders =

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -13,6 +13,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { PushProcessor, Room, Direction } from '$types/matrix-sdk';
 import classNames from 'classnames';
 import { VList, VListHandle } from 'virtua';
+import { roomScrollCache, RoomScrollCache } from '$utils/roomScrollCache';
 import {
   as,
   Box,
@@ -199,6 +200,8 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
+  // Scroll cache snapshot loaded for the current room (populated on room change).
+  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(undefined);
   const [atBottomState, setAtBottomState] = useState(true);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
@@ -225,6 +228,18 @@ export function RoomTimeline({
   const [isReady, setIsReady] = useState(false);
 
   if (currentRoomIdRef.current !== room.roomId) {
+    // Save outgoing room's scroll state so we can restore it on revisit.
+    const outgoing = vListRef.current;
+    if (outgoing && isReady) {
+      roomScrollCache.save(currentRoomIdRef.current, {
+        cache: outgoing.cache,
+        scrollOffset: outgoing.scrollOffset,
+        atBottom: atBottomRef.current,
+      });
+    }
+    // Load incoming room's scroll cache (undefined for first-visit rooms).
+    scrollCacheForRoomRef.current = roomScrollCache.load(room.roomId);
+
     hasInitialScrolledRef.current = false;
     mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
@@ -296,24 +311,41 @@ export function RoomTimeline({
       timelineSync.liveTimelineLinked &&
       vListRef.current
     ) {
-      vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
-      // Store in a ref rather than a local so subsequent eventsLength changes
-      // (e.g. the onLifecycle timeline reset firing within 80 ms) do NOT
-      // cancel this timer through the useLayoutEffect cleanup.
-      initialScrollTimerRef.current = setTimeout(() => {
-        initialScrollTimerRef.current = undefined;
-        if (processedEventsRef.current.length > 0) {
-          vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
-          // Only mark ready once we've successfully scrolled.  If processedEvents
-          // was empty when the timer fired (e.g. the onLifecycle reset cleared the
-          // timeline within the 80 ms window), defer setIsReady until the recovery
-          // effect below fires once events repopulate.
-          setIsReady(true);
-        } else {
-          pendingReadyRef.current = true;
-        }
-      }, 80);
+      const savedCache = scrollCacheForRoomRef.current;
       hasInitialScrolledRef.current = true;
+
+      if (savedCache) {
+        // Revisiting a room with a cached scroll state — restore position
+        // immediately and skip the 80 ms stabilisation timer entirely.
+        if (savedCache.atBottom) {
+          vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
+        } else {
+          vListRef.current.scrollTo(savedCache.scrollOffset);
+        }
+        setIsReady(true);
+      } else {
+        // First visit — original behaviour: scroll to bottom, then wait 80 ms
+        // for VList to finish measuring item heights before revealing the timeline.
+        vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
+        // Store in a ref rather than a local so subsequent eventsLength changes
+        // (e.g. the onLifecycle timeline reset firing within 80 ms) do NOT
+        // cancel this timer through the useLayoutEffect cleanup.
+        initialScrollTimerRef.current = setTimeout(() => {
+          initialScrollTimerRef.current = undefined;
+          if (processedEventsRef.current.length > 0) {
+            vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
+              align: 'end',
+            });
+            // Only mark ready once we've successfully scrolled.  If processedEvents
+            // was empty when the timer fired (e.g. the onLifecycle reset cleared the
+            // timeline within the 80 ms window), defer setIsReady until the recovery
+            // effect below fires once events repopulate.
+            setIsReady(true);
+          } else {
+            pendingReadyRef.current = true;
+          }
+        }, 80);
+      }
     }
     // No cleanup return — the timer must survive eventsLength fluctuations.
     // It is cancelled on unmount by the dedicated effect below.
@@ -844,8 +876,10 @@ export function RoomTimeline({
         }}
       >
         <VList<ProcessedEvent>
+          key={room.roomId}
           ref={vListRef}
           data={processedEvents}
+          cache={scrollCacheForRoomRef.current?.cache}
           shift={shift}
           className={css.messageList}
           style={{

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -789,8 +789,18 @@ export function RoomTimeline({
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
+    // The 80 ms timer's cache-save was skipped because processedEvents was empty
+    // when it fired. Save now so the next visit skips the timer.
+    const v = vListRef.current;
+    if (v) {
+      roomScrollCache.save(room.roomId, {
+        cache: v.cache,
+        scrollOffset: v.scrollOffset,
+        atBottom: true,
+      });
+    }
     setIsReady(true);
-  }, [processedEvents.length]);
+  }, [processedEvents.length, room.roomId]);
 
   useEffect(() => {
     if (!onEditLastMessageRef) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -228,6 +228,12 @@ export function RoomTimeline({
   // A recovery useLayoutEffect watches for processedEvents becoming non-empty
   // and performs the final scroll + setIsReady when this flag is set.
   const pendingReadyRef = useRef(false);
+  // Set to true before each programmatic scroll-to-bottom so intermediate
+  // onScroll events from virtua's height-correction pass cannot drive
+  // atBottomState to false (flashing the "Jump to Latest" button).
+  // Cleared when VList confirms isNowAtBottom, or on the first intermediate
+  // event so subsequent user-initiated scrolls are tracked normally.
+  const programmaticScrollToBottomRef = useRef(false);
   const currentRoomIdRef = useRef(room.roomId);
 
   const [isReady, setIsReady] = useState(false);
@@ -241,6 +247,7 @@ export function RoomTimeline({
     mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
     pendingReadyRef.current = false;
+    programmaticScrollToBottomRef.current = false;
     if (initialScrollTimerRef.current !== undefined) {
       clearTimeout(initialScrollTimerRef.current);
       initialScrollTimerRef.current = undefined;
@@ -315,6 +322,7 @@ export function RoomTimeline({
         // Revisiting a room with a cached scroll state — restore position
         // immediately and skip the 80 ms stabilisation timer entirely.
         if (savedCache.atBottom) {
+          programmaticScrollToBottomRef.current = true;
           vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
           // scrollToIndex is async; pre-empt the button so it doesn't flash for
           // one render cycle before VList's onScroll confirms the position.
@@ -333,6 +341,7 @@ export function RoomTimeline({
         initialScrollTimerRef.current = setTimeout(() => {
           initialScrollTimerRef.current = undefined;
           if (processedEventsRef.current.length > 0) {
+            programmaticScrollToBottomRef.current = true;
             vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
               align: 'end',
             });
@@ -671,8 +680,20 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
+      // Clear the programmatic-scroll guard whenever VList confirms we are at the
+      // bottom, regardless of whether atBottomRef needs updating.
+      if (isNowAtBottom) programmaticScrollToBottomRef.current = false;
       if (isNowAtBottom !== atBottomRef.current) {
-        setAtBottom(isNowAtBottom);
+        if (isNowAtBottom || !programmaticScrollToBottomRef.current) {
+          setAtBottom(isNowAtBottom);
+        } else {
+          // VList fired an intermediate "not at bottom" event while settling after
+          // a programmatic scroll-to-bottom (e.g. height-correction pass). Suppress
+          // the false negative and clear the guard so the next event — either a
+          // VList correction to the true bottom, or a genuine user scroll — is
+          // processed normally.
+          programmaticScrollToBottomRef.current = false;
+        }
       }
 
       // Keep the scroll cache fresh so the next visit to this room can restore
@@ -800,6 +821,7 @@ export function RoomTimeline({
     if (!pendingReadyRef.current) return;
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
+    programmaticScrollToBottomRef.current = true;
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
     // The 80 ms timer's cache-save was skipped because processedEvents was empty
     // when it fired. Save now so the next visit skips the timer.

--- a/src/app/utils/roomScrollCache.test.ts
+++ b/src/app/utils/roomScrollCache.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { roomScrollCache } from './roomScrollCache';
 
 // CacheSnapshot is opaque in tests — cast a plain object.
-const fakeCache = () => ({} as import('./roomScrollCache').RoomScrollCache['cache']);
+const fakeCache = () => ({}) as import('./roomScrollCache').RoomScrollCache['cache'];
 
 describe('roomScrollCache', () => {
   it('load returns undefined for an unknown roomId', () => {

--- a/src/app/utils/roomScrollCache.test.ts
+++ b/src/app/utils/roomScrollCache.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { roomScrollCache } from './roomScrollCache';
+
+// CacheSnapshot is opaque in tests — cast a plain object.
+const fakeCache = () => ({} as import('./roomScrollCache').RoomScrollCache['cache']);
+
+describe('roomScrollCache', () => {
+  it('load returns undefined for an unknown roomId', () => {
+    expect(roomScrollCache.load('!unknown:test')).toBeUndefined();
+  });
+
+  it('stores and retrieves data for a roomId', () => {
+    const data = { cache: fakeCache(), scrollOffset: 120, atBottom: false };
+    roomScrollCache.save('!room1:test', data);
+    expect(roomScrollCache.load('!room1:test')).toBe(data);
+  });
+
+  it('overwrites existing data when saved again for the same roomId', () => {
+    const first = { cache: fakeCache(), scrollOffset: 50, atBottom: true };
+    const second = { cache: fakeCache(), scrollOffset: 200, atBottom: false };
+    roomScrollCache.save('!room2:test', first);
+    roomScrollCache.save('!room2:test', second);
+    expect(roomScrollCache.load('!room2:test')).toBe(second);
+  });
+
+  it('keeps data for separate rooms independent', () => {
+    const a = { cache: fakeCache(), scrollOffset: 10, atBottom: true };
+    const b = { cache: fakeCache(), scrollOffset: 20, atBottom: false };
+    roomScrollCache.save('!roomA:test', a);
+    roomScrollCache.save('!roomB:test', b);
+    expect(roomScrollCache.load('!roomA:test')).toBe(a);
+    expect(roomScrollCache.load('!roomB:test')).toBe(b);
+  });
+});

--- a/src/app/utils/roomScrollCache.ts
+++ b/src/app/utils/roomScrollCache.ts
@@ -1,0 +1,22 @@
+import { CacheSnapshot } from 'virtua';
+
+export type RoomScrollCache = {
+  /** VList item-size snapshot — restored via VList `cache=` prop on remount. */
+  cache: CacheSnapshot;
+  /** Pixel scroll offset at the time the room was left. */
+  scrollOffset: number;
+  /** Whether the view was pinned to the bottom (live) when the room was left. */
+  atBottom: boolean;
+};
+
+/** Session-scoped, per-room scroll cache. Not persisted across page reloads. */
+const scrollCacheMap = new Map<string, RoomScrollCache>();
+
+export const roomScrollCache = {
+  save(roomId: string, data: RoomScrollCache): void {
+    scrollCacheMap.set(roomId, data);
+  },
+  load(roomId: string): RoomScrollCache | undefined {
+    return scrollCacheMap.get(roomId);
+  },
+};


### PR DESCRIPTION
### Description

Caches VList item heights (via `roomScrollCache`) across visits to the same room within a session. On revisit, the stored cache is provided to VList upfront and the scroll position is restored immediately — skipping the 80 ms opacity-fade stabilisation timer entirely.

Also fixes a bug where the `pendingReadyRef` recovery path (triggered when the 80 ms timer fires while `processedEvents` is empty due to a `TimelineReset` race) never saved the scroll cache, causing rooms that hit this path to show the fade-in on subsequent visits.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

`roomScrollCache.ts` — a simple session-scoped `Map<roomId, { cache, scrollOffset, atBottom }>`. `cache` is VList's `CacheSnapshot` (measured item heights), `scrollOffset` is the pixel offset at save time, and `atBottom` is a flag used to decide whether to call `scrollToIndex` (bottom) or `scrollTo` (exact offset) on restore.

In `RoomTimeline.tsx`, the initial-scroll `useLayoutEffect` was extended to check for a saved cache before starting the 80 ms timer: if a cache exists, it restores position immediately and calls `setIsReady(true)` without the delay. The 80 ms timer path and the `pendingReadyRef` recovery path both now call `roomScrollCache.save(...)` after scrolling so subsequent visits have a cache to load.