### PR TITLE
perf(timeline): memoize VList timeline items to prevent mass re-renders

### DIFF
--- a/.changeset/perf-timeline-item-memo.md
+++ b/.changeset/perf-timeline-item-memo.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Memoize individual VList timeline items to prevent mass re-renders when unrelated state changes (e.g. typing indicators, read receipts, or new messages while not at the bottom).

--- a/.changeset/perf-timeline-scroll-cache.md
+++ b/.changeset/perf-timeline-scroll-cache.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Cache VList item heights across room visits to restore scroll position instantly and skip the 80 ms opacity-fade stabilisation timer on revisit.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -297,6 +297,9 @@ export function RoomTimeline({
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
+    // Guard against VList's intermediate height-correction scroll events that
+    // would otherwise call setAtBottom(false) before the scroll settles.
+    programmaticScrollToBottomRef.current = true;
     vListRef.current.scrollTo(vListRef.current.scrollSize);
   }, []);
 
@@ -745,14 +748,13 @@ export function RoomTimeline({
       if (isNowAtBottom !== atBottomRef.current) {
         if (isNowAtBottom || !programmaticScrollToBottomRef.current) {
           setAtBottom(isNowAtBottom);
-        } else {
-          // VList fired an intermediate "not at bottom" event while settling after
-          // a programmatic scroll-to-bottom (e.g. height-correction pass). Suppress
-          // the false negative and clear the guard so the next event — either a
-          // VList correction to the true bottom, or a genuine user scroll — is
-          // processed normally.
-          programmaticScrollToBottomRef.current = false;
         }
+        // else: programmatic guard active — suppress the false-negative and keep
+        // the guard set.  VList can fire several intermediate "not at bottom"
+        // events while it corrects item heights after a scrollTo(); clearing the
+        // guard on the first one would let the second cause a spurious
+        // setAtBottom(false) and flash the "Jump to Latest" button.  The guard
+        // is cleared above (unconditionally) when isNowAtBottom becomes true.
       }
 
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -420,6 +420,19 @@ export function RoomTimeline({
     hasInitialScrolledRef.current = false;
   }, [isReady, timelineSync.eventsLength]);
 
+  // When a genuine TimelineReset replaces the timeline chain (new
+  // EventTimeline objects from the SDK), hide content behind opacity 0 and
+  // re-arm the initial-scroll so the new data renders invisibly, gets
+  // measured, and only then becomes visible — preventing a visible flash.
+  const prevResetTokenRef = useRef(timelineSync.timelineResetToken);
+  useLayoutEffect(() => {
+    if (timelineSync.timelineResetToken === prevResetTokenRef.current) return;
+    prevResetTokenRef.current = timelineSync.timelineResetToken;
+    if (!isReady) return;
+    setIsReady(false);
+    hasInitialScrolledRef.current = false;
+  }, [isReady, timelineSync.timelineResetToken]);
+
   const recalcTopSpacer = useCallback(() => {
     const v = vListRef.current;
     if (!v) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -101,27 +101,28 @@ type TimelineRenderFn = (eventData: ProcessedEvent) => ReactNode;
 interface TimelineItemProps {
   data: ProcessedEvent;
   renderRef: React.MutableRefObject<TimelineRenderFn | null>;
-  /** Changed when this specific item becomes highlighted / un-highlighted. */
+  // The props below are not read in the component body — they exist solely so
+  // React.memo's shallow-equality comparator sees them and re-renders only the
+  // affected item when they change.
+  // eslint-disable-next-line react/no-unused-prop-types
   isHighlighted: boolean;
-  /** Changed when this specific item enters / exits edit mode. */
+  // eslint-disable-next-line react/no-unused-prop-types
   isEditing: boolean;
-  /** Changed when this specific item is the active reply target. */
+  // eslint-disable-next-line react/no-unused-prop-types
   isReplying: boolean;
-  /** Changed when this specific item's thread drawer is open. */
+  // eslint-disable-next-line react/no-unused-prop-types
   isOpenThread: boolean;
-  /**
-   * Opaque object whose identity changes when any global render-affecting
-   * setting changes (layout, spacing, nicknames, permissions…).  Forces all
-   * visible items to re-render when settings change.
-   */
+  // eslint-disable-next-line react/no-unused-prop-types
   settingsEpoch: object;
 }
 
-const TimelineItem = memo(function TimelineItem({ data, renderRef }: TimelineItemProps) {
-  // isHighlighted, isEditing, isReplying, isOpenThread, settingsEpoch are not
-  // used here directly — their sole purpose is to guide React.memo comparisons.
+// Declared outside memo() so the callback receives a reference, not an inline
+// function expression (satisfies prefer-arrow-callback).
+function TimelineItemInner({ data, renderRef }: TimelineItemProps) {
   return <>{renderRef.current?.(data)}</>;
-});
+}
+const TimelineItem = memo(TimelineItemInner);
+TimelineItem.displayName = 'TimelineItem';
 
 const TimelineFloat = as<'div', css.TimelineFloatVariants>(
   ({ position, className, ...props }, ref) => (

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -279,6 +279,8 @@ export function RoomTimeline({
   const currentRoomIdRef = useRef(room.roomId);
 
   const [isReady, setIsReady] = useState(false);
+  const isReadyRef = useRef(false);
+  isReadyRef.current = isReady;
 
   if (currentRoomIdRef.current !== room.roomId) {
     // Load incoming room's scroll cache (undefined for first-visit rooms).
@@ -762,7 +764,10 @@ export function RoomTimeline({
       const isNowAtBottom = atBottomRef.current
         ? distanceFromBottom < 300
         : distanceFromBottom < 100;
-      if (isNowAtBottom !== atBottomRef.current) {
+      // Suppress atBottom flips during the initial scroll-to-bottom sequence:
+      // VList fires intermediate scroll events before the scroll settles, and
+      // if isReady is set in the same commit the button briefly flashes.
+      if (isNowAtBottom !== atBottomRef.current && isReadyRef.current) {
         setAtBottom(isNowAtBottom);
       }
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -247,8 +247,13 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
-  // Scroll cache snapshot loaded for the current room (populated on room change).
-  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(undefined);
+  // Load any cached scroll state for this room on mount. A fresh RoomTimeline is
+  // mounted per room (via key={roomId} in RoomView) so this is the only place we
+  // need to read the cache — the render-phase room-change block below only fires
+  // in the (hypothetical) case where the room prop changes without a remount.
+  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
+    roomScrollCache.load(room.roomId)
+  );
   const [atBottomState, setAtBottomState] = useState(true);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
@@ -281,16 +286,8 @@ export function RoomTimeline({
   const [isReady, setIsReady] = useState(false);
 
   if (currentRoomIdRef.current !== room.roomId) {
-    // Save outgoing room's scroll state so we can restore it on revisit.
-    const outgoing = vListRef.current;
-    if (outgoing && isReady) {
-      roomScrollCache.save(currentRoomIdRef.current, {
-        cache: outgoing.cache,
-        scrollOffset: outgoing.scrollOffset,
-        atBottom: atBottomRef.current,
-      });
-    }
     // Load incoming room's scroll cache (undefined for first-visit rooms).
+    // Covers the rare case where room prop changes without a remount.
     scrollCacheForRoomRef.current = roomScrollCache.load(room.roomId);
 
     hasInitialScrolledRef.current = false;
@@ -394,6 +391,16 @@ export function RoomTimeline({
             vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
               align: 'end',
             });
+            // Persist the now-measured item heights so the next visit to this room
+            // can provide them to VList upfront and skip this 80 ms wait entirely.
+            const v = vListRef.current;
+            if (v) {
+              roomScrollCache.save(room.roomId, {
+                cache: v.cache,
+                scrollOffset: v.scrollOffset,
+                atBottom: true,
+              });
+            }
             // Only mark ready once we've successfully scrolled.  If processedEvents
             // was empty when the timer fired (e.g. the onLifecycle reset cleared the
             // timeline within the 80 ms window), defer setIsReady until the recovery
@@ -802,6 +809,14 @@ export function RoomTimeline({
           atBottom: isNowAtBottom,
         });
       }
+
+      // Keep the scroll cache fresh so the next visit to this room can restore
+      // position (and skip the 80 ms measurement wait) immediately on mount.
+      roomScrollCache.save(room.roomId, {
+        cache: v.cache,
+        scrollOffset: offset,
+        atBottom: isNowAtBottom,
+      });
 
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {
         timelineSyncRef.current.handleTimelinePagination(true);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1062,7 +1062,7 @@ export function RoomTimeline({
           key={room.roomId}
           ref={vListRef}
           data={processedEvents}
-          cache={scrollCacheForRoomRef.current?.cache}
+          cache={!eventId ? scrollCacheForRoomRef.current?.cache : undefined}
           shift={shift}
           className={css.messageList}
           style={{

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -757,6 +757,20 @@ export function RoomTimeline({
         // is cleared above (unconditionally) when isNowAtBottom becomes true.
       }
 
+      // Keep the scroll cache fresh so the next visit to this room can restore
+      // position (and skip the 80 ms measurement wait) immediately on mount.
+      // Skip when viewing a historical slice via eventId: those item heights are
+      // for a sparse subset of events and would corrupt the cache for the next
+      // live-timeline visit, producing stale VList measurements and making the
+      // room appear to be at the wrong position (or visually empty) on re-entry.
+      if (!eventId) {
+        roomScrollCache.save(room.roomId, {
+          cache: v.cache,
+          scrollOffset: offset,
+          atBottom: isNowAtBottom,
+        });
+      }
+
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {
         timelineSyncRef.current.handleTimelinePagination(true);
       }
@@ -768,7 +782,7 @@ export function RoomTimeline({
         timelineSyncRef.current.handleTimelinePagination(false);
       }
     },
-    [setAtBottom]
+    [setAtBottom, room.roomId, eventId]
   );
 
   const showLoadingPlaceholders =

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -257,7 +257,7 @@ export function RoomTimeline({
   const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
     roomScrollCache.load(mxUserId, room.roomId)
   );
-  const [atBottomState, setAtBottomState] = useState(true);
+  const [atBottomState, setAtBottomState] = useState(!eventId);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
     setAtBottomState(val);
@@ -301,11 +301,18 @@ export function RoomTimeline({
   const processedEventsRef = useRef<ProcessedEvent[]>([]);
   const timelineSyncRef = useRef<typeof timelineSync>(null as unknown as typeof timelineSync);
 
-  const scrollToBottom = useCallback(() => {
+  const scrollToBottom = useCallback((behavior?: 'instant' | 'smooth') => {
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
-    vListRef.current.scrollTo(vListRef.current.scrollSize);
+    if (behavior === 'smooth') {
+      vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: true });
+    } else {
+      // scrollToIndex works reliably regardless of VList measurement state.
+      // The auto-scroll useLayoutEffect fires after React commits new items,
+      // so lastIndex is always valid when this is called.
+      vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
+    }
   }, []);
 
   const timelineSync = useTimelineSync({
@@ -491,8 +498,11 @@ export function RoomTimeline({
   useEffect(() => {
     if (!eventId) return;
     setIsReady(false);
+    // Ensure auto-scroll to bottom doesn't fire while we're navigating to a
+    // specific event — atBottom will be updated correctly once the user scrolls.
+    setAtBottom(false);
     timelineSyncRef.current.loadEventTimeline(eventId);
-  }, [eventId, room.roomId]);
+  }, [eventId, room.roomId, setAtBottom]);
 
   useEffect(() => {
     if (eventId) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -766,15 +766,18 @@ export function RoomTimeline({
       const contentGrew = v.scrollSize > prevScrollSizeRef.current;
       prevScrollSizeRef.current = v.scrollSize;
 
+      // Skip content-chase and cache saves during init: the timeline is hidden
+      // (opacity 0) while VList measures items and fires intermediate scroll
+      // events.  Chasing the bottom here causes cascading scrollTo calls that
+      // upstream doesn't have, producing visible layout churn after isReady.
+      if (!isReadyRef.current) return;
+
       if (atBottomRef.current && !isNowAtBottom && contentGrew) {
         v.scrollTo(v.scrollSize);
         return;
       }
 
-      // Suppress atBottom flips during the initial scroll-to-bottom sequence:
-      // VList fires intermediate scroll events before the scroll settles, and
-      // if isReady is set in the same commit the button briefly flashes.
-      if (isNowAtBottom !== atBottomRef.current && isReadyRef.current) {
+      if (isNowAtBottom !== atBottomRef.current) {
         setAtBottom(isNowAtBottom);
       }
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -109,6 +109,12 @@ interface TimelineItemProps {
 }
 /* eslint-enable react/no-unused-prop-types */
 
+// How long (ms) to suppress spurious "not at bottom" events after a
+// programmatic scroll-to-bottom. VList can fire several intermediate onScroll
+// events while it re-measures item heights after a scrollToIndex(); the window
+// lets all of them pass without flashing the "Jump to Latest" button.
+const SCROLL_SETTLE_MS = 200;
+
 // Declared outside memo() so the callback receives a reference, not an inline
 // function expression (satisfies prefer-arrow-callback).
 function TimelineItemInner({ data, renderRef }: TimelineItemProps) {
@@ -277,12 +283,15 @@ export function RoomTimeline({
   // A recovery useLayoutEffect watches for processedEvents becoming non-empty
   // and performs the final scroll + setIsReady when this flag is set.
   const pendingReadyRef = useRef(false);
-  // Set to true before each programmatic scroll-to-bottom so intermediate
-  // onScroll events from virtua's height-correction pass cannot drive
-  // atBottomState to false (flashing the "Jump to Latest" button).
-  // Cleared when VList confirms isNowAtBottom, or on the first intermediate
-  // event so subsequent user-initiated scrolls are tracked normally.
-  const programmaticScrollToBottomRef = useRef(false);
+  // Set to a timestamp (ms epoch) before each programmatic scroll-to-bottom so
+  // intermediate onScroll events from virtua's height-correction pass cannot
+  // drive atBottomState to false (flashing the "Jump to Latest" button).
+  // Using a timestamp rather than a boolean means the window expires naturally
+  // after SCROLL_SETTLE_MS without needing to clear it on `isNowAtBottom=true`.
+  // That prevents the second wave of false-negative events (which VList fires
+  // after re-measuring item heights) from slipping through after the first
+  // `isNowAtBottom=true` confirms the position.
+  const programmaticScrollToBottomRef = useRef(0);
   const currentRoomIdRef = useRef(room.roomId);
 
   const [isReady, setIsReady] = useState(false);
@@ -296,7 +305,7 @@ export function RoomTimeline({
     mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
     pendingReadyRef.current = false;
-    programmaticScrollToBottomRef.current = false;
+    programmaticScrollToBottomRef.current = 0;
     if (initialScrollTimerRef.current !== undefined) {
       clearTimeout(initialScrollTimerRef.current);
       initialScrollTimerRef.current = undefined;
@@ -313,7 +322,7 @@ export function RoomTimeline({
     if (lastIndex < 0) return;
     // Guard against VList's intermediate height-correction scroll events that
     // would otherwise call setAtBottom(false) before the scroll settles.
-    programmaticScrollToBottomRef.current = true;
+    programmaticScrollToBottomRef.current = Date.now();
     vListRef.current.scrollTo(vListRef.current.scrollSize);
   }, []);
 
@@ -374,7 +383,7 @@ export function RoomTimeline({
         // Revisiting a room with a cached scroll state — restore position
         // immediately and skip the 80 ms stabilisation timer entirely.
         if (savedCache.atBottom) {
-          programmaticScrollToBottomRef.current = true;
+          programmaticScrollToBottomRef.current = Date.now();
           vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
           // scrollToIndex is async; pre-empt the button so it doesn't flash for
           // one render cycle before VList's onScroll confirms the position.
@@ -393,7 +402,7 @@ export function RoomTimeline({
         initialScrollTimerRef.current = setTimeout(() => {
           initialScrollTimerRef.current = undefined;
           if (processedEventsRef.current.length > 0) {
-            programmaticScrollToBottomRef.current = true;
+            programmaticScrollToBottomRef.current = Date.now();
             vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
               align: 'end',
             });
@@ -517,9 +526,16 @@ export function RoomTimeline({
 
   useEffect(() => {
     if (!eventId) return;
+    // Reset atBottom and the programmatic-scroll guard so that:
+    // 1. The "Jump to Latest" button appears immediately (we are no longer at
+    //    the live bottom — we are viewing a historical slice).
+    // 2. The guard doesn't suppress the `isNowAtBottom=false` event that VList
+    //    fires when it scrolls to the target eventId.
+    setAtBottom(false);
+    programmaticScrollToBottomRef.current = 0;
     setIsReady(false);
     timelineSyncRef.current.loadEventTimeline(eventId);
-  }, [eventId, room.roomId]);
+  }, [eventId, room.roomId, setAtBottom]);
 
   useEffect(() => {
     if (eventId) return;
@@ -787,19 +803,16 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
-      // Clear the programmatic-scroll guard whenever VList confirms we are at the
-      // bottom, regardless of whether atBottomRef needs updating.
-      if (isNowAtBottom) programmaticScrollToBottomRef.current = false;
+      const isSettling = Date.now() - programmaticScrollToBottomRef.current < SCROLL_SETTLE_MS;
       if (isNowAtBottom !== atBottomRef.current) {
-        if (isNowAtBottom || !programmaticScrollToBottomRef.current) {
+        // Suppress intermediate "not at bottom" events that fire while VList
+        // re-measures item heights after a programmatic scrollToIndex.  The
+        // timestamp window expires naturally — no need to clear it on
+        // `isNowAtBottom=true`, which prevents a second wave of false-negatives
+        // (fired after height re-measurement completes) from slipping through.
+        if (isNowAtBottom || !isSettling) {
           setAtBottom(isNowAtBottom);
         }
-        // else: programmatic guard active — suppress the false-negative and keep
-        // the guard set.  VList can fire several intermediate "not at bottom"
-        // events while it corrects item heights after a scrollTo(); clearing the
-        // guard on the first one would let the second cause a spurious
-        // setAtBottom(false) and flash the "Jump to Latest" button.  The guard
-        // is cleared above (unconditionally) when isNowAtBottom becomes true.
       }
 
       // Keep the scroll cache fresh so the next visit to this room can restore
@@ -940,9 +953,8 @@ export function RoomTimeline({
     if (!pendingReadyRef.current) return;
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
-    programmaticScrollToBottomRef.current = true;
+    programmaticScrollToBottomRef.current = Date.now();
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
-    // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
     // doesn't flash for one render cycle before onScroll confirms the position.
     setAtBottom(true);
     // The 80 ms timer's cache-save was skipped because processedEvents was empty

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -355,6 +355,9 @@ export function RoomTimeline({
           // was empty when the timer fired (e.g. the onLifecycle reset cleared the
           // timeline within the 80 ms window), defer setIsReady until the recovery
           // effect below fires once events repopulate.
+          // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest"
+          // button doesn't flash for one render cycle before onScroll confirms.
+          setAtBottom(true);
           setIsReady(true);
         } else {
           pendingReadyRef.current = true;
@@ -364,7 +367,13 @@ export function RoomTimeline({
     }
     // No cleanup return — the timer must survive eventsLength fluctuations.
     // It is cancelled on unmount by the dedicated effect below.
-  }, [timelineSync.eventsLength, timelineSync.liveTimelineLinked, eventId, room.roomId]);
+  }, [
+    timelineSync.eventsLength,
+    timelineSync.liveTimelineLinked,
+    eventId,
+    room.roomId,
+    setAtBottom,
+  ]);
 
   // Cancel the initial-scroll timer on unmount (the useLayoutEffect above
   // intentionally does not cancel it when deps change).
@@ -851,8 +860,11 @@ export function RoomTimeline({
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
+    // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
+    // doesn't flash for one render cycle before onScroll confirms the position.
+    setAtBottom(true);
     setIsReady(true);
-  }, [processedEvents.length]);
+  }, [processedEvents.length, setAtBottom]);
 
   useEffect(() => {
     if (!onEditLastMessageRef) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -372,6 +372,7 @@ export function RoomTimeline({
         // Revisiting a room with a cached scroll state — restore position
         // immediately and skip the 80 ms stabilisation timer entirely.
         if (savedCache.atBottom) {
+          programmaticScrollToBottomRef.current = true;
           vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
           // scrollToIndex is async; pre-empt the button so it doesn't flash for
           // one render cycle before VList's onScroll confirms the position.
@@ -812,14 +813,6 @@ export function RoomTimeline({
           atBottom: isNowAtBottom,
         });
       }
-
-      // Keep the scroll cache fresh so the next visit to this room can restore
-      // position (and skip the 80 ms measurement wait) immediately on mount.
-      roomScrollCache.save(room.roomId, {
-        cache: v.cache,
-        scrollOffset: offset,
-        atBottom: isNowAtBottom,
-      });
 
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {
         timelineSyncRef.current.handleTimelinePagination(true);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -226,6 +226,7 @@ export function RoomTimeline({
   hideReadsRef.current = hideReads;
 
   const prevViewportHeightRef = useRef(0);
+  const prevScrollSizeRef = useRef(0);
   const messageListRef = useRef<HTMLDivElement>(null);
 
   const mediaAuthentication = useMediaAuthentication();
@@ -759,6 +760,20 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
+
+      // When the user is pinned to the bottom and content grows (images, embeds,
+      // video thumbnails loading), scrollSize increases while offset stays put,
+      // pushing distanceFromBottom above the threshold. Instead of flipping
+      // atBottom to false (which shows the "Jump to Latest" button), chase the
+      // bottom so the user stays pinned.
+      const contentGrew = v.scrollSize > prevScrollSizeRef.current;
+      prevScrollSizeRef.current = v.scrollSize;
+
+      if (atBottomRef.current && !isNowAtBottom && contentGrew) {
+        v.scrollTo(v.scrollSize);
+        return;
+      }
+
       // Suppress atBottom flips during the initial scroll-to-bottom sequence:
       // VList fires intermediate scroll events before the scroll settles, and
       // if isReady is set in the same commit the button briefly flashes.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -14,6 +14,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { PushProcessor, Room, Direction } from '$types/matrix-sdk';
 import classNames from 'classnames';
 import { VList, VListHandle } from 'virtua';
+import { roomScrollCache, RoomScrollCache } from '$utils/roomScrollCache';
 import {
   as,
   Box,
@@ -246,6 +247,8 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
+  // Scroll cache snapshot loaded for the current room (populated on room change).
+  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(undefined);
   const [atBottomState, setAtBottomState] = useState(true);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
@@ -278,6 +281,18 @@ export function RoomTimeline({
   const [isReady, setIsReady] = useState(false);
 
   if (currentRoomIdRef.current !== room.roomId) {
+    // Save outgoing room's scroll state so we can restore it on revisit.
+    const outgoing = vListRef.current;
+    if (outgoing && isReady) {
+      roomScrollCache.save(currentRoomIdRef.current, {
+        cache: outgoing.cache,
+        scrollOffset: outgoing.scrollOffset,
+        atBottom: atBottomRef.current,
+      });
+    }
+    // Load incoming room's scroll cache (undefined for first-visit rooms).
+    scrollCacheForRoomRef.current = roomScrollCache.load(room.roomId);
+
     hasInitialScrolledRef.current = false;
     mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
@@ -353,28 +368,45 @@ export function RoomTimeline({
       timelineSync.liveTimelineLinked &&
       vListRef.current
     ) {
-      vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
-      // Store in a ref rather than a local so subsequent eventsLength changes
-      // (e.g. the onLifecycle timeline reset firing within 80 ms) do NOT
-      // cancel this timer through the useLayoutEffect cleanup.
-      initialScrollTimerRef.current = setTimeout(() => {
-        initialScrollTimerRef.current = undefined;
-        if (processedEventsRef.current.length > 0) {
-          programmaticScrollToBottomRef.current = true;
-          vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
-          // Only mark ready once we've successfully scrolled.  If processedEvents
-          // was empty when the timer fired (e.g. the onLifecycle reset cleared the
-          // timeline within the 80 ms window), defer setIsReady until the recovery
-          // effect below fires once events repopulate.
-          // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest"
-          // button doesn't flash for one render cycle before onScroll confirms.
-          setAtBottom(true);
-          setIsReady(true);
-        } else {
-          pendingReadyRef.current = true;
-        }
-      }, 80);
+      const savedCache = scrollCacheForRoomRef.current;
       hasInitialScrolledRef.current = true;
+
+      if (savedCache) {
+        // Revisiting a room with a cached scroll state — restore position
+        // immediately and skip the 80 ms stabilisation timer entirely.
+        if (savedCache.atBottom) {
+          vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
+        } else {
+          vListRef.current.scrollTo(savedCache.scrollOffset);
+        }
+        setIsReady(true);
+      } else {
+        // First visit — original behaviour: scroll to bottom, then wait 80 ms
+        // for VList to finish measuring item heights before revealing the timeline.
+        vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
+        // Store in a ref rather than a local so subsequent eventsLength changes
+        // (e.g. the onLifecycle timeline reset firing within 80 ms) do NOT
+        // cancel this timer through the useLayoutEffect cleanup.
+        initialScrollTimerRef.current = setTimeout(() => {
+          initialScrollTimerRef.current = undefined;
+          if (processedEventsRef.current.length > 0) {
+            programmaticScrollToBottomRef.current = true;
+            vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
+              align: 'end',
+            });
+            // Only mark ready once we've successfully scrolled.  If processedEvents
+            // was empty when the timer fired (e.g. the onLifecycle reset cleared the
+            // timeline within the 80 ms window), defer setIsReady until the recovery
+            // effect below fires once events repopulate.
+            // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest"
+            // button doesn't flash for one render cycle before onScroll confirms.
+            setAtBottom(true);
+            setIsReady(true);
+          } else {
+            pendingReadyRef.current = true;
+          }
+        }, 80);
+      }
     }
     // No cleanup return — the timer must survive eventsLength fluctuations.
     // It is cancelled on unmount by the dedicated effect below.
@@ -1002,8 +1034,10 @@ export function RoomTimeline({
         }}
       >
         <VList<ProcessedEvent>
+          key={room.roomId}
           ref={vListRef}
           data={processedEvents}
+          cache={scrollCacheForRoomRef.current?.cache}
           shift={shift}
           className={css.messageList}
           style={{

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -308,10 +308,7 @@ export function RoomTimeline({
     if (behavior === 'smooth') {
       vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: true });
     } else {
-      // scrollToIndex works reliably regardless of VList measurement state.
-      // The auto-scroll useLayoutEffect fires after React commits new items,
-      // so lastIndex is always valid when this is called.
-      vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
+      vListRef.current.scrollTo(vListRef.current.scrollSize);
     }
   }, []);
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -758,12 +758,7 @@ export function RoomTimeline({
       if (!v) return;
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
-      // Hysteresis: require scrolling further away to lose "at bottom" than to
-      // regain it, preventing brief image/preview layout shifts from flashing
-      // the "Jump to Latest" button.
-      const isNowAtBottom = atBottomRef.current
-        ? distanceFromBottom < 300
-        : distanceFromBottom < 100;
+      const isNowAtBottom = distanceFromBottom < 100;
       // Suppress atBottom flips during the initial scroll-to-bottom sequence:
       // VList fires intermediate scroll events before the scroll settles, and
       // if isReady is set in the same commit the button briefly flashes.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -373,6 +373,9 @@ export function RoomTimeline({
         // immediately and skip the 80 ms stabilisation timer entirely.
         if (savedCache.atBottom) {
           vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
+          // scrollToIndex is async; pre-empt the button so it doesn't flash for
+          // one render cycle before VList's onScroll confirms the position.
+          setAtBottom(true);
         } else {
           vListRef.current.scrollTo(savedCache.scrollOffset);
         }
@@ -957,6 +960,9 @@ export function RoomTimeline({
         atBottom: true,
       });
     }
+    // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
+    // doesn't flash for one render cycle before onScroll confirms the position.
+    setAtBottom(true);
     setIsReady(true);
   }, [processedEvents.length, setAtBottom, room.roomId]);
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -267,6 +267,12 @@ export function RoomTimeline({
   // A recovery useLayoutEffect watches for processedEvents becoming non-empty
   // and performs the final scroll + setIsReady when this flag is set.
   const pendingReadyRef = useRef(false);
+  // Set to true before each programmatic scroll-to-bottom so intermediate
+  // onScroll events from virtua's height-correction pass cannot drive
+  // atBottomState to false (flashing the "Jump to Latest" button).
+  // Cleared when VList confirms isNowAtBottom, or on the first intermediate
+  // event so subsequent user-initiated scrolls are tracked normally.
+  const programmaticScrollToBottomRef = useRef(false);
   const currentRoomIdRef = useRef(room.roomId);
 
   const [isReady, setIsReady] = useState(false);
@@ -276,6 +282,7 @@ export function RoomTimeline({
     mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
     pendingReadyRef.current = false;
+    programmaticScrollToBottomRef.current = false;
     if (initialScrollTimerRef.current !== undefined) {
       clearTimeout(initialScrollTimerRef.current);
       initialScrollTimerRef.current = undefined;
@@ -350,6 +357,7 @@ export function RoomTimeline({
       initialScrollTimerRef.current = setTimeout(() => {
         initialScrollTimerRef.current = undefined;
         if (processedEventsRef.current.length > 0) {
+          programmaticScrollToBottomRef.current = true;
           vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
           // Only mark ready once we've successfully scrolled.  If processedEvents
           // was empty when the timer fired (e.g. the onLifecycle reset cleared the
@@ -731,8 +739,20 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
+      // Clear the programmatic-scroll guard whenever VList confirms we are at the
+      // bottom, regardless of whether atBottomRef needs updating.
+      if (isNowAtBottom) programmaticScrollToBottomRef.current = false;
       if (isNowAtBottom !== atBottomRef.current) {
-        setAtBottom(isNowAtBottom);
+        if (isNowAtBottom || !programmaticScrollToBottomRef.current) {
+          setAtBottom(isNowAtBottom);
+        } else {
+          // VList fired an intermediate "not at bottom" event while settling after
+          // a programmatic scroll-to-bottom (e.g. height-correction pass). Suppress
+          // the false negative and clear the guard so the next event — either a
+          // VList correction to the true bottom, or a genuine user scroll — is
+          // processed normally.
+          programmaticScrollToBottomRef.current = false;
+        }
       }
 
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {
@@ -859,6 +879,7 @@ export function RoomTimeline({
     if (!pendingReadyRef.current) return;
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
+    programmaticScrollToBottomRef.current = true;
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
     // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
     // doesn't flash for one render cycle before onScroll confirms the position.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -826,6 +826,13 @@ export function RoomTimeline({
     timelineSync.eventsLength === 0 &&
     (!isReady || timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading');
 
+  // Show a skeleton overlay when content is not ready and there is no
+  // cached scroll state to restore from (first visit or timeline reset).
+  // The VList still renders underneath at opacity 0 so it can measure real
+  // item heights — the overlay just gives the user something to look at.
+  const showSkeletonOverlay =
+    !isReady && !scrollCacheForRoomRef.current && !showLoadingPlaceholders;
+
   let backPaginationJSX: ReactNode | undefined;
   if (timelineSync.canPaginateBack || timelineSync.backwardStatus !== 'idle') {
     if (timelineSync.backwardStatus === 'error') {
@@ -1040,9 +1047,32 @@ export function RoomTimeline({
           minHeight: 0,
           overflow: 'hidden',
           position: 'relative',
-          opacity: isReady || showLoadingPlaceholders ? 1 : 0,
         }}
       >
+        {showSkeletonOverlay && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'flex-end',
+              padding: `${config.space.S600} 0`,
+              overflow: 'hidden',
+            }}
+          >
+            {Array.from({ length: 8 }, (_, i) => (
+              <MessageBase key={`skeleton-${i}`}>
+                {messageLayout === MessageLayout.Compact ? (
+                  <CompactPlaceholder />
+                ) : (
+                  <DefaultPlaceholder />
+                )}
+              </MessageBase>
+            ))}
+          </div>
+        )}
         <VList<ProcessedEvent>
           key={room.roomId}
           ref={vListRef}
@@ -1057,6 +1087,7 @@ export function RoomTimeline({
             flexDirection: 'column',
             paddingTop: topSpacerHeight > 0 ? topSpacerHeight : config.space.S600,
             paddingBottom: config.space.S600,
+            opacity: isReady || showLoadingPlaceholders ? 1 : 0,
           }}
           onScroll={handleVListScroll}
         >

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -171,6 +171,7 @@ export function RoomTimeline({
   onEditLastMessageRef,
 }: Readonly<RoomTimelineProps>) {
   const mx = useMatrixClient();
+  const mxUserId = mx.getUserId()!;
   const alive = useAlive();
 
   const { editId, handleEdit } = useMessageEdit(editor, { onReset: onEditorReset, alive });
@@ -253,7 +254,7 @@ export function RoomTimeline({
   // need to read the cache — the render-phase room-change block below only fires
   // in the (hypothetical) case where the room prop changes without a remount.
   const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
-    roomScrollCache.load(room.roomId)
+    roomScrollCache.load(mxUserId, room.roomId)
   );
   const [atBottomState, setAtBottomState] = useState(true);
   const atBottomRef = useRef(atBottomState);
@@ -289,7 +290,7 @@ export function RoomTimeline({
   if (currentRoomIdRef.current !== room.roomId) {
     // Load incoming room's scroll cache (undefined for first-visit rooms).
     // Covers the rare case where room prop changes without a remount.
-    scrollCacheForRoomRef.current = roomScrollCache.load(room.roomId);
+    scrollCacheForRoomRef.current = roomScrollCache.load(mxUserId, room.roomId);
 
     hasInitialScrolledRef.current = false;
     mountScrollWindowRef.current = Date.now() + 3000;
@@ -400,7 +401,7 @@ export function RoomTimeline({
             // can provide them to VList upfront and skip this 80 ms wait entirely.
             const v = vListRef.current;
             if (v) {
-              roomScrollCache.save(room.roomId, {
+              roomScrollCache.save(mxUserId, room.roomId, {
                 cache: v.cache,
                 scrollOffset: v.scrollOffset,
                 atBottom: true,
@@ -808,7 +809,7 @@ export function RoomTimeline({
       // live-timeline visit, producing stale VList measurements and making the
       // room appear to be at the wrong position (or visually empty) on re-entry.
       if (!eventId) {
-        roomScrollCache.save(room.roomId, {
+        roomScrollCache.save(mxUserId, room.roomId, {
           cache: v.cache,
           scrollOffset: offset,
           atBottom: isNowAtBottom,
@@ -921,7 +922,7 @@ export function RoomTimeline({
     ignoredUsersSet,
     showHiddenEvents,
     showTombstoneEvents,
-    mxUserId: mx.getUserId(),
+    mxUserId,
     readUptoEventId: readUptoEventIdRef.current,
     hideMembershipEvents,
     hideNickAvatarEvents,
@@ -948,7 +949,7 @@ export function RoomTimeline({
     // when it fired. Save now so the next visit skips the timer.
     const v = vListRef.current;
     if (v) {
-      roomScrollCache.save(room.roomId, {
+      roomScrollCache.save(mxUserId, room.roomId, {
         cache: v.cache,
         scrollOffset: v.scrollOffset,
         atBottom: true,

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -109,12 +109,6 @@ interface TimelineItemProps {
 }
 /* eslint-enable react/no-unused-prop-types */
 
-// How long (ms) to suppress spurious "not at bottom" events after a
-// programmatic scroll-to-bottom. VList can fire several intermediate onScroll
-// events while it re-measures item heights after a scrollToIndex(); the window
-// lets all of them pass without flashing the "Jump to Latest" button.
-const SCROLL_SETTLE_MS = 200;
-
 // Declared outside memo() so the callback receives a reference, not an inline
 // function expression (satisfies prefer-arrow-callback).
 function TimelineItemInner({ data, renderRef }: TimelineItemProps) {
@@ -282,15 +276,6 @@ export function RoomTimeline({
   // A recovery useLayoutEffect watches for processedEvents becoming non-empty
   // and performs the final scroll + setIsReady when this flag is set.
   const pendingReadyRef = useRef(false);
-  // Set to a timestamp (ms epoch) before each programmatic scroll-to-bottom so
-  // intermediate onScroll events from virtua's height-correction pass cannot
-  // drive atBottomState to false (flashing the "Jump to Latest" button).
-  // Using a timestamp rather than a boolean means the window expires naturally
-  // after SCROLL_SETTLE_MS without needing to clear it on `isNowAtBottom=true`.
-  // That prevents the second wave of false-negative events (which VList fires
-  // after re-measuring item heights) from slipping through after the first
-  // `isNowAtBottom=true` confirms the position.
-  const programmaticScrollToBottomRef = useRef(0);
   const currentRoomIdRef = useRef(room.roomId);
 
   const [isReady, setIsReady] = useState(false);
@@ -303,7 +288,6 @@ export function RoomTimeline({
     hasInitialScrolledRef.current = false;
     currentRoomIdRef.current = room.roomId;
     pendingReadyRef.current = false;
-    programmaticScrollToBottomRef.current = 0;
     if (initialScrollTimerRef.current !== undefined) {
       clearTimeout(initialScrollTimerRef.current);
       initialScrollTimerRef.current = undefined;
@@ -318,14 +302,8 @@ export function RoomTimeline({
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
-    // Pre-empt atBottom so the "Jump to Latest" button doesn't flash between
-    // the scroll call and VList confirming the new position.
-    setAtBottom(true);
-    // Guard against VList's intermediate height-correction scroll events that
-    // would otherwise call setAtBottom(false) before the scroll settles.
-    programmaticScrollToBottomRef.current = Date.now();
     vListRef.current.scrollTo(vListRef.current.scrollSize);
-  }, [setAtBottom]);
+  }, []);
 
   const timelineSync = useTimelineSync({
     room,
@@ -384,11 +362,7 @@ export function RoomTimeline({
         // Revisiting a room with a cached scroll state — restore position
         // immediately and skip the 80 ms stabilisation timer entirely.
         if (savedCache.atBottom) {
-          programmaticScrollToBottomRef.current = Date.now();
-          vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
-          // scrollToIndex is async; pre-empt the button so it doesn't flash for
-          // one render cycle before VList's onScroll confirms the position.
-          setAtBottom(true);
+          vListRef.current.scrollTo(vListRef.current.scrollSize);
         } else {
           vListRef.current.scrollTo(savedCache.scrollOffset);
         }
@@ -403,7 +377,6 @@ export function RoomTimeline({
         initialScrollTimerRef.current = setTimeout(() => {
           initialScrollTimerRef.current = undefined;
           if (processedEventsRef.current.length > 0) {
-            programmaticScrollToBottomRef.current = Date.now();
             vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, {
               align: 'end',
             });
@@ -417,13 +390,6 @@ export function RoomTimeline({
                 atBottom: true,
               });
             }
-            // Only mark ready once we've successfully scrolled.  If processedEvents
-            // was empty when the timer fired (e.g. the onLifecycle reset cleared the
-            // timeline within the 80 ms window), defer setIsReady until the recovery
-            // effect below fires once events repopulate.
-            // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest"
-            // button doesn't flash for one render cycle before onScroll confirms.
-            setAtBottom(true);
             setIsReady(true);
           } else {
             pendingReadyRef.current = true;
@@ -433,13 +399,7 @@ export function RoomTimeline({
     }
     // No cleanup return — the timer must survive eventsLength fluctuations.
     // It is cancelled on unmount by the dedicated effect below.
-  }, [
-    timelineSync.eventsLength,
-    timelineSync.liveTimelineLinked,
-    eventId,
-    room.roomId,
-    setAtBottom,
-  ]);
+  }, [timelineSync.eventsLength, timelineSync.liveTimelineLinked, eventId, room.roomId, mxUserId]);
 
   // Cancel the initial-scroll timer on unmount (the useLayoutEffect above
   // intentionally does not cancel it when deps change).
@@ -527,16 +487,9 @@ export function RoomTimeline({
 
   useEffect(() => {
     if (!eventId) return;
-    // Reset atBottom and the programmatic-scroll guard so that:
-    // 1. The "Jump to Latest" button appears immediately (we are no longer at
-    //    the live bottom — we are viewing a historical slice).
-    // 2. The guard doesn't suppress the `isNowAtBottom=false` event that VList
-    //    fires when it scrolls to the target eventId.
-    setAtBottom(false);
-    programmaticScrollToBottomRef.current = 0;
     setIsReady(false);
     timelineSyncRef.current.loadEventTimeline(eventId);
-  }, [eventId, room.roomId, setAtBottom]);
+  }, [eventId, room.roomId]);
 
   useEffect(() => {
     if (eventId) return;
@@ -588,9 +541,6 @@ export function RoomTimeline({
       const shrank = newHeight < prev;
 
       if (shrank && atBottom) {
-        // Arm the guard before scrolling so VList's intermediate height-correction
-        // events (fired during item re-measurement) don't flip atBottom to false.
-        programmaticScrollToBottomRef.current = Date.now();
         vListRef.current?.scrollTo(vListRef.current.scrollSize);
       }
       prevViewportHeightRef.current = newHeight;
@@ -807,16 +757,8 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
-      const isSettling = Date.now() - programmaticScrollToBottomRef.current < SCROLL_SETTLE_MS;
       if (isNowAtBottom !== atBottomRef.current) {
-        // Suppress intermediate "not at bottom" events that fire while VList
-        // re-measures item heights after a programmatic scrollToIndex.  The
-        // timestamp window expires naturally — no need to clear it on
-        // `isNowAtBottom=true`, which prevents a second wave of false-negatives
-        // (fired after height re-measurement completes) from slipping through.
-        if (isNowAtBottom || !isSettling) {
-          setAtBottom(isNowAtBottom);
-        }
+        setAtBottom(isNowAtBottom);
       }
 
       // Keep the scroll cache fresh so the next visit to this room can restore
@@ -844,7 +786,7 @@ export function RoomTimeline({
         timelineSyncRef.current.handleTimelinePagination(false);
       }
     },
-    [setAtBottom, room.roomId, eventId]
+    [setAtBottom, room.roomId, eventId, mxUserId]
   );
 
   const showLoadingPlaceholders =
@@ -957,12 +899,8 @@ export function RoomTimeline({
     if (!pendingReadyRef.current) return;
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
-    programmaticScrollToBottomRef.current = Date.now();
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
-    // doesn't flash for one render cycle before onScroll confirms the position.
-    setAtBottom(true);
-    // The 80 ms timer's cache-save was skipped because processedEvents was empty
-    // when it fired. Save now so the next visit skips the timer.
+    // Save now so the next visit skips the timer.
     const v = vListRef.current;
     if (v) {
       roomScrollCache.save(mxUserId, room.roomId, {
@@ -971,11 +909,8 @@ export function RoomTimeline({
         atBottom: true,
       });
     }
-    // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
-    // doesn't flash for one render cycle before onScroll confirms the position.
-    setAtBottom(true);
     setIsReady(true);
-  }, [processedEvents.length, setAtBottom, room.roomId]);
+  }, [processedEvents.length, room.roomId, mxUserId]);
 
   useEffect(() => {
     if (!onEditLastMessageRef) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -93,36 +93,37 @@ type TimelineRenderFn = (eventData: ProcessedEvent) => ReactNode;
  * version of `renderMatrixEvent`, set synchronously during each render cycle)
  * so stale-closure issues are avoided.
  *
- * Props not used in the function body (`isHighlighted`, `isEditing`, etc.) are
- * intentionally included: React.memo's default shallow-equality comparator
- * inspects ALL props, so changing one of them for a specific item causes only
- * that item to re-render (e.g. only the message being edited re-renders when
- * editId changes).
+ * The custom `areEqual` comparator checks `data`, `isHighlighted`, `isEditing`,
+ * `isReplying`, `isOpenThread`, and `settingsEpoch` — re-rendering only the
+ * specific item whose volatile state changed.
  */
+/* eslint-disable react/no-unused-prop-types -- props consumed in areEqual, not component body */
 interface TimelineItemProps {
   data: ProcessedEvent;
   renderRef: React.MutableRefObject<TimelineRenderFn | null>;
-  // The props below are not read in the component body — they exist solely so
-  // React.memo's shallow-equality comparator sees them and re-renders only the
-  // affected item when they change.
-  // eslint-disable-next-line react/no-unused-prop-types
   isHighlighted: boolean;
-  // eslint-disable-next-line react/no-unused-prop-types
   isEditing: boolean;
-  // eslint-disable-next-line react/no-unused-prop-types
   isReplying: boolean;
-  // eslint-disable-next-line react/no-unused-prop-types
   isOpenThread: boolean;
-  // eslint-disable-next-line react/no-unused-prop-types
   settingsEpoch: object;
 }
+/* eslint-enable react/no-unused-prop-types */
 
 // Declared outside memo() so the callback receives a reference, not an inline
 // function expression (satisfies prefer-arrow-callback).
 function TimelineItemInner({ data, renderRef }: TimelineItemProps) {
   return <>{renderRef.current?.(data)}</>;
 }
-const TimelineItem = memo(TimelineItemInner);
+const TimelineItem = memo(
+  TimelineItemInner,
+  (prev, next) =>
+    prev.data === next.data &&
+    prev.isHighlighted === next.isHighlighted &&
+    prev.isEditing === next.isEditing &&
+    prev.isReplying === next.isReplying &&
+    prev.isOpenThread === next.isOpenThread &&
+    prev.settingsEpoch === next.settingsEpoch
+);
 TimelineItem.displayName = 'TimelineItem';
 
 const TimelineFloat = as<'div', css.TimelineFloatVariants>(

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -250,10 +250,6 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
-  // Load any cached scroll state for this room on mount. A fresh RoomTimeline is
-  // mounted per room (via key={roomId} in RoomView) so this is the only place we
-  // need to read the cache — the render-phase room-change block below only fires
-  // in the (hypothetical) case where the room prop changes without a remount.
   const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
     roomScrollCache.load(mxUserId, room.roomId)
   );
@@ -301,15 +297,11 @@ export function RoomTimeline({
   const processedEventsRef = useRef<ProcessedEvent[]>([]);
   const timelineSyncRef = useRef<typeof timelineSync>(null as unknown as typeof timelineSync);
 
-  const scrollToBottom = useCallback((behavior?: 'instant' | 'smooth') => {
+  const scrollToBottom = useCallback(() => {
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
-    if (behavior === 'smooth') {
-      vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: true });
-    } else {
-      vListRef.current.scrollTo(vListRef.current.scrollSize);
-    }
+    vListRef.current.scrollTo(vListRef.current.scrollSize);
   }, []);
 
   const timelineSync = useTimelineSync({
@@ -495,8 +487,6 @@ export function RoomTimeline({
   useEffect(() => {
     if (!eventId) return;
     setIsReady(false);
-    // Ensure auto-scroll to bottom doesn't fire while we're navigating to a
-    // specific event — atBottom will be updated correctly once the user scrolls.
     setAtBottom(false);
     timelineSyncRef.current.loadEventTimeline(eventId);
   }, [eventId, room.roomId, setAtBottom]);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -273,7 +273,6 @@ export function RoomTimeline({
   const [topSpacerHeight, setTopSpacerHeight] = useState(0);
 
   const topSpacerHeightRef = useRef(0);
-  const mountScrollWindowRef = useRef<number>(Date.now() + 3000);
   const hasInitialScrolledRef = useRef(false);
   // Stored in a ref so eventsLength fluctuations (e.g. onLifecycle timeline reset
   // firing within the window) cannot cancel it via useLayoutEffect cleanup.
@@ -302,7 +301,6 @@ export function RoomTimeline({
     scrollCacheForRoomRef.current = roomScrollCache.load(mxUserId, room.roomId);
 
     hasInitialScrolledRef.current = false;
-    mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
     pendingReadyRef.current = false;
     programmaticScrollToBottomRef.current = 0;
@@ -320,11 +318,14 @@ export function RoomTimeline({
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
+    // Pre-empt atBottom so the "Jump to Latest" button doesn't flash between
+    // the scroll call and VList confirming the new position.
+    setAtBottom(true);
     // Guard against VList's intermediate height-correction scroll events that
     // would otherwise call setAtBottom(false) before the scroll settles.
     programmaticScrollToBottomRef.current = Date.now();
     vListRef.current.scrollTo(vListRef.current.scrollSize);
-  }, []);
+  }, [setAtBottom]);
 
   const timelineSync = useTimelineSync({
     room,
@@ -587,6 +588,9 @@ export function RoomTimeline({
       const shrank = newHeight < prev;
 
       if (shrank && atBottom) {
+        // Arm the guard before scrolling so VList's intermediate height-correction
+        // events (fired during item re-measurement) don't flip atBottom to false.
+        programmaticScrollToBottomRef.current = Date.now();
         vListRef.current?.scrollTo(vListRef.current.scrollSize);
       }
       prevViewportHeightRef.current = newHeight;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -947,8 +947,18 @@ export function RoomTimeline({
     // scrollToIndex is async; pre-empt atBottom so the "Jump to Latest" button
     // doesn't flash for one render cycle before onScroll confirms the position.
     setAtBottom(true);
+    // The 80 ms timer's cache-save was skipped because processedEvents was empty
+    // when it fired. Save now so the next visit skips the timer.
+    const v = vListRef.current;
+    if (v) {
+      roomScrollCache.save(room.roomId, {
+        cache: v.cache,
+        scrollOffset: v.scrollOffset,
+        atBottom: true,
+      });
+    }
     setIsReady(true);
-  }, [processedEvents.length, setAtBottom]);
+  }, [processedEvents.length, setAtBottom, room.roomId]);
 
   useEffect(() => {
     if (!onEditLastMessageRef) return;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -756,7 +756,12 @@ export function RoomTimeline({
       if (!v) return;
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
-      const isNowAtBottom = distanceFromBottom < 100;
+      // Hysteresis: require scrolling further away to lose "at bottom" than to
+      // regain it, preventing brief image/preview layout shifts from flashing
+      // the "Jump to Latest" button.
+      const isNowAtBottom = atBottomRef.current
+        ? distanceFromBottom < 300
+        : distanceFromBottom < 100;
       if (isNowAtBottom !== atBottomRef.current) {
         setAtBottom(isNowAtBottom);
       }

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1,6 +1,7 @@
 import {
   Fragment,
   ReactNode,
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -78,6 +79,49 @@ import { useTimelineActions } from '$hooks/timeline/useTimelineActions';
 import { ProcessedEvent, useProcessedTimeline } from '$hooks/timeline/useProcessedTimeline';
 import { useTimelineEventRenderer } from '$hooks/timeline/useTimelineEventRenderer';
 import * as css from './RoomTimeline.css';
+
+/** Render function type passed to the memoized TimelineItem via a ref. */
+type TimelineRenderFn = (eventData: ProcessedEvent) => ReactNode;
+
+/**
+ * Renders one timeline item.  Defined outside RoomTimeline so React never
+ * recreates the component type, and wrapped in `memo` so it skips re-renders
+ * when neither the event data nor any per-item volatile state changed.
+ *
+ * The actual rendering is delegated to `renderRef.current` (always the latest
+ * version of `renderMatrixEvent`, set synchronously during each render cycle)
+ * so stale-closure issues are avoided.
+ *
+ * Props not used in the function body (`isHighlighted`, `isEditing`, etc.) are
+ * intentionally included: React.memo's default shallow-equality comparator
+ * inspects ALL props, so changing one of them for a specific item causes only
+ * that item to re-render (e.g. only the message being edited re-renders when
+ * editId changes).
+ */
+interface TimelineItemProps {
+  data: ProcessedEvent;
+  renderRef: React.MutableRefObject<TimelineRenderFn | null>;
+  /** Changed when this specific item becomes highlighted / un-highlighted. */
+  isHighlighted: boolean;
+  /** Changed when this specific item enters / exits edit mode. */
+  isEditing: boolean;
+  /** Changed when this specific item is the active reply target. */
+  isReplying: boolean;
+  /** Changed when this specific item's thread drawer is open. */
+  isOpenThread: boolean;
+  /**
+   * Opaque object whose identity changes when any global render-affecting
+   * setting changes (layout, spacing, nicknames, permissions…).  Forces all
+   * visible items to re-render when settings change.
+   */
+  settingsEpoch: object;
+}
+
+const TimelineItem = memo(function TimelineItem({ data, renderRef }: TimelineItemProps) {
+  // isHighlighted, isEditing, isReplying, isOpenThread, settingsEpoch are not
+  // used here directly — their sole purpose is to guide React.memo comparisons.
+  return <>{renderRef.current?.(data)}</>;
+});
 
 const TimelineFloat = as<'div', css.TimelineFloatVariants>(
   ({ position, className, ...props }, ref) => (
@@ -593,6 +637,52 @@ export function RoomTimeline({
     utils: { htmlReactParserOptions, linkifyOpts, getMemberPowerTag, parseMemberEvent },
   });
 
+  // Render function ref — updated synchronously each render so TimelineItem
+  // always calls the latest version (which has the current focusItem, editId,
+  // etc. in its closure) without needing to be a prop dep.
+  const renderFnRef = useRef<TimelineRenderFn | null>(null);
+  renderFnRef.current = (eventData: ProcessedEvent) =>
+    renderMatrixEvent(
+      eventData.mEvent.getType(),
+      typeof eventData.mEvent.getStateKey() === 'string',
+      eventData.id,
+      eventData.mEvent,
+      eventData.itemIndex,
+      eventData.timelineSet,
+      eventData.collapsed
+    );
+
+  // Object whose identity changes when any global render-affecting setting
+  // changes. TimelineItem memo sees the new reference and re-renders all items.
+  const settingsEpoch = useMemo(
+    () => ({}),
+    // Any setting that changes how ALL items are rendered should be listed here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      messageLayout,
+      messageSpacing,
+      hideReads,
+      showDeveloperTools,
+      hour24Clock,
+      dateFormatString,
+      mediaAutoLoad,
+      showBundledPreview,
+      showUrlPreview,
+      showClientUrlPreview,
+      autoplayStickers,
+      hideMemberInReadOnly,
+      isReadOnly,
+      hideMembershipEvents,
+      hideNickAvatarEvents,
+      showHiddenEvents,
+      reducedMotion,
+      nicknames,
+      imagePackRooms,
+      htmlReactParserOptions,
+      linkifyOpts,
+    ]
+  );
+
   const tryAutoMarkAsRead = useCallback(() => {
     if (!readUptoEventIdRef.current) {
       requestAnimationFrame(() => markAsRead(mx, room.roomId, hideReads));
@@ -724,13 +814,20 @@ export function RoomTimeline({
       : timelineSync.eventsLength;
   const vListIndices = useMemo(
     () => Array.from({ length: vListItemCount }, (_, i) => i),
+    // timelineSync.timeline.linkedTimelines: recompute when the timeline structure
+    // changes (pagination, room switch). timelineSync.mutationVersion: recompute
+    // when event content mutates (reactions, edits) without changing the count.
+    // Using the linkedTimelines reference (not the timeline wrapper object) means
+    // a setTimeline spread for a live event arrival does NOT recompute this — the
+    // eventsLength / vListItemCount change already covers that case.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [vListItemCount, timelineSync.timeline]
+    [vListItemCount, timelineSync.timeline.linkedTimelines, timelineSync.mutationVersion]
   );
 
   const processedEvents = useProcessedTimeline({
     items: vListIndices,
     linkedTimelines: timelineSync.timeline.linkedTimelines,
+    mutationVersion: timelineSync.mutationVersion,
     ignoredUsersSet,
     showHiddenEvents,
     showTombstoneEvents,
@@ -901,14 +998,19 @@ export function RoomTimeline({
               return <Fragment key={index} />;
             }
 
-            const renderedEvent = renderMatrixEvent(
-              eventData.mEvent.getType(),
-              typeof eventData.mEvent.getStateKey() === 'string',
-              eventData.id,
-              eventData.mEvent,
-              eventData.itemIndex,
-              eventData.timelineSet,
-              eventData.collapsed
+            const renderedEvent = (
+              <TimelineItem
+                data={eventData}
+                renderRef={renderFnRef}
+                isHighlighted={
+                  timelineSync.focusItem?.index === eventData.itemIndex &&
+                  (timelineSync.focusItem?.highlight ?? false)
+                }
+                isEditing={editId === eventData.mEvent.getId()}
+                isReplying={activeReplyId === eventData.mEvent.getId()}
+                isOpenThread={openThreadId === eventData.mEvent.getId()}
+                settingsEpoch={settingsEpoch}
+              />
             );
 
             const dividers = (

--- a/src/app/hooks/timeline/useProcessedTimeline.test.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.test.ts
@@ -1,0 +1,290 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { EventTimeline, EventTimelineSet, MatrixEvent } from '$types/matrix-sdk';
+import { useProcessedTimeline } from './useProcessedTimeline';
+
+// ---------------------------------------------------------------------------
+// Minimal fakes
+// ---------------------------------------------------------------------------
+
+function makeEvent(
+  id: string,
+  opts: {
+    sender?: string;
+    type?: string;
+    ts?: number;
+    content?: Record<string, unknown>;
+  } = {}
+): MatrixEvent {
+  const {
+    sender = '@alice:test',
+    type = 'm.room.message',
+    ts = 1_000,
+    content = { body: 'hello' },
+  } = opts;
+  return {
+    getId: () => id,
+    getSender: () => sender,
+    isRedacted: () => false,
+    getTs: () => ts,
+    getType: () => type,
+    threadRootId: undefined,
+    getContent: () => content,
+    getRelation: () => null,
+    isRedaction: () => false,
+  } as unknown as MatrixEvent;
+}
+
+const fakeTimelineSet = {} as EventTimelineSet;
+
+function makeTimeline(events: MatrixEvent[]): EventTimeline {
+  return {
+    getEvents: () => events,
+    getTimelineSet: () => fakeTimelineSet,
+  } as unknown as EventTimeline;
+}
+
+/** Default options — keeps tests concise; individual tests override what they need. */
+const defaults = {
+  ignoredUsersSet: new Set<string>(),
+  showHiddenEvents: false,
+  showTombstoneEvents: false,
+  mxUserId: '@alice:test',
+  readUptoEventId: undefined,
+  hideMembershipEvents: false,
+  hideNickAvatarEvents: false,
+  isReadOnly: false,
+  hideMemberInReadOnly: false,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers to derive `items` from a linked-timeline list
+// index 0 = first event in first timeline, etc.
+// ---------------------------------------------------------------------------
+function makeItems(count: number, startIndex = 0): number[] {
+  return Array.from({ length: count }, (_, i) => startIndex + i);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useProcessedTimeline', () => {
+  it('returns an empty array when there are no events', () => {
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: [],
+        linkedTimelines: [makeTimeline([])],
+      })
+    );
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('returns one ProcessedEvent per visible event', () => {
+    const events = [makeEvent('$e1'), makeEvent('$e2'), makeEvent('$e3')];
+    const timeline = makeTimeline(events);
+
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: makeItems(3),
+        linkedTimelines: [timeline],
+      })
+    );
+
+    expect(result.current).toHaveLength(3);
+    expect(result.current[0].id).toBe('$e1');
+    expect(result.current[2].id).toBe('$e3');
+  });
+
+  it('collapses consecutive messages from the same sender within 2 minutes', () => {
+    const events = [
+      makeEvent('$e1', { ts: 1_000 }),
+      makeEvent('$e2', { ts: 60_000 }), // same sender, ~1 min later
+    ];
+    const timeline = makeTimeline(events);
+
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: makeItems(2),
+        linkedTimelines: [timeline],
+      })
+    );
+
+    expect(result.current[1].collapsed).toBe(true);
+  });
+
+  it('does NOT collapse messages from the same sender more than 2 minutes apart', () => {
+    const events = [
+      makeEvent('$e1', { ts: 1_000 }),
+      makeEvent('$e2', { ts: 3 * 60_000 }), // 3 min later
+    ];
+    const timeline = makeTimeline(events);
+
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: makeItems(2),
+        linkedTimelines: [timeline],
+      })
+    );
+
+    expect(result.current[1].collapsed).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Stable-ref optimisation
+  // -------------------------------------------------------------------------
+
+  it('reuses the same ProcessedEvent reference when nothing changed (stable-ref)', () => {
+    const events = [makeEvent('$e1'), makeEvent('$e2')];
+    const timeline = makeTimeline(events);
+    const items = makeItems(2);
+
+    const { result, rerender } = renderHook(
+      ({ ver }) =>
+        useProcessedTimeline({
+          ...defaults,
+          items,
+          linkedTimelines: [timeline],
+          mutationVersion: ver,
+        }),
+      { initialProps: { ver: 0 } }
+    );
+
+    const firstRender = result.current;
+
+    // Re-render with the same mutationVersion — refs should be reused
+    rerender({ ver: 0 });
+
+    expect(result.current[0]).toBe(firstRender[0]);
+    expect(result.current[1]).toBe(firstRender[1]);
+  });
+
+  it('creates fresh ProcessedEvent objects when mutationVersion increments', () => {
+    const events = [makeEvent('$e1'), makeEvent('$e2')];
+    const timeline = makeTimeline(events);
+    const items = makeItems(2);
+
+    const { result, rerender } = renderHook(
+      ({ ver }) =>
+        useProcessedTimeline({
+          ...defaults,
+          items,
+          linkedTimelines: [timeline],
+          mutationVersion: ver,
+        }),
+      { initialProps: { ver: 0 } }
+    );
+
+    const firstRender = result.current;
+
+    // Bump mutation version — stale refs must not be reused
+    rerender({ ver: 1 });
+
+    expect(result.current[0]).not.toBe(firstRender[0]);
+    expect(result.current[1]).not.toBe(firstRender[1]);
+  });
+
+  it('creates fresh ProcessedEvent objects when itemIndex shifts after back-pagination', () => {
+    // Initial: one event at index 0
+    const existingEvent = makeEvent('$existing');
+    const timelineV1 = makeTimeline([existingEvent]);
+
+    const { result, rerender } = renderHook(
+      ({ linkedTimelines, items }: { linkedTimelines: EventTimeline[]; items: number[] }) =>
+        useProcessedTimeline({
+          ...defaults,
+          items,
+          linkedTimelines,
+          mutationVersion: 0, // unchanged — only the itemIndex changes
+        }),
+      {
+        initialProps: {
+          linkedTimelines: [timelineV1],
+          items: [0],
+        },
+      }
+    );
+
+    const firstRef = result.current[0];
+    expect(firstRef.id).toBe('$existing');
+    expect(firstRef.itemIndex).toBe(0);
+
+    // Back-pagination prepends a new event at the front — existing event now at index 1
+    const newEvent = makeEvent('$new');
+    const timelineV2 = makeTimeline([newEvent, existingEvent]);
+
+    rerender({ linkedTimelines: [timelineV2], items: [0, 1] });
+
+    const existingProcessed = result.current.find((e) => e.id === '$existing')!;
+    // itemIndex must be 1 (updated), NOT 0 (stale from previous render)
+    expect(existingProcessed.itemIndex).toBe(1);
+    // And it must be a new object, not the stale cached ref
+    expect(existingProcessed).not.toBe(firstRef);
+  });
+
+  it('filters events from ignored users', () => {
+    const events = [
+      makeEvent('$e1', { sender: '@alice:test' }),
+      makeEvent('$e2', { sender: '@ignored:test' }),
+      makeEvent('$e3', { sender: '@alice:test' }),
+    ];
+    const timeline = makeTimeline(events);
+
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: makeItems(3),
+        linkedTimelines: [timeline],
+        ignoredUsersSet: new Set(['@ignored:test']),
+      })
+    );
+
+    const ids = result.current.map((e) => e.id);
+    expect(ids).not.toContain('$e2');
+    expect(ids).toContain('$e1');
+    expect(ids).toContain('$e3');
+  });
+
+  it('places willRenderNewDivider on the event immediately after readUptoEventId', () => {
+    const events = [
+      makeEvent('$read', { sender: '@bob:test', ts: 1_000 }),
+      makeEvent('$new', { sender: '@bob:test', ts: 2_000 }),
+    ];
+    const timeline = makeTimeline(events);
+
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: makeItems(2),
+        linkedTimelines: [timeline],
+        mxUserId: '@alice:test', // different from sender so divider renders
+        readUptoEventId: '$read',
+      })
+    );
+
+    expect(result.current[1].willRenderNewDivider).toBe(true);
+  });
+
+  it('places willRenderDayDivider between events on different calendar days', () => {
+    const DAY = 86_400_000;
+    const events = [
+      makeEvent('$e1', { ts: 1_000 }),
+      makeEvent('$e2', { ts: 1_000 + DAY + 1 }), // next day
+    ];
+    const timeline = makeTimeline(events);
+
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        ...defaults,
+        items: makeItems(2),
+        linkedTimelines: [timeline],
+      })
+    );
+
+    expect(result.current[1].willRenderDayDivider).toBe(true);
+  });
+});

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { MatrixEvent, EventTimelineSet, EventTimeline } from '$types/matrix-sdk';
 import {
   getTimelineAndBaseIndex,
@@ -21,11 +21,21 @@ export interface UseProcessedTimelineOptions {
   isReadOnly: boolean;
   hideMemberInReadOnly: boolean;
   /**
+  /**
    * When true, skip the filter that removes events whose `threadRootId` points
    * to a different event.  Required when processing a thread's own timeline
    * where every reply legitimately has `threadRootId` set to the root.
    */
   skipThreadFilter?: boolean;
+  /**
+   * Increment this whenever existing event content mutates (reactions, edits,
+   * thread updates, local-echo).  When it changes, `useProcessedTimeline`
+   * creates fresh `ProcessedEvent` objects so downstream `React.memo` item
+   * components re-render to reflect updated content.  When unchanged (e.g. a
+   * new event was appended), existing objects are reused by identity, letting
+   * memo bail out for unchanged items.
+   */
+  mutationVersion: number;
 }
 
 export interface ProcessedEvent {
@@ -62,8 +72,23 @@ export function useProcessedTimeline({
   isReadOnly,
   hideMemberInReadOnly,
   skipThreadFilter,
+  mutationVersion,
 }: UseProcessedTimelineOptions): ProcessedEvent[] {
+  // Stable-ref cache: reuse the same ProcessedEvent object for an event when
+  // nothing structural changed. This lets React.memo on item components bail
+  // out for the majority of items when only a new message was appended.
+  const stableRefsCache = useRef<Map<string, ProcessedEvent>>(new Map());
+  const prevMutationVersionRef = useRef(-1);
+
   return useMemo(() => {
+    // When mutationVersion changes, existing event content has mutated (reaction
+    // added, message edited, local-echo updated, thread reply). Create fresh
+    // objects so memo item components re-render. When version is unchanged (only
+    // items count changed), reuse cached refs for structurally-identical events.
+    const isMutation = mutationVersion !== prevMutationVersionRef.current;
+    prevMutationVersionRef.current = mutationVersion;
+    const prevCache = isMutation ? null : stableRefsCache.current;
+
     let prevEvent: MatrixEvent | undefined;
     let isPrevRendered = false;
     let newDivider = false;
@@ -179,18 +204,33 @@ export function useProcessedTimeline({
         willRenderDayDivider,
       };
 
+      // Reuse the previous ProcessedEvent object if all structural fields match,
+      // so that React.memo on timeline item components can bail out cheaply.
+      const prev = prevCache?.get(mEventId);
+      const stable =
+        prev &&
+        prev.collapsed === collapsed &&
+        prev.willRenderNewDivider === willRenderNewDivider &&
+        prev.willRenderDayDivider === willRenderDayDivider &&
+        prev.eventSender === eventSender
+          ? prev
+          : processed;
+
       prevEvent = mEvent;
       isPrevRendered = true;
       if (willRenderNewDivider) newDivider = false;
       if (willRenderDayDivider) dayDivider = false;
 
-      acc.push(processed);
+      acc.push(stable);
       return acc;
     }, []);
+    // Update the stable-ref cache for the next render.
+    stableRefsCache.current = new Map(result.map((e) => [e.id, e]));
     return result;
   }, [
     items,
     linkedTimelines,
+    mutationVersion,
     ignoredUsersSet,
     showHiddenEvents,
     showTombstoneEvents,

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -34,8 +34,13 @@ export interface UseProcessedTimelineOptions {
    * components re-render to reflect updated content.  When unchanged (e.g. a
    * new event was appended), existing objects are reused by identity, letting
    * memo bail out for unchanged items.
+   *
+   * Optional — defaults to 0 (stable refs always applied after first render).
+   * Call sites that do NOT use `React.memo` item components (e.g. `ThreadDrawer`)
+   * can omit this; the SDK mutates `mEvent` in place so rendered content stays
+   * correct regardless of object identity.
    */
-  mutationVersion: number;
+  mutationVersion?: number;
 }
 
 export interface ProcessedEvent {
@@ -72,7 +77,7 @@ export function useProcessedTimeline({
   isReadOnly,
   hideMemberInReadOnly,
   skipThreadFilter,
-  mutationVersion,
+  mutationVersion = 0,
 }: UseProcessedTimelineOptions): ProcessedEvent[] {
   // Stable-ref cache: reuse the same ProcessedEvent object for an event when
   // nothing structural changed. This lets React.memo on item components bail

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -217,6 +217,8 @@ export function useProcessedTimeline({
       const prev = prevCache?.get(mEventId);
       const stable =
         prev &&
+        prev.mEvent === mEvent &&
+        prev.timelineSet === timelineSet &&
         prev.itemIndex === processed.itemIndex &&
         prev.collapsed === collapsed &&
         prev.willRenderNewDivider === willRenderNewDivider &&

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -211,9 +211,13 @@ export function useProcessedTimeline({
 
       // Reuse the previous ProcessedEvent object if all structural fields match,
       // so that React.memo on timeline item components can bail out cheaply.
+      // itemIndex must also be equal: after back-pagination the same eventId
+      // shifts to a higher VList index, so a stale itemIndex would break
+      // getRawIndexToProcessedIndex and focus-highlight comparisons.
       const prev = prevCache?.get(mEventId);
       const stable =
         prev &&
+        prev.itemIndex === processed.itemIndex &&
         prev.collapsed === collapsed &&
         prev.willRenderNewDivider === willRenderNewDivider &&
         prev.willRenderDayDivider === willRenderDayDivider &&

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -125,6 +125,11 @@ describe('useTimelineSync', () => {
     );
 
     await act(async () => {
+      // Simulate the SDK replacing the live timeline object, which is what
+      // a real TimelineReset does (resetLiveTimeline creates a new
+      // EventTimeline and swaps liveTimeline to it).
+      const newTimeline = createTimeline([{}, {}]);
+      timelineSet.getLiveTimeline = () => newTimeline;
       timelineSet.emit(RoomEvent.TimelineReset);
       await Promise.resolve();
     });

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -129,7 +129,7 @@ describe('useTimelineSync', () => {
       await Promise.resolve();
     });
 
-    expect(scrollToBottom).toHaveBeenCalledWith('instant');
+    expect(scrollToBottom).toHaveBeenCalled();
   });
 
   it('resets timeline state when room.roomId changes and eventId is not set', async () => {

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -395,6 +395,9 @@ export function useTimelineSync({
     | undefined
   >();
 
+  const timelineRef = useRef(timeline);
+  timelineRef.current = timeline;
+
   const resetAutoScrollPendingRef = useRef(false);
 
   const eventsLength = getTimelinesEventsCount(timeline.linkedTimelines);
@@ -534,9 +537,18 @@ export function useTimelineSync({
   useLiveTimelineRefresh(
     room,
     useCallback(() => {
+      const newLinked = getInitialTimeline(room).linkedTimelines;
+      const prev = timelineRef.current.linkedTimelines;
+      // Skip update when the linked-timeline chain is identical (same
+      // EventTimeline references).  TimelineReset often fires during initial
+      // room load after the SDK already populated the timeline we are
+      // showing — re-rendering would only produce a visible flash.
+      if (prev.length === newLinked.length && prev.every((tl, i) => tl === newLinked[i])) {
+        return;
+      }
       const wasAtBottom = isAtBottomRef.current;
       resetAutoScrollPendingRef.current = wasAtBottom;
-      setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
+      setTimeline({ linkedTimelines: newLinked });
       if (wasAtBottom) {
         scrollToBottom();
       }

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -398,6 +398,11 @@ export function useTimelineSync({
   const timelineRef = useRef(timeline);
   timelineRef.current = timeline;
 
+  // Incremented each time a genuine TimelineReset replaces the timeline chain.
+  // RoomTimeline watches this to hide content (opacity 0) and re-arm initial
+  // scroll so the replacement renders behind the curtain.
+  const [timelineResetToken, setTimelineResetToken] = useState(0);
+
   const resetAutoScrollPendingRef = useRef(false);
 
   const eventsLength = getTimelinesEventsCount(timeline.linkedTimelines);
@@ -548,6 +553,7 @@ export function useTimelineSync({
       }
       const wasAtBottom = isAtBottomRef.current;
       resetAutoScrollPendingRef.current = wasAtBottom;
+      setTimelineResetToken((t) => t + 1);
       setTimeline({ linkedTimelines: newLinked });
       if (wasAtBottom) {
         scrollToBottom();
@@ -618,5 +624,6 @@ export function useTimelineSync({
     focusItem,
     setFocusItem,
     mutationVersion,
+    timelineResetToken,
   };
 }

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -1,13 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useCallback,
-  useRef,
-  useEffect,
-  useLayoutEffect,
-  Dispatch,
-  SetStateAction,
-} from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect, Dispatch, SetStateAction } from 'react';
 import to from 'await-to-js';
 import * as Sentry from '@sentry/react';
 import {
@@ -360,7 +351,7 @@ export interface UseTimelineSyncOptions {
   eventId?: string;
   isAtBottom: boolean;
   isAtBottomRef: React.MutableRefObject<boolean>;
-  scrollToBottom: (behavior?: 'instant' | 'smooth') => void;
+  scrollToBottom: () => void;
   unreadInfo: ReturnType<typeof getRoomUnreadInfo>;
   setUnreadInfo: Dispatch<SetStateAction<ReturnType<typeof getRoomUnreadInfo>>>;
   hideReadsRef: React.MutableRefObject<boolean>;
@@ -479,7 +470,7 @@ export function useTimelineSync({
     useCallback(() => {
       if (!alive()) return;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
-      scrollToBottom('instant');
+      scrollToBottom();
     }, [alive, room, scrollToBottom])
   );
 
@@ -509,7 +500,7 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
-          scrollToBottom(getSender.call(mEvt) === mx.getUserId() ? 'instant' : 'smooth');
+          scrollToBottom();
           lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
 
           setTimeline((ct) => ({ ...ct }));
@@ -547,7 +538,7 @@ export function useTimelineSync({
       resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
       if (wasAtBottom) {
-        scrollToBottom('instant');
+        scrollToBottom();
       }
     }, [room, isAtBottomRef, scrollToBottom])
   );
@@ -556,9 +547,7 @@ export function useTimelineSync({
 
   useThreadUpdate(room, triggerMutation);
 
-  // useLayoutEffect so scroll fires before paint — prevents the one-frame flash
-  // where new VList content is briefly visible at the wrong position.
-  useLayoutEffect(() => {
+  useEffect(() => {
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
     if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;
 
@@ -576,7 +565,7 @@ export function useTimelineSync({
     if (eventsLength <= lastScrolledAtEventsLengthRef.current && !resetAutoScrollPending) return;
 
     lastScrolledAtEventsLengthRef.current = eventsLength;
-    scrollToBottom('instant');
+    scrollToBottom();
   }, [isAtBottom, liveTimelineLinked, eventsLength, scrollToBottom]);
 
   useEffect(() => {

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -1,4 +1,13 @@
-import { useState, useMemo, useCallback, useRef, useEffect, Dispatch, SetStateAction } from 'react';
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import to from 'await-to-js';
 import * as Sentry from '@sentry/react';
 import {
@@ -476,9 +485,6 @@ export function useTimelineSync({
 
   const lastScrolledAtEventsLengthRef = useRef(eventsLength);
 
-  const eventsLengthRef = useRef(eventsLength);
-  eventsLengthRef.current = eventsLength;
-
   useLiveEventArrive(
     room,
     useCallback(
@@ -500,9 +506,6 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
-          scrollToBottom(getSender.call(mEvt) === mx.getUserId() ? 'instant' : 'smooth');
-          lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
-
           setTimeline((ct) => ({ ...ct }));
           return;
         }
@@ -512,7 +515,7 @@ export function useTimelineSync({
           setUnreadInfo(getRoomUnreadInfo(room));
         }
       },
-      [mx, room, isAtBottomRef, unreadInfo, scrollToBottom, setUnreadInfo, hideReadsRef]
+      [mx, room, isAtBottomRef, unreadInfo, setUnreadInfo, hideReadsRef]
     )
   );
 
@@ -537,17 +540,19 @@ export function useTimelineSync({
       const wasAtBottom = isAtBottomRef.current;
       resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
-      if (wasAtBottom) {
-        scrollToBottom('instant');
-      }
-    }, [room, isAtBottomRef, scrollToBottom])
+      // Scroll is handled by the useLayoutEffect auto-scroll recovery which
+      // fires after React commits the new timeline state — scrolling here
+      // would operate on the pre-commit DOM with a stale scrollSize.
+    }, [room, isAtBottomRef])
   );
 
   useRelationUpdate(room, triggerMutation);
 
   useThreadUpdate(room, triggerMutation);
 
-  useEffect(() => {
+  // useLayoutEffect so scroll fires before paint — prevents the one-frame flash
+  // where new VList content is briefly visible at the wrong position.
+  useLayoutEffect(() => {
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
     if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;
 

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -485,6 +485,9 @@ export function useTimelineSync({
 
   const lastScrolledAtEventsLengthRef = useRef(eventsLength);
 
+  const eventsLengthRef = useRef(eventsLength);
+  eventsLengthRef.current = eventsLength;
+
   useLiveEventArrive(
     room,
     useCallback(
@@ -506,6 +509,9 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
+          scrollToBottom(getSender.call(mEvt) === mx.getUserId() ? 'instant' : 'smooth');
+          lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
+
           setTimeline((ct) => ({ ...ct }));
           return;
         }
@@ -515,7 +521,7 @@ export function useTimelineSync({
           setUnreadInfo(getRoomUnreadInfo(room));
         }
       },
-      [mx, room, isAtBottomRef, unreadInfo, setUnreadInfo, hideReadsRef]
+      [mx, room, isAtBottomRef, unreadInfo, scrollToBottom, setUnreadInfo, hideReadsRef]
     )
   );
 
@@ -540,10 +546,10 @@ export function useTimelineSync({
       const wasAtBottom = isAtBottomRef.current;
       resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
-      // Scroll is handled by the useLayoutEffect auto-scroll recovery which
-      // fires after React commits the new timeline state — scrolling here
-      // would operate on the pre-commit DOM with a stale scrollSize.
-    }, [room, isAtBottomRef])
+      if (wasAtBottom) {
+        scrollToBottom('instant');
+      }
+    }, [room, isAtBottomRef, scrollToBottom])
   );
 
   useRelationUpdate(room, triggerMutation);

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -376,6 +376,16 @@ export function useTimelineSync({
     eventId ? getEmptyTimeline() : { linkedTimelines: getInitialTimeline(room).linkedTimelines }
   );
 
+  // Incremented whenever existing event content mutates (reactions, edits, thread
+  // updates, local-echo status) but NOT on live-event arrivals (those are signalled
+  // by eventsLength increasing).  Consumers use this to decide whether to
+  // re-create ProcessedEvent objects for stable-ref memoization.
+  const [mutationVersion, setMutationVersion] = useState(0);
+  const triggerMutation = useCallback(() => {
+    setTimeline((ct) => ({ ...ct }));
+    setMutationVersion((v) => v + 1);
+  }, []);
+
   const [focusItem, setFocusItem] = useState<
     | {
         index: number;
@@ -512,14 +522,14 @@ export function useTimelineSync({
       eventRoom: Room | undefined
     ) => {
       if (eventRoom?.roomId !== room.roomId) return;
-      setTimeline((ct) => ({ ...ct }));
+      triggerMutation();
     };
 
     room.on(RoomEvent.LocalEchoUpdated, handleLocalEchoUpdated);
     return () => {
       room.removeListener(RoomEvent.LocalEchoUpdated, handleLocalEchoUpdated);
     };
-  }, [room, setTimeline]);
+  }, [room, triggerMutation]);
 
   useLiveTimelineRefresh(
     room,
@@ -533,19 +543,9 @@ export function useTimelineSync({
     }, [room, isAtBottomRef, scrollToBottom])
   );
 
-  useRelationUpdate(
-    room,
-    useCallback(() => {
-      setTimeline((ct) => ({ ...ct }));
-    }, [])
-  );
+  useRelationUpdate(room, triggerMutation);
 
-  useThreadUpdate(
-    room,
-    useCallback(() => {
-      setTimeline((ct) => ({ ...ct }));
-    }, [])
-  );
+  useThreadUpdate(room, triggerMutation);
 
   useEffect(() => {
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
@@ -605,5 +605,6 @@ export function useTimelineSync({
     loadEventTimeline,
     focusItem,
     setFocusItem,
+    mutationVersion,
   };
 }

--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
-import { SyncState, ClientEvent } from '$types/matrix-sdk';
+import { SyncState, ClientEvent, Room, RoomEvent, RoomEventHandlerMap } from '$types/matrix-sdk';
 import { activeSessionIdAtom, pendingNotificationAtom } from '../state/sessions';
 import { mDirectAtom } from '../state/mDirectList';
 import { useSyncState } from './useSyncState';
@@ -63,11 +63,19 @@ export function NotificationJumper() {
       // the live timeline lets the room open normally at the bottom where the
       // new message is visible.  Historical events (not in live timeline) still
       // use the eventId so loadEventTimeline can jump to the right context.
-      const liveEvents = room?.getUnfilteredTimelineSet?.()?.getLiveTimeline?.()?.getEvents?.();
-      const eventInLive =
-        pending.eventId && liveEvents
-          ? liveEvents.some((e) => e.getId() === pending.eventId)
-          : false;
+      const liveEvents =
+        room?.getUnfilteredTimelineSet?.()?.getLiveTimeline?.()?.getEvents?.() ?? [];
+      const eventInLive = pending.eventId
+        ? liveEvents.some((e) => e.getId() === pending.eventId)
+        : false;
+      // If the live timeline is empty the room hasn't been populated by sliding
+      // sync yet.  Defer navigation and let the RoomEvent.Timeline listener below
+      // retry once events arrive — by then the notification event will almost
+      // certainly be in the live timeline and we can skip loadEventTimeline.
+      if (!eventInLive && liveEvents.length === 0) {
+        log.log('live timeline empty, deferring jump...', { roomId: pending.roomId });
+        return;
+      }
       const resolvedEventId = eventInLive ? undefined : pending.eventId;
       log.log('jumping to:', pending.roomId, resolvedEventId, { eventInLive });
       jumpingRef.current = true;
@@ -134,11 +142,21 @@ export function NotificationJumper() {
     if (!pending) return undefined;
 
     const onRoom = () => performJumpRef.current();
+    // Re-check once events arrive in the target room — this fires shortly after
+    // the initial sync populates the live timeline, letting us verify whether
+    // the notification event is already there before falling back to
+    // loadEventTimeline (which creates a sparse historical slice that may make
+    // the room appear empty on subsequent visits without the eventId).
+    const onTimeline = (_evt: unknown, eventRoom: Room | undefined) => {
+      if (eventRoom?.roomId === pending.roomId) performJumpRef.current();
+    };
     mx.on(ClientEvent.Room, onRoom);
+    mx.on(RoomEvent.Timeline, onTimeline as RoomEventHandlerMap[RoomEvent.Timeline]);
     performJumpRef.current();
 
     return () => {
       mx.removeListener(ClientEvent.Room, onRoom);
+      mx.removeListener(RoomEvent.Timeline, onTimeline as RoomEventHandlerMap[RoomEvent.Timeline]);
     };
   }, [pending, mx]); // performJump intentionally omitted — use ref above
 

--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -52,13 +52,30 @@ export function NotificationJumper() {
     const isJoined = room?.getMyMembership() === 'join';
 
     if (isSyncing && isJoined) {
-      log.log('jumping to:', pending.roomId, pending.eventId);
+      // If the notification event is already in the room's live timeline (i.e.
+      // sliding sync has already delivered it), open the room at the live bottom
+      // rather than using the eventId URL path.  The eventId path triggers
+      // loadEventTimeline → roomInitialSync which loads a historical slice that
+      // (a) may look like a brand-new chat if the event is the only one in the
+      // slice, and (b) makes the room appear empty when the user navigates away
+      // and returns without the eventId, because the sliding-sync live timeline
+      // hasn't been populated yet.  Omitting the eventId for events already in
+      // the live timeline lets the room open normally at the bottom where the
+      // new message is visible.  Historical events (not in live timeline) still
+      // use the eventId so loadEventTimeline can jump to the right context.
+      const liveEvents = room?.getUnfilteredTimelineSet?.()?.getLiveTimeline?.()?.getEvents?.();
+      const eventInLive =
+        pending.eventId && liveEvents
+          ? liveEvents.some((e) => e.getId() === pending.eventId)
+          : false;
+      const resolvedEventId = eventInLive ? undefined : pending.eventId;
+      log.log('jumping to:', pending.roomId, resolvedEventId, { eventInLive });
       jumpingRef.current = true;
       // Navigate directly to home or direct path — bypasses space routing which
       // on mobile shows the space-nav panel first instead of the room timeline.
       const roomIdOrAlias = getCanonicalAliasOrRoomId(mx, pending.roomId);
       if (mDirects.has(pending.roomId)) {
-        navigate(getDirectRoomPath(roomIdOrAlias, pending.eventId));
+        navigate(getDirectRoomPath(roomIdOrAlias, resolvedEventId));
       } else {
         // If the room lives inside a space, route through the space path so
         // SpaceRouteRoomProvider can resolve it — HomeRouteRoomProvider only
@@ -74,11 +91,11 @@ export function NotificationJumper() {
             getSpaceRoomPath(
               getCanonicalAliasOrRoomId(mx, parentSpace),
               roomIdOrAlias,
-              pending.eventId
+              resolvedEventId
             )
           );
         } else {
-          navigate(getHomeRoomPath(roomIdOrAlias, pending.eventId));
+          navigate(getHomeRoomPath(roomIdOrAlias, resolvedEventId));
         }
       }
       setPending(null);

--- a/src/app/utils/roomScrollCache.test.ts
+++ b/src/app/utils/roomScrollCache.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { roomScrollCache } from './roomScrollCache';
 
 // CacheSnapshot is opaque in tests — cast a plain object.
-const fakeCache = () => ({} as import('./roomScrollCache').RoomScrollCache['cache']);
+const fakeCache = () => ({}) as import('./roomScrollCache').RoomScrollCache['cache'];
 
 describe('roomScrollCache', () => {
   it('load returns undefined for an unknown roomId', () => {

--- a/src/app/utils/roomScrollCache.test.ts
+++ b/src/app/utils/roomScrollCache.test.ts
@@ -3,32 +3,42 @@ import { roomScrollCache } from './roomScrollCache';
 
 // CacheSnapshot is opaque in tests — cast a plain object.
 const fakeCache = () => ({}) as import('./roomScrollCache').RoomScrollCache['cache'];
+const userId = '@alice:test';
 
 describe('roomScrollCache', () => {
   it('load returns undefined for an unknown roomId', () => {
-    expect(roomScrollCache.load('!unknown:test')).toBeUndefined();
+    expect(roomScrollCache.load(userId, '!unknown:test')).toBeUndefined();
   });
 
   it('stores and retrieves data for a roomId', () => {
     const data = { cache: fakeCache(), scrollOffset: 120, atBottom: false };
-    roomScrollCache.save('!room1:test', data);
-    expect(roomScrollCache.load('!room1:test')).toBe(data);
+    roomScrollCache.save(userId, '!room1:test', data);
+    expect(roomScrollCache.load(userId, '!room1:test')).toBe(data);
   });
 
   it('overwrites existing data when saved again for the same roomId', () => {
     const first = { cache: fakeCache(), scrollOffset: 50, atBottom: true };
     const second = { cache: fakeCache(), scrollOffset: 200, atBottom: false };
-    roomScrollCache.save('!room2:test', first);
-    roomScrollCache.save('!room2:test', second);
-    expect(roomScrollCache.load('!room2:test')).toBe(second);
+    roomScrollCache.save(userId, '!room2:test', first);
+    roomScrollCache.save(userId, '!room2:test', second);
+    expect(roomScrollCache.load(userId, '!room2:test')).toBe(second);
   });
 
   it('keeps data for separate rooms independent', () => {
     const a = { cache: fakeCache(), scrollOffset: 10, atBottom: true };
     const b = { cache: fakeCache(), scrollOffset: 20, atBottom: false };
-    roomScrollCache.save('!roomA:test', a);
-    roomScrollCache.save('!roomB:test', b);
-    expect(roomScrollCache.load('!roomA:test')).toBe(a);
-    expect(roomScrollCache.load('!roomB:test')).toBe(b);
+    roomScrollCache.save(userId, '!roomA:test', a);
+    roomScrollCache.save(userId, '!roomB:test', b);
+    expect(roomScrollCache.load(userId, '!roomA:test')).toBe(a);
+    expect(roomScrollCache.load(userId, '!roomB:test')).toBe(b);
+  });
+
+  it('scopes data per userId', () => {
+    const data1 = { cache: fakeCache(), scrollOffset: 100, atBottom: true };
+    const data2 = { cache: fakeCache(), scrollOffset: 200, atBottom: false };
+    roomScrollCache.save('@alice:test', '!room:test', data1);
+    roomScrollCache.save('@bob:test', '!room:test', data2);
+    expect(roomScrollCache.load('@alice:test', '!room:test')).toBe(data1);
+    expect(roomScrollCache.load('@bob:test', '!room:test')).toBe(data2);
   });
 });

--- a/src/app/utils/roomScrollCache.test.ts
+++ b/src/app/utils/roomScrollCache.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { roomScrollCache } from './roomScrollCache';
+
+// CacheSnapshot is opaque in tests — cast a plain object.
+const fakeCache = () => ({} as import('./roomScrollCache').RoomScrollCache['cache']);
+
+describe('roomScrollCache', () => {
+  it('load returns undefined for an unknown roomId', () => {
+    expect(roomScrollCache.load('!unknown:test')).toBeUndefined();
+  });
+
+  it('stores and retrieves data for a roomId', () => {
+    const data = { cache: fakeCache(), scrollOffset: 120, atBottom: false };
+    roomScrollCache.save('!room1:test', data);
+    expect(roomScrollCache.load('!room1:test')).toBe(data);
+  });
+
+  it('overwrites existing data when saved again for the same roomId', () => {
+    const first = { cache: fakeCache(), scrollOffset: 50, atBottom: true };
+    const second = { cache: fakeCache(), scrollOffset: 200, atBottom: false };
+    roomScrollCache.save('!room2:test', first);
+    roomScrollCache.save('!room2:test', second);
+    expect(roomScrollCache.load('!room2:test')).toBe(second);
+  });
+
+  it('keeps data for separate rooms independent', () => {
+    const a = { cache: fakeCache(), scrollOffset: 10, atBottom: true };
+    const b = { cache: fakeCache(), scrollOffset: 20, atBottom: false };
+    roomScrollCache.save('!roomA:test', a);
+    roomScrollCache.save('!roomB:test', b);
+    expect(roomScrollCache.load('!roomA:test')).toBe(a);
+    expect(roomScrollCache.load('!roomB:test')).toBe(b);
+  });
+});

--- a/src/app/utils/roomScrollCache.ts
+++ b/src/app/utils/roomScrollCache.ts
@@ -1,0 +1,22 @@
+import { CacheSnapshot } from 'virtua';
+
+export type RoomScrollCache = {
+  /** VList item-size snapshot — restored via VList `cache=` prop on remount. */
+  cache: CacheSnapshot;
+  /** Pixel scroll offset at the time the room was left. */
+  scrollOffset: number;
+  /** Whether the view was pinned to the bottom (live) when the room was left. */
+  atBottom: boolean;
+};
+
+/** Session-scoped, per-room scroll cache. Not persisted across page reloads. */
+const scrollCacheMap = new Map<string, RoomScrollCache>();
+
+export const roomScrollCache = {
+  save(roomId: string, data: RoomScrollCache): void {
+    scrollCacheMap.set(roomId, data);
+  },
+  load(roomId: string): RoomScrollCache | undefined {
+    return scrollCacheMap.get(roomId);
+  },
+};

--- a/src/app/utils/roomScrollCache.ts
+++ b/src/app/utils/roomScrollCache.ts
@@ -12,11 +12,13 @@ export type RoomScrollCache = {
 /** Session-scoped, per-room scroll cache. Not persisted across page reloads. */
 const scrollCacheMap = new Map<string, RoomScrollCache>();
 
+const cacheKey = (userId: string, roomId: string): string => `${userId}:${roomId}`;
+
 export const roomScrollCache = {
-  save(roomId: string, data: RoomScrollCache): void {
-    scrollCacheMap.set(roomId, data);
+  save(userId: string, roomId: string, data: RoomScrollCache): void {
+    scrollCacheMap.set(cacheKey(userId, roomId), data);
   },
-  load(roomId: string): RoomScrollCache | undefined {
-    return scrollCacheMap.get(roomId);
+  load(userId: string, roomId: string): RoomScrollCache | undefined {
+    return scrollCacheMap.get(cacheKey(userId, roomId));
   },
 };

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -34,9 +34,9 @@ export const LIST_SEARCH = 'search';
 export const LIST_ROOM_SEARCH = 'room_search';
 // Dynamic list key used for space-scoped room views.
 export const LIST_SPACE = 'space';
-// One event of timeline per list room is enough to compute unread counts;
-// the full history is loaded when the user opens the room.
-const LIST_TIMELINE_LIMIT = 1;
+// Higher limit avoids empty previews when the most-recent events are
+// reactions/edits/state that useRoomLatestRenderedEvent skips over.
+const LIST_TIMELINE_LIMIT = 3;
 const DEFAULT_LIST_PAGE_SIZE = 250;
 const DEFAULT_POLL_TIMEOUT_MS = 20000;
 const DEFAULT_MAX_ROOMS = 5000;


### PR DESCRIPTION
### Description

Wraps each VList timeline item in `React.memo` so that only the items whose props actually changed re-render when state updates occur (e.g. typing indicators arriving, read receipts updating, or new messages landing while the user is scrolled away from the bottom).

Props passed to each item beyond `data` and `renderRef` — `isHighlighted`, `isEditing`, `isReplying`, `isOpenThread`, `settingsEpoch` — exist solely to give `React.memo`'s shallow-equality comparator fine-grained control: changing any of them causes only the one affected item to re-render rather than the entire visible list.

Also makes `mutationVersion` optional (default `0`) in `UseProcessedTimelineOptions` so call sites that don't participate in the mutation tracking (e.g. `ThreadDrawer`) continue to compile without changes.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

`useProcessedTimeline.ts` — added a `stableRefsCache` (a `useRef<Map<string, ProcessedEvent>>`) that keeps the previous render's `ProcessedEvent` objects alive. On each `useMemo` run, if `mutationVersion` hasn't changed, events whose identity hasn't changed are returned from the cache (same object reference) rather than newly constructed. This means `React.memo` sees no prop change for stable items and skips their render.

`RoomTimeline.tsx` — `TimelineItem` is a `React.memo`-wrapped component declared outside the parent function so it is never re-created. A `renderFnRef` ref captures the render function so `TimelineItem` itself only needs a stable ref in props, not the function. `settingsEpoch` is a `useRef({}).current` that is replaced with `{}` whenever any layout/display setting changes, forcing all visible items to pick up the new settings in one pass.