### PR TITLE
fix - statuses sticking, and badge rendering

### DIFF
--- a/.changeset/fix-status-sticking-issue.md
+++ b/.changeset/fix-status-sticking-issue.md
@@ -1,0 +1,4 @@
+---
+default: patch
+---
+Fix status sometimes sticking in member tile

--- a/.changeset/fix-status-sticking-issue.md
+++ b/.changeset/fix-status-sticking-issue.md
@@ -1,4 +1,5 @@
 ---
 default: patch
 ---
+
 Fix status sometimes sticking in member tile

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -26,12 +26,7 @@ import { useNavigate } from 'react-router-dom';
 import { NavButton, NavItem, NavItemContent, NavItemOptions } from '$components/nav';
 import { UnreadBadge, UnreadBadgeCenter } from '$components/unread-badge';
 import { RoomAvatar, RoomIcon } from '$components/room-avatar';
-import {
-  getDirectRoomAvatarUrl,
-  getRoomAvatarUrl,
-  getStateEvent,
-  roomHaveUnread,
-} from '$utils/room';
+import { getDirectRoomAvatarUrl, getRoomAvatarUrl, roomHaveUnread } from '$utils/room';
 import { nameInitials } from '$utils/common';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useRoomUnread } from '$state/hooks/unread';
@@ -61,7 +56,7 @@ import { useRoomCreators } from '$hooks/useRoomCreators';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
 import { InviteUserPrompt } from '$components/invite-user-prompt';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
-import { useRoomName } from '$hooks/useRoomMeta';
+import { useRoomName, useRoomTopic } from '$hooks/useRoomMeta';
 import { nicknamesAtom } from '$state/nicknames';
 import { useRoomNavigate } from '$hooks/useRoomNavigate';
 
@@ -74,7 +69,6 @@ import { CallControlState } from '$plugins/call/CallControlState';
 import { useAutoDiscoveryInfo } from '$hooks/useAutoDiscoveryInfo';
 import { livekitSupport } from '$hooks/useLivekitSupport';
 import { Presence, useUserPresence } from '$hooks/useUserPresence';
-import { StateEvent } from '$types/matrix/room';
 import { AvatarPresence, PresenceBadge } from '$components/presence';
 import { RoomNavUser } from './RoomNavUser';
 
@@ -293,11 +287,8 @@ export function RoomNavItem({
   const matrixRoomName = useRoomName(room);
   const roomName = (dmUserId && nicknames[dmUserId]) || matrixRoomName;
   const presence = useUserPresence(dmUserId ?? '');
-  const topicEvent = getStateEvent(room, StateEvent.RoomTopic);
-
-  const roomDescription = direct
-    ? (customDMCards && (topicEvent?.getContent().topic as string)) || presence?.status
-    : undefined;
+  const getRoomTopic = useRoomTopic(room);
+  const roomTopic = direct ? ((customDMCards && getRoomTopic) ?? presence?.status) : undefined;
 
   const { navigateRoom } = useRoomNavigate();
   const navigate = useNavigate();
@@ -447,7 +438,7 @@ export function RoomNavItem({
                 >
                   {roomName}
                 </Text>
-                {roomDescription && (
+                {roomTopic && (
                   <Text
                     truncate
                     size="T200"
@@ -457,7 +448,7 @@ export function RoomNavItem({
                       marginTop: '-2px',
                     }}
                   >
-                    {roomDescription}
+                    {roomTopic}
                   </Text>
                 )}
               </Box>

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -293,10 +293,8 @@ export function RoomNavItem({
   const matrixRoomName = useRoomName(room);
   const roomName = (dmUserId && nicknames[dmUserId]) || matrixRoomName;
   const presence = useUserPresence(dmUserId ?? '');
-  const [topicEvent, setTopicEvent] = useState(getStateEvent(room, StateEvent.RoomTopic));
+  const topicEvent = getStateEvent(room, StateEvent.RoomTopic);
 
-  // Ensures that the description does not stick to the position the room is in the row
-  useEffect(() => setTopicEvent(getStateEvent(room, StateEvent.RoomTopic)), [room, setTopicEvent]);
   const roomDescription = direct
     ? (customDMCards && (topicEvent?.getContent().topic as string)) || presence?.status
     : undefined;

--- a/src/app/hooks/useUserPresence.ts
+++ b/src/app/hooks/useUserPresence.ts
@@ -25,22 +25,27 @@ const getUserPresence = (user: User): UserPresence => ({
 export const useUserPresence = (userId: string): UserPresence | undefined => {
   const mx = useMatrixClient();
   const user = mx.getUser(userId);
-
   const [presence, setPresence] = useState(() => (user ? getUserPresence(user) : undefined));
 
   useEffect(() => {
-    const updatePresence: UserEventHandlerMap[UserEvent.Presence] = (event, u) => {
-      if (u.userId === user?.userId) {
+    if (!user) {
+      setPresence(undefined);
+      return undefined;
+    }
+    setPresence(getUserPresence(user));
+    const updatePresence: UserEventHandlerMap[UserEvent.Presence] = (e, u) => {
+      if (u.userId === user.userId) {
         setPresence(getUserPresence(user));
       }
     };
-    user?.on(UserEvent.Presence, updatePresence);
-    user?.on(UserEvent.CurrentlyActive, updatePresence);
-    user?.on(UserEvent.LastPresenceTs, updatePresence);
+    user.on(UserEvent.Presence, updatePresence);
+    user.on(UserEvent.CurrentlyActive, updatePresence);
+    user.on(UserEvent.LastPresenceTs, updatePresence);
+
     return () => {
-      user?.removeListener(UserEvent.Presence, updatePresence);
-      user?.removeListener(UserEvent.CurrentlyActive, updatePresence);
-      user?.removeListener(UserEvent.LastPresenceTs, updatePresence);
+      user.removeListener(UserEvent.Presence, updatePresence);
+      user.removeListener(UserEvent.CurrentlyActive, updatePresence);
+      user.removeListener(UserEvent.LastPresenceTs, updatePresence);
     };
   }, [user]);
 

--- a/src/app/pages/client/sidebar/DirectDMsList.tsx
+++ b/src/app/pages/client/sidebar/DirectDMsList.tsx
@@ -15,7 +15,7 @@ import {
 } from '$components/sidebar';
 import { RoomAvatar } from '$components/room-avatar';
 import { UserAvatar } from '$components/user-avatar';
-import { getDirectRoomAvatarUrl } from '$utils/room';
+import { getDirectRoomAvatarUrl, getRoomAvatarUrl } from '$utils/room';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { nameInitials } from '$utils/common';
 import { getCanonicalAliasOrRoomId, mxcUrlToHttp } from '$utils/matrix';
@@ -69,7 +69,10 @@ function DMItem({ room, selected }: DMItemProps) {
         <Avatar size="400" radii="400">
           <RoomAvatar
             roomId={room.roomId}
-            src={getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)}
+            src={
+              getRoomAvatarUrl(mx, room, 96, useAuthentication) ||
+              getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)
+            }
             alt={room.name}
             renderFallback={() => (
               <Text as="span" size="H6">


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fix statuses sticking from optimization and badge showing the wrong pfp in the DM list

(same 2 'people' in this chat, both dm chat, showing the right pfp with their statuses fixed)
<img width="317" height="164" alt="image" src="https://github.com/user-attachments/assets/5fd789bb-0aba-4a5b-bf28-70ba4bdd0d22" />


Fixes Issue mentioned in the space

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
A sleep paralysis demon moved my body as to type the fix