### PR TITLE
fix(timeline): scroll stay-at-bottom, Jump to Latest button, and phantom unread regressions

### DIFF
--- a/.changeset/fix-timeline-scroll-regressions.md
+++ b/.changeset/fix-timeline-scroll-regressions.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix timeline scroll regressions: stay-at-bottom, Jump to Latest button flicker, phantom unread dot, and blank notification page recovery

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -405,6 +405,21 @@ export function RoomTimeline({
     }
   }, [timelineSync.focusItem]);
 
+  // Recovery: if event timeline load failed and fell back to live timeline,
+  // reveal the timeline so the user doesn't see a blank page.
+  useEffect(() => {
+    if (eventId && !isReady && timelineSync.liveTimelineLinked && timelineSync.eventsLength > 0) {
+      scrollToBottom();
+      setIsReady(true);
+    }
+  }, [
+    eventId,
+    isReady,
+    timelineSync.liveTimelineLinked,
+    timelineSync.eventsLength,
+    scrollToBottom,
+  ]);
+
   useEffect(() => {
     if (!eventId) return;
     setIsReady(false);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -224,6 +224,13 @@ export function RoomTimeline({
   const pendingReadyRef = useRef(false);
   const currentRoomIdRef = useRef(room.roomId);
 
+  // Timestamp (epoch ms) of the last programmatic scrollToIndex call.
+  // While Date.now() - ref < SCROLL_SETTLE_MS the handleVListScroll callback
+  // suppresses false-negative "not at bottom" reports that VList fires during
+  // its height re-measurement pass.
+  const SCROLL_SETTLE_MS = 200;
+  const programmaticScrollToBottomRef = useRef(0);
+
   const [isReady, setIsReady] = useState(false);
 
   if (currentRoomIdRef.current !== room.roomId) {
@@ -231,6 +238,7 @@ export function RoomTimeline({
     mountScrollWindowRef.current = Date.now() + 3000;
     currentRoomIdRef.current = room.roomId;
     pendingReadyRef.current = false;
+    programmaticScrollToBottomRef.current = 0;
     if (initialScrollTimerRef.current !== undefined) {
       clearTimeout(initialScrollTimerRef.current);
       initialScrollTimerRef.current = undefined;
@@ -247,7 +255,7 @@ export function RoomTimeline({
     if (lastIndex < 0) return;
     // Guard against VList's intermediate height-correction scroll events that
     // would otherwise call setAtBottom(false) before the scroll settles.
-    programmaticScrollToBottomRef.current = true;
+    programmaticScrollToBottomRef.current = Date.now();
     vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
   }, []);
 
@@ -301,6 +309,7 @@ export function RoomTimeline({
       timelineSync.liveTimelineLinked &&
       vListRef.current
     ) {
+      programmaticScrollToBottomRef.current = Date.now();
       vListRef.current.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
       // Store in a ref rather than a local so subsequent eventsLength changes
       // (e.g. the onLifecycle timeline reset firing within 80 ms) do NOT
@@ -308,6 +317,7 @@ export function RoomTimeline({
       initialScrollTimerRef.current = setTimeout(() => {
         initialScrollTimerRef.current = undefined;
         if (processedEventsRef.current.length > 0) {
+          programmaticScrollToBottomRef.current = Date.now();
           vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
           // Only mark ready once we've successfully scrolled.  If processedEvents
           // was empty when the timer fired (e.g. the onLifecycle reset cleared the
@@ -649,8 +659,17 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
+
+      // During the settling window after a programmatic scroll, suppress
+      // false-negative "not at bottom" reports from VList.  Virtua fires
+      // several intermediate onScroll events while re-measuring item heights
+      // after scrollToIndex(); without this guard those would flash the
+      // "Jump to Latest" button for one or more render frames.
+      const isSettling = Date.now() - programmaticScrollToBottomRef.current < SCROLL_SETTLE_MS;
       if (isNowAtBottom !== atBottomRef.current) {
-        setAtBottom(isNowAtBottom);
+        if (isNowAtBottom || !isSettling) {
+          setAtBottom(isNowAtBottom);
+        }
       }
 
       if (offset < 500 && canPaginateBackRef.current && backwardStatusRef.current === 'idle') {
@@ -770,6 +789,7 @@ export function RoomTimeline({
     if (!pendingReadyRef.current) return;
     if (processedEvents.length === 0) return;
     pendingReadyRef.current = false;
+    programmaticScrollToBottomRef.current = Date.now();
     vListRef.current?.scrollToIndex(processedEvents.length - 1, { align: 'end' });
     setIsReady(true);
   }, [processedEvents.length]);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -249,14 +249,14 @@ export function RoomTimeline({
   const processedEventsRef = useRef<ProcessedEvent[]>([]);
   const timelineSyncRef = useRef<typeof timelineSync>(null as unknown as typeof timelineSync);
 
-  const scrollToBottom = useCallback(() => {
+  const scrollToBottom = useCallback((behavior?: 'instant' | 'smooth') => {
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
     // Guard against VList's intermediate height-correction scroll events that
     // would otherwise call setAtBottom(false) before the scroll settles.
     programmaticScrollToBottomRef.current = Date.now();
-    vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
+    vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: behavior === 'smooth' });
   }, []);
 
   const timelineSync = useTimelineSync({

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -263,10 +263,7 @@ export function RoomTimeline({
     if (behavior === 'smooth') {
       vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: true });
     } else {
-      // scrollToIndex works reliably regardless of VList measurement state.
-      // The auto-scroll useLayoutEffect fires after React commits new items,
-      // so lastIndex is always valid when this is called.
-      vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
+      vListRef.current.scrollTo(vListRef.current.scrollSize);
     }
   }, []);
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -201,13 +201,6 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
-  // Load any cached scroll state for this room on mount. A fresh RoomTimeline is
-  // mounted per room (via key={roomId} in RoomView) so this is the only place we
-  // need to read the cache — the render-phase room-change block below only fires
-  // in the (hypothetical) case where the room prop changes without a remount.
-  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
-    roomScrollCache.load(mxUserId, room.roomId)
-  );
   const [atBottomState, setAtBottomState] = useState(!eventId);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
@@ -256,15 +249,11 @@ export function RoomTimeline({
   const processedEventsRef = useRef<ProcessedEvent[]>([]);
   const timelineSyncRef = useRef<typeof timelineSync>(null as unknown as typeof timelineSync);
 
-  const scrollToBottom = useCallback((behavior?: 'instant' | 'smooth') => {
+  const scrollToBottom = useCallback(() => {
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
-    if (behavior === 'smooth') {
-      vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: true });
-    } else {
-      vListRef.current.scrollTo(vListRef.current.scrollSize);
-    }
+    vListRef.current.scrollTo(vListRef.current.scrollSize);
   }, []);
 
   const timelineSync = useTimelineSync({
@@ -455,8 +444,6 @@ export function RoomTimeline({
   useEffect(() => {
     if (!eventId) return;
     setIsReady(false);
-    // Ensure auto-scroll to bottom doesn't fire while we're navigating to a
-    // specific event — atBottom will be updated correctly once the user scrolls.
     setAtBottom(false);
     timelineSyncRef.current.loadEventTimeline(eventId);
   }, [eventId, room.roomId, setAtBottom]);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -365,6 +365,7 @@ export function RoomTimeline({
       setTopSpacerHeight(newH);
       if (prev > 0 && newH === 0 && processedEventsRef.current.length > 0) {
         requestAnimationFrame(() => {
+          programmaticScrollToBottomRef.current = Date.now();
           vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
         });
       }
@@ -388,6 +389,7 @@ export function RoomTimeline({
     } else if (prev === 'loading' && timelineSync.backwardStatus === 'idle') {
       setShift(false);
       if (wasAtBottomBeforePaginationRef.current) {
+        programmaticScrollToBottomRef.current = Date.now();
         vListRef.current?.scrollToIndex(processedEventsRef.current.length - 1, { align: 'end' });
       }
     }
@@ -420,14 +422,23 @@ export function RoomTimeline({
 
   // Recovery: if event timeline load failed and fell back to live timeline,
   // reveal the timeline so the user doesn't see a blank page.
+  // Skip when focusItem is set — that means loadEventTimeline succeeded and
+  // the success effects (415–419) already handle setIsReady.
   useEffect(() => {
-    if (eventId && !isReady && timelineSync.liveTimelineLinked && timelineSync.eventsLength > 0) {
+    if (
+      eventId &&
+      !isReady &&
+      !timelineSync.focusItem &&
+      timelineSync.liveTimelineLinked &&
+      timelineSync.eventsLength > 0
+    ) {
       scrollToBottom();
       setIsReady(true);
     }
   }, [
     eventId,
     isReady,
+    timelineSync.focusItem,
     timelineSync.liveTimelineLinked,
     timelineSync.eventsLength,
     scrollToBottom,

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -245,7 +245,10 @@ export function RoomTimeline({
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
-    vListRef.current.scrollTo(vListRef.current.scrollSize);
+    // Guard against VList's intermediate height-correction scroll events that
+    // would otherwise call setAtBottom(false) before the scroll settles.
+    programmaticScrollToBottomRef.current = true;
+    vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
   }, []);
 
   const timelineSync = useTimelineSync({

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -201,7 +201,14 @@ export function RoomTimeline({
   const setOpenThread = useSetAtom(openThreadAtom);
 
   const vListRef = useRef<VListHandle>(null);
-  const [atBottomState, setAtBottomState] = useState(true);
+  // Load any cached scroll state for this room on mount. A fresh RoomTimeline is
+  // mounted per room (via key={roomId} in RoomView) so this is the only place we
+  // need to read the cache — the render-phase room-change block below only fires
+  // in the (hypothetical) case where the room prop changes without a remount.
+  const scrollCacheForRoomRef = useRef<RoomScrollCache | undefined>(
+    roomScrollCache.load(mxUserId, room.roomId)
+  );
+  const [atBottomState, setAtBottomState] = useState(!eventId);
   const atBottomRef = useRef(atBottomState);
   const setAtBottom = useCallback((val: boolean) => {
     setAtBottomState(val);
@@ -253,10 +260,14 @@ export function RoomTimeline({
     if (!vListRef.current) return;
     const lastIndex = processedEventsRef.current.length - 1;
     if (lastIndex < 0) return;
-    // Guard against VList's intermediate height-correction scroll events that
-    // would otherwise call setAtBottom(false) before the scroll settles.
-    programmaticScrollToBottomRef.current = Date.now();
-    vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: behavior === 'smooth' });
+    if (behavior === 'smooth') {
+      vListRef.current.scrollToIndex(lastIndex, { align: 'end', smooth: true });
+    } else {
+      // scrollToIndex works reliably regardless of VList measurement state.
+      // The auto-scroll useLayoutEffect fires after React commits new items,
+      // so lastIndex is always valid when this is called.
+      vListRef.current.scrollToIndex(lastIndex, { align: 'end' });
+    }
   }, []);
 
   const timelineSync = useTimelineSync({
@@ -447,8 +458,11 @@ export function RoomTimeline({
   useEffect(() => {
     if (!eventId) return;
     setIsReady(false);
+    // Ensure auto-scroll to bottom doesn't fire while we're navigating to a
+    // specific event — atBottom will be updated correctly once the user scrolls.
+    setAtBottom(false);
     timelineSyncRef.current.loadEventTimeline(eventId);
-  }, [eventId, room.roomId]);
+  }, [eventId, room.roomId, setAtBottom]);
 
   useEffect(() => {
     if (eventId) return;

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -132,7 +132,7 @@ describe('useTimelineSync', () => {
       await Promise.resolve();
     });
 
-    expect(scrollToBottom).toHaveBeenCalledWith('instant');
+    expect(scrollToBottom).toHaveBeenCalled();
   });
 
   it('resets timeline state when room.roomId changes and eventId is not set', async () => {

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -107,7 +107,7 @@ describe('useTimelineSync', () => {
   });
 
   it('keeps a bottom-pinned user anchored after TimelineReset', async () => {
-    const { room, timelineSet } = createRoom();
+    const { room, timelineSet, events } = createRoom();
     const scrollToBottom = vi.fn();
 
     renderHook(() =>
@@ -125,6 +125,9 @@ describe('useTimelineSync', () => {
     );
 
     await act(async () => {
+      // Simulate the SDK replacing the live timeline with new events,
+      // which is what a real TimelineReset does.
+      events.push({});
       timelineSet.emit(RoomEvent.TimelineReset);
       await Promise.resolve();
     });

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -475,6 +475,9 @@ export function useTimelineSync({
 
   const lastScrolledAtEventsLengthRef = useRef(eventsLength);
 
+  const eventsLengthRef = useRef(eventsLength);
+  eventsLengthRef.current = eventsLength;
+
   useLiveEventArrive(
     room,
     useCallback(
@@ -496,6 +499,9 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
+          scrollToBottom(getSender.call(mEvt) === mx.getUserId() ? 'instant' : 'smooth');
+          lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
+
           setTimeline((ct) => ({ ...ct }));
           return;
         }
@@ -505,7 +511,7 @@ export function useTimelineSync({
           setUnreadInfo(getRoomUnreadInfo(room));
         }
       },
-      [mx, room, isAtBottomRef, unreadInfo, setUnreadInfo, hideReadsRef]
+      [mx, room, isAtBottomRef, unreadInfo, scrollToBottom, setUnreadInfo, hideReadsRef]
     )
   );
 
@@ -530,10 +536,10 @@ export function useTimelineSync({
       const wasAtBottom = isAtBottomRef.current;
       resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
-      // Scroll is handled by the useLayoutEffect auto-scroll recovery which
-      // fires after React commits the new timeline state — scrolling here
-      // would operate on the pre-commit DOM with a stale scrollSize.
-    }, [room, isAtBottomRef])
+      if (wasAtBottom) {
+        scrollToBottom('instant');
+      }
+    }, [room, isAtBottomRef, scrollToBottom])
   );
 
   useRelationUpdate(

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -1,13 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useCallback,
-  useRef,
-  useEffect,
-  useLayoutEffect,
-  Dispatch,
-  SetStateAction,
-} from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect, Dispatch, SetStateAction } from 'react';
 import to from 'await-to-js';
 import * as Sentry from '@sentry/react';
 import {
@@ -360,7 +351,7 @@ export interface UseTimelineSyncOptions {
   eventId?: string;
   isAtBottom: boolean;
   isAtBottomRef: React.MutableRefObject<boolean>;
-  scrollToBottom: (behavior?: 'instant' | 'smooth') => void;
+  scrollToBottom: () => void;
   unreadInfo: ReturnType<typeof getRoomUnreadInfo>;
   setUnreadInfo: Dispatch<SetStateAction<ReturnType<typeof getRoomUnreadInfo>>>;
   hideReadsRef: React.MutableRefObject<boolean>;
@@ -469,7 +460,7 @@ export function useTimelineSync({
     useCallback(() => {
       if (!alive()) return;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
-      scrollToBottom('instant');
+      scrollToBottom();
     }, [alive, room, scrollToBottom])
   );
 
@@ -499,7 +490,7 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
-          scrollToBottom(getSender.call(mEvt) === mx.getUserId() ? 'instant' : 'smooth');
+          scrollToBottom();
           lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
 
           setTimeline((ct) => ({ ...ct }));
@@ -537,7 +528,7 @@ export function useTimelineSync({
       resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
       if (wasAtBottom) {
-        scrollToBottom('instant');
+        scrollToBottom();
       }
     }, [room, isAtBottomRef, scrollToBottom])
   );
@@ -556,9 +547,7 @@ export function useTimelineSync({
     }, [])
   );
 
-  // useLayoutEffect so scroll fires before paint — prevents the one-frame flash
-  // where new VList content is briefly visible at the wrong position.
-  useLayoutEffect(() => {
+  useEffect(() => {
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
     if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;
 
@@ -576,7 +565,7 @@ export function useTimelineSync({
     if (eventsLength <= lastScrolledAtEventsLengthRef.current && !resetAutoScrollPending) return;
 
     lastScrolledAtEventsLengthRef.current = eventsLength;
-    scrollToBottom('instant');
+    scrollToBottom();
   }, [isAtBottom, liveTimelineLinked, eventsLength, scrollToBottom]);
 
   useEffect(() => {

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -1,4 +1,13 @@
-import { useState, useMemo, useCallback, useRef, useEffect, Dispatch, SetStateAction } from 'react';
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import to from 'await-to-js';
 import * as Sentry from '@sentry/react';
 import {
@@ -527,10 +536,10 @@ export function useTimelineSync({
       const wasAtBottom = isAtBottomRef.current;
       resetAutoScrollPendingRef.current = wasAtBottom;
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
-      if (wasAtBottom) {
-        scrollToBottom('instant');
-      }
-    }, [room, isAtBottomRef, scrollToBottom])
+      // Scroll is handled by the useLayoutEffect auto-scroll recovery which
+      // fires after React commits the new timeline state — scrolling here
+      // would operate on the pre-commit DOM with a stale scrollSize.
+    }, [room, isAtBottomRef])
   );
 
   useRelationUpdate(
@@ -547,7 +556,11 @@ export function useTimelineSync({
     }, [])
   );
 
-  useEffect(() => {
+  // useLayoutEffect so the scroll position is corrected before the browser
+  // paints. Without this, a sliding-sync subscription upgrade (timeline_limit
+  // 1 → 50) replaces the VList content and the user sees one frame at the
+  // wrong scroll position before the useEffect-based scroll fires.
+  useLayoutEffect(() => {
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
     if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;
 

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -475,9 +475,6 @@ export function useTimelineSync({
 
   const lastScrolledAtEventsLengthRef = useRef(eventsLength);
 
-  const eventsLengthRef = useRef(eventsLength);
-  eventsLengthRef.current = eventsLength;
-
   useLiveEventArrive(
     room,
     useCallback(
@@ -499,9 +496,6 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
-          scrollToBottom(getSender.call(mEvt) === mx.getUserId() ? 'instant' : 'smooth');
-          lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
-
           setTimeline((ct) => ({ ...ct }));
           return;
         }
@@ -511,7 +505,7 @@ export function useTimelineSync({
           setUnreadInfo(getRoomUnreadInfo(room));
         }
       },
-      [mx, room, isAtBottomRef, unreadInfo, scrollToBottom, setUnreadInfo, hideReadsRef]
+      [mx, room, isAtBottomRef, unreadInfo, setUnreadInfo, hideReadsRef]
     )
   );
 

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -550,10 +550,8 @@ export function useTimelineSync({
     }, [])
   );
 
-  // useLayoutEffect so the scroll position is corrected before the browser
-  // paints. Without this, a sliding-sync subscription upgrade (timeline_limit
-  // 1 → 50) replaces the VList content and the user sees one frame at the
-  // wrong scroll position before the useEffect-based scroll fires.
+  // useLayoutEffect so scroll fires before paint — prevents the one-frame flash
+  // where new VList content is briefly visible at the wrong position.
   useLayoutEffect(() => {
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
     if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -276,7 +276,7 @@ export const roomHaveUnread = (mx: MatrixClient, room: Room) => {
     if (event.getId() === readUpToId) {
       return false;
     }
-    if (isNotificationEvent(event, room, userId)) {
+    if (isNotificationEvent(event, room, userId) && event.getSender() !== userId) {
       return true;
     }
   }

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -34,9 +34,9 @@ export const LIST_SEARCH = 'search';
 export const LIST_ROOM_SEARCH = 'room_search';
 // Dynamic list key used for space-scoped room views.
 export const LIST_SPACE = 'space';
-// One event of timeline per list room is enough to compute unread counts;
-// the full history is loaded when the user opens the room.
-const LIST_TIMELINE_LIMIT = 1;
+// Higher limit avoids empty previews when the most-recent events are
+// reactions/edits/state that useRoomLatestRenderedEvent skips over.
+const LIST_TIMELINE_LIMIT = 3;
 const DEFAULT_LIST_PAGE_SIZE = 250;
 const DEFAULT_POLL_TIMEOUT_MS = 20000;
 const DEFAULT_MAX_ROOMS = 5000;


### PR DESCRIPTION
### Description

A collection of scroll and UI regression fixes for the VList-based timeline:

1. **Phantom unread dot + blank notification page recovery** — fix stale unread indicators and empty notification view after room transitions.
2. **`useLayoutEffect` for auto-scroll recovery after timeline reset** — when sliding sync upgrades `timeline_limit` (1 → 50), a `TimelineReset` replaces VList content. The old `useEffect` fired after paint, causing a visible flash at the wrong scroll position. Switching to `useLayoutEffect` corrects scroll before the browser paints.
3. **`scrollToIndex` for stay-at-bottom** — use virtua's `scrollToIndex` instead of `scrollToBottom` for the stay-at-bottom behaviour, and remove a premature scroll call that raced with layout.
4. **Timestamp-based settling window for Jump to Latest button** — replace the boolean `programmaticScrollToBottomRef` guard with a timestamp + 200 ms settling window (`SCROLL_SETTLE_MS`). VList fires multiple intermediate `onScroll` events during re-measurement after `scrollToIndex()`; the old boolean guard cleared on the first `isNowAtBottom=true` callback, letting subsequent callbacks flash the button. The timestamp approach suppresses false negatives for the entire measurement pass.

Related to SableClient/Sable#635
Related to SableClient/Sable#55

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI assisted with diagnosing the scroll timing issues and writing the timestamp-based settling window. The settling window stores `Date.now()` when a programmatic scroll starts and ignores `atBottom=false` reports within 200 ms, letting VList's re-measurement pass complete without false negatives. AI also assisted with updating the `useTimelineSync` test to push a new event before `TimelineReset` so the `useLayoutEffect` auto-scroll recovery fires correctly.