### PR TITLE
feat(presence): presence badges, auto-idle, and Discord-style status picker

### DIFF
--- a/.changeset/presence.md
+++ b/.changeset/presence.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix presence: optimistic badge updates, own-status sync, idle timer on desktop, and REST API fallback.

--- a/src/app/components/member-tile/MemberTile.tsx
+++ b/src/app/components/member-tile/MemberTile.tsx
@@ -7,8 +7,8 @@ import { useSableCosmetics } from '$hooks/useSableCosmetics';
 import { useAtomValue } from 'jotai';
 import { nicknamesAtom } from '$state/nicknames';
 import { UserAvatar } from '$components/user-avatar';
-import { useUserPresence } from '$hooks/useUserPresence';
-import { PresenceBadge } from '$components/presence';
+import { Presence, useUserPresence } from '$hooks/useUserPresence';
+import { AvatarPresence, PresenceBadge } from '$components/presence';
 import * as css from './style.css';
 
 const getName = (room: Room, member: RoomMember, nicknames: Record<string, string>) =>
@@ -39,25 +39,30 @@ export const MemberTile = as<'button', MemberTileProps>(
 
     return (
       <AsMemberTile className={css.MemberTile} {...props} ref={ref}>
-        <Avatar size="300" radii="400">
-          <UserAvatar
-            userId={member.userId}
-            src={avatarUrl ?? undefined}
-            alt={name}
-            renderFallback={() => <Icon size="300" src={Icons.User} filled />}
-          />
-        </Avatar>
+        <AvatarPresence
+          badge={
+            presence && presence.presence !== Presence.Offline ? (
+              <PresenceBadge presence={presence.presence} size="200" />
+            ) : undefined
+          }
+        >
+          <Avatar size="300" radii="400">
+            <UserAvatar
+              userId={member.userId}
+              src={avatarUrl ?? undefined}
+              alt={name}
+              renderFallback={() => <Icon size="300" src={Icons.User} filled />}
+            />
+          </Avatar>
+        </AvatarPresence>
         <Box grow="Yes" as="span" direction="Column">
           <Text as="span" size="T300" truncate style={{ color, fontFamily: font }}>
             <b>{name}</b>
           </Text>
-          {presence && presence.status && (
-            <Box alignItems="Center" gap="100">
-              <PresenceBadge presence={presence.presence} size="200" />
-              <Text as="span" size="T200" priority="300" truncate>
-                {presence.status}
-              </Text>
-            </Box>
+          {presence?.status && (
+            <Text as="span" size="T200" priority="300" truncate>
+              {presence.status}
+            </Text>
           )}
         </Box>
         {after}

--- a/src/app/components/presence/Presence.tsx
+++ b/src/app/components/presence/Presence.tsx
@@ -9,6 +9,7 @@ const PresenceToColor: Record<Presence, MainColor> = {
   [Presence.Online]: 'Success',
   [Presence.Unavailable]: 'Warning',
   [Presence.Offline]: 'Secondary',
+  [Presence.Dnd]: 'Critical',
 };
 
 type PresenceBadgeProps = {

--- a/src/app/components/room-avatar/AvatarImage.tsx
+++ b/src/app/components/room-avatar/AvatarImage.tsx
@@ -6,6 +6,12 @@ import { settingsAtom } from '$state/settings';
 import { useSetting } from '$state/hooks/settings';
 import * as css from './RoomAvatar.css';
 
+// Module-level cache: maps a Matrix media URL → processed blob URL so that
+// SVG processing only runs once per unique image, even as virtual-list items
+// unmount and remount. MXC URLs are content-addressed and never change, so
+// the mapping is stable for the lifetime of the page.
+const svgBlobCache = new Map<string, string>();
+
 type AvatarImageProps = {
   src: string;
   alt?: string;
@@ -23,9 +29,15 @@ export function AvatarImage({ src, alt, uniformIcons, onError }: AvatarImageProp
 
   useEffect(() => {
     let isMounted = true;
-    let objectUrl: string | null = null;
 
     const processImage = async () => {
+      // Return the cached blob URL immediately — no network round-trip needed.
+      const cachedBlobUrl = svgBlobCache.get(src);
+      if (cachedBlobUrl) {
+        setProcessedSrc(cachedBlobUrl);
+        return;
+      }
+
       try {
         const res = await fetch(src, { mode: 'cors' });
         const contentType = res.headers.get('content-type');
@@ -46,8 +58,10 @@ export function AvatarImage({ src, alt, uniformIcons, onError }: AvatarImageProp
           const newSvgString = serializer.serializeToString(doc);
           const blob = new Blob([newSvgString], { type: 'image/svg+xml' });
 
-          objectUrl = URL.createObjectURL(blob);
-          if (isMounted) setProcessedSrc(objectUrl);
+          const blobUrl = URL.createObjectURL(blob);
+          // Store in module cache so future remounts skip processing.
+          svgBlobCache.set(src, blobUrl);
+          if (isMounted) setProcessedSrc(blobUrl);
         } else if (isMounted) setProcessedSrc(src);
       } catch {
         if (isMounted) setProcessedSrc(src);
@@ -58,9 +72,8 @@ export function AvatarImage({ src, alt, uniformIcons, onError }: AvatarImageProp
 
     return () => {
       isMounted = false;
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
+      // Blob URLs are retained in svgBlobCache — do not revoke them here so
+      // that subsequent remounts can use the cached result without re-fetching.
     };
   }, [src]);
 

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -26,7 +26,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
 
 import { AvatarPresence, PresenceBadge } from '$components/presence';
-import { useUserPresence } from '$hooks/useUserPresence';
+import { Presence, useUserPresence } from '$hooks/useUserPresence';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { UseStateProvider } from '$components/UseStateProvider';
 import type { SearchItemStrGetter, UseAsyncSearchOptions } from '$hooks/useAsyncSearch';
@@ -150,7 +150,7 @@ function MemberItem({
     >
       <AvatarPresence
         badge={
-          presence && presence.lastActiveTs !== 0 ? (
+          presence && presence.presence !== Presence.Offline ? (
             <PresenceBadge presence={presence.presence} size="200" />
           ) : undefined
         }

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -296,8 +296,6 @@ export function MembersDrawer({ room, members }: MembersDrawerProps) {
   );
 
   const handleMemberClick: MouseEventHandler<HTMLButtonElement> = (evt) => {
-    // oxlint-disable-next-line no-console
-    console.log(evt);
     const btn = evt.currentTarget as HTMLButtonElement;
     const userId = btn.getAttribute('data-user-id');
     if (!userId) return;

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -43,6 +43,9 @@ import { useCapabilities } from '$hooks/useCapabilities';
 import { profilesCacheAtom } from '$state/userRoomProfile';
 import { SequenceCardStyle } from '$features/settings/styles.css';
 import { useUserPresence } from '$hooks/useUserPresence';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
+import { getSlidingSyncManager } from '$client/initMatrix';
 import type { MSC1767Text } from '$types/matrix/common';
 import { TimezoneEditor } from './TimezoneEditor';
 import { PronounEditor } from './PronounEditor';
@@ -485,7 +488,13 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
 
   const pronouns = (profile.pronouns as PronounSet[]) || [];
   const presence = useUserPresence(userId);
-  const currentStatus = presence?.status || '';
+  // presenceStatusMsg is the locally-cached status. On sliding sync, own presence is
+  // never echoed back by the server, so presence?.status would always be stale/empty.
+  // The settings atom is the authoritative local source; fall back to the SDK value for
+  // other clients (e.g. when viewing another user's profile page — but this component
+  // is only rendered for the own user, so the atom always wins in practice).
+  const [presenceStatusMsg, setPresenceStatusMsg] = useSetting(settingsAtom, 'presenceStatusMsg');
+  const currentStatus = presenceStatusMsg || presence?.status || '';
 
   // Keys we don't render here nor handle seperately but still need to exclude
   const EXCLUDED_KEYS = new Set([
@@ -513,14 +522,14 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
 
   const handleSaveStatus = useCallback(
     async (newStatus: string) => {
-      const currentState = presence?.presence || 'online';
-
-      await mx.setPresence({
-        presence: currentState,
-        status_msg: newStatus,
-      });
+      const currentState = presence?.presence ?? 'online';
+      setPresenceStatusMsg(newStatus);
+      await mx.setPresence({ presence: currentState, status_msg: newStatus });
+      // MSC4186 servers don't echo own presence back; synthesize the update locally so
+      // useUserPresence(myUserId) and the member-list badge stay accurate.
+      getSlidingSyncManager(mx)?.updateOwnPresence(currentState, newStatus);
     },
-    [mx, presence]
+    [mx, presence, setPresenceStatusMsg]
   );
 
   return (

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -522,14 +522,24 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
 
   const handleSaveStatus = useCallback(
     async (newStatus: string) => {
-      const currentState = presence?.presence ?? 'online';
+      // Only update the local atom. PresenceFeature's effect will broadcast the new
+      // status_msg to the server on its next run (triggered by this atom change).
+      // We don't call mx.setPresence here to avoid passing our internal Presence.Dnd
+      // value ('dnd'), which is not a valid Matrix presence state.
       setPresenceStatusMsg(newStatus);
-      await mx.setPresence({ presence: currentState, status_msg: newStatus });
-      // MSC4186 servers don't echo own presence back; synthesize the update locally so
-      // useUserPresence(myUserId) and the member-list badge stay accurate.
-      getSlidingSyncManager(mx)?.updateOwnPresence(currentState, newStatus);
+
+      // Eagerly mirror the change in the SDK store so the member list updates without
+      // waiting for the PresenceFeature effect to resolve the network call.
+      const myUser = mx.getUser(mx.getUserId() ?? '');
+      const isDnd = myUser?.presence === 'online' && myUser?.presenceStatusMsg === 'dnd';
+      if (!isDnd) {
+        // Not in DND: update local presence to reflect the new status immediately.
+        getSlidingSyncManager(mx)?.updateOwnPresence(myUser?.presence ?? 'online', newStatus);
+      }
+      // In DND mode the sentinel ('dnd') stays as status_msg on the wire; the user's
+      // custom status is preserved in the atom and used once they leave DND.
     },
-    [mx, presence, setPresenceStatusMsg]
+    [mx, setPresenceStatusMsg]
   );
 
   return (

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -482,7 +482,7 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
           <SettingTile
             title="Auto-Idle"
             focusId="auto-idle-presence"
-            description="Automatically appear unavailable after 5 minutes of inactivity or when the tab is hidden."
+            description="Automatically appear unavailable after 5 minutes of inactivity or when the app isn't active."
             after={
               <Switch
                 variant="Primary"

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -482,7 +482,7 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
           <SettingTile
             title="Auto-Idle"
             focusId="auto-idle-presence"
-            description="Automatically appear unavailable after 5 minutes of inactivity or when the app isn't active."
+            description="Automatically appear unavailable after a period of inactivity or when the app isn't active."
             after={
               <Switch
                 variant="Primary"
@@ -490,6 +490,16 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
                 onChange={setAutoIdlePresence}
               />
             }
+          />
+        </SequenceCard>
+      )}
+      {sendPresence && autoIdlePresence && (
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Idle Timeout"
+            focusId="presence-idle-timeout"
+            description="Minutes of inactivity before appearing unavailable."
+            after={<PresenceIdleTimeoutInput />}
           />
         </SequenceCard>
       )}
@@ -854,6 +864,52 @@ function EmojiSelectorThresholdInput() {
       onKeyDown={handleKeyDown}
       outlined
     />
+  );
+}
+
+function PresenceIdleTimeoutInput() {
+  const [idleTimeoutMins, setIdleTimeoutMins] = useSetting(settingsAtom, 'presenceIdleTimeoutMins');
+  const [inputValue, setInputValue] = useState(idleTimeoutMins.toString());
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (evt) => {
+    const val = evt.target.value;
+    setInputValue(val);
+    const parsed = Number.parseInt(val, 10);
+    if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 60) {
+      setIdleTimeoutMins(parsed);
+    }
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (evt) => {
+    if (isKeyHotkey('escape', evt)) {
+      evt.stopPropagation();
+      setInputValue(idleTimeoutMins.toString());
+      (evt.target as HTMLInputElement).blur();
+    }
+    if (isKeyHotkey('enter', evt)) {
+      (evt.target as HTMLInputElement).blur();
+    }
+  };
+
+  return (
+    <Box alignItems="Center" gap="200">
+      <Input
+        style={{ width: toRem(80) }}
+        variant={Number.parseInt(inputValue, 10) === idleTimeoutMins ? 'Secondary' : 'Success'}
+        size="300"
+        radii="300"
+        type="number"
+        min="1"
+        max="60"
+        value={inputValue}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        outlined
+      />
+      <Text size="T200" priority="300">
+        min
+      </Text>
+    </Box>
   );
 }
 

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -484,11 +484,7 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
             focusId="auto-idle-presence"
             description="Automatically appear unavailable after a period of inactivity or when the app isn't active."
             after={
-              <Switch
-                variant="Primary"
-                value={autoIdlePresence}
-                onChange={setAutoIdlePresence}
-              />
+              <Switch variant="Primary" value={autoIdlePresence} onChange={setAutoIdlePresence} />
             }
           />
         </SequenceCard>

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -419,6 +419,7 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
   const [hideActivity, setHideActivity] = useSetting(settingsAtom, 'hideActivity');
   const [hideReads, setHideReads] = useSetting(settingsAtom, 'hideReads');
   const [sendPresence, setSendPresence] = useSetting(settingsAtom, 'sendPresence');
+  const [autoIdlePresence, setAutoIdlePresence] = useSetting(settingsAtom, 'autoIdlePresence');
   const [mentionInReplies, setMentionInReplies] = useSetting(settingsAtom, 'mentionInReplies');
 
   return (
@@ -476,6 +477,22 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
           after={<Switch variant="Primary" value={sendPresence} onChange={setSendPresence} />}
         />
       </SequenceCard>
+      {sendPresence && (
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Auto-Idle"
+            focusId="auto-idle-presence"
+            description="Automatically appear unavailable after 5 minutes of inactivity or when the tab is hidden."
+            after={
+              <Switch
+                variant="Primary"
+                value={autoIdlePresence}
+                onChange={setAutoIdlePresence}
+              />
+            }
+          />
+        </SequenceCard>
+      )}
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile
           title="Send notifications for replies"

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -26,9 +26,9 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
         `App visibility changed: ${isVisible ? 'visible (foreground)' : 'hidden (background)'}`,
         { visibilityState: document.visibilityState }
       );
-      appEvents.onVisibilityChange?.(isVisible);
+      appEvents.emitVisibilityChange(isVisible);
       if (!isVisible) {
-        appEvents.onVisibilityHidden?.();
+        appEvents.emitVisibilityHidden();
       }
     };
 
@@ -46,9 +46,7 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
       togglePusher(mx, clientConfig, isVisible, usePushNotifications, pushSubAtom, isMobile);
     };
 
-    appEvents.onVisibilityChange = handleVisibilityForNotifications;
-    return () => {
-      appEvents.onVisibilityChange = null;
-    };
+    const unsub = appEvents.onVisibilityChange(handleVisibilityForNotifications);
+    return unsub;
   }, [mx, clientConfig, usePushNotifications, pushSubAtom, isMobile]);
 }

--- a/src/app/hooks/usePresenceAutoIdle.test.tsx
+++ b/src/app/hooks/usePresenceAutoIdle.test.tsx
@@ -88,9 +88,9 @@ describe('usePresenceAutoIdle', () => {
     });
     expect(result.current).toBe(true);
 
-    // Simulate user activity.
+    // Simulate user activity (keydown is not filtered by the focus guard).
     act(() => {
-      document.dispatchEvent(new Event('mousemove'));
+      document.dispatchEvent(new Event('keydown'));
     });
     expect(result.current).toBe(false);
   });

--- a/src/app/hooks/usePresenceAutoIdle.test.tsx
+++ b/src/app/hooks/usePresenceAutoIdle.test.tsx
@@ -1,0 +1,226 @@
+import { act, renderHook } from '@testing-library/react';
+import { Provider, useAtomValue } from 'jotai';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { usePresenceAutoIdle } from './usePresenceAutoIdle';
+import { presenceAutoIdledAtom } from '$state/settings';
+import { appEvents } from '$utils/appEvents';
+import type { ReactNode } from 'react';
+
+// -------- mock setup --------
+
+const userListeners = new Map<string, ((...args: unknown[]) => void)[]>();
+
+const makeMockUser = () => ({
+  userId: '@alice:test',
+  presence: 'online',
+  on: vi
+    .fn<(event: string, handler: (...args: unknown[]) => void) => void>()
+    .mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+      const list = userListeners.get(event) ?? [];
+      list.push(handler);
+      userListeners.set(event, list);
+    }),
+  removeListener: vi.fn<() => void>(),
+});
+
+let mockUser: ReturnType<typeof makeMockUser> | null = null;
+
+const makeMockMx = () => ({
+  getUserId: vi.fn<() => string>(() => '@alice:test'),
+  getUser: vi.fn<() => ReturnType<typeof makeMockUser> | null>(() => mockUser),
+});
+
+let mockMx: ReturnType<typeof makeMockMx>;
+
+const wrapper = ({ children }: { children: ReactNode }) => <Provider>{children}</Provider>;
+
+// Helper to read the atom value alongside the hook under test.
+function useAutoIdledReader(
+  mx: ReturnType<typeof makeMockMx>,
+  presenceMode: string,
+  sendPresence: boolean,
+  timeoutMs: number
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  usePresenceAutoIdle(mx as any, presenceMode, sendPresence, timeoutMs);
+  return useAtomValue(presenceAutoIdledAtom);
+}
+
+// -------- lifecycle --------
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  userListeners.clear();
+  mockUser = makeMockUser();
+  mockMx = makeMockMx();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// -------- tests --------
+
+describe('usePresenceAutoIdle', () => {
+  it('sets auto-idle after the timeout elapses', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 5000), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('resets auto-idle when user activity is detected', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 5000), {
+      wrapper,
+    });
+
+    // Go idle.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(true);
+
+    // Simulate user activity.
+    act(() => {
+      document.dispatchEvent(new Event('mousemove'));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('resets auto-idle when app becomes visible via appEvents', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 5000), {
+      wrapper,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(true);
+
+    // Simulate app returning to foreground.
+    act(() => {
+      appEvents.emitVisibilityChange(true);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not go idle when presenceMode is not online', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'dnd', true, 5000), { wrapper });
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not go idle when sendPresence is false', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', false, 5000), {
+      wrapper,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not go idle when timeoutMs is 0', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 0), { wrapper });
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('restarts the idle timer on activity before timeout', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 5000), {
+      wrapper,
+    });
+
+    // Advance partially, then trigger activity.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      document.dispatchEvent(new Event('keydown'));
+    });
+
+    // Original timeout would have fired at 5000ms, but we reset.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current).toBe(false);
+
+    // Now the full 5000ms from last activity should trigger idle.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('clears auto-idle when presenceMode changes away from online', () => {
+    const { result, rerender } = renderHook(
+      ({ mode }) => useAutoIdledReader(mockMx, mode, true, 5000),
+      { wrapper, initialProps: { mode: 'online' } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(true);
+
+    rerender({ mode: 'dnd' });
+    expect(result.current).toBe(false);
+  });
+
+  it('clears auto-idle when another device sets presence to online', () => {
+    const { result } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 5000), {
+      wrapper,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(true);
+
+    // Simulate User.presence event from another device.
+    const handlers = userListeners.get('User.presence') ?? [];
+    expect(handlers.length).toBeGreaterThan(0);
+
+    act(() => {
+      handlers.forEach((h) => h({}, { userId: '@alice:test', presence: 'online' }));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('unsubscribes from appEvents.onVisibilityChange on cleanup', () => {
+    const { result, unmount } = renderHook(() => useAutoIdledReader(mockMx, 'online', true, 5000), {
+      wrapper,
+    });
+
+    // Go idle.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(true);
+
+    unmount();
+
+    // After unmount, emitting visibility change should have no effect.
+    // (No error thrown means the handler was properly unsubscribed.)
+    act(() => {
+      appEvents.emitVisibilityChange(true);
+    });
+  });
+});

--- a/src/app/hooks/usePresenceAutoIdle.ts
+++ b/src/app/hooks/usePresenceAutoIdle.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSetAtom } from 'jotai';
+import { type MatrixClient, UserEvent, type UserEventHandlerMap } from '$types/matrix-sdk';
+import { presenceAutoIdledAtom } from '$state/settings';
+import { appEvents } from '$utils/appEvents';
+import { createDebugLogger } from '$utils/debugLogger';
+
+const debugLog = createDebugLogger('PresenceAutoIdle');
+const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'wheel'] as const;
+
+/**
+ * Automatically transitions presence to idle after a configurable inactivity
+ * timeout, and clears the idle state when activity is detected.
+ *
+ * Also subscribes to the Matrix `User.presence` event so that if another device
+ * sets you back to `online`, the auto-idle state is cleared here too (multi-device
+ * sync).
+ *
+ * Note: On iOS Safari PWA, background tab throttling may delay or prevent the
+ * inactivity timer from firing reliably. The feature degrades gracefully — presence
+ * will eventually update when the tab regains focus.
+ */
+export function usePresenceAutoIdle(
+  mx: MatrixClient,
+  presenceMode: string,
+  sendPresence: boolean,
+  timeoutMs: number
+): void {
+  const setAutoIdled = useSetAtom(presenceAutoIdledAtom);
+  const autoIdledRef = useRef(false);
+  const timerRef = useRef<number | undefined>(undefined);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== undefined) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
+
+  // Inactivity timer: go idle after timeoutMs without user input.
+  useEffect(() => {
+    const shouldAutoIdle = presenceMode === 'online' && sendPresence && timeoutMs > 0;
+    if (!shouldAutoIdle) {
+      clearTimer();
+      if (autoIdledRef.current) {
+        autoIdledRef.current = false;
+        setAutoIdled(false);
+      }
+      return undefined;
+    }
+
+    const goIdle = () => {
+      debugLog.info('general', 'Inactivity timeout — auto-idling');
+      autoIdledRef.current = true;
+      setAutoIdled(true);
+    };
+
+    const handleActivity = () => {
+      clearTimer();
+      if (autoIdledRef.current) {
+        debugLog.info('general', 'Activity detected — clearing auto-idle');
+        autoIdledRef.current = false;
+        setAutoIdled(false);
+      }
+      timerRef.current = window.setTimeout(goIdle, timeoutMs);
+    };
+
+    // Start the initial timer.
+    timerRef.current = window.setTimeout(goIdle, timeoutMs);
+    ACTIVITY_EVENTS.forEach((ev) =>
+      document.addEventListener(ev, handleActivity, { passive: true })
+    );
+
+    // When the app returns to the foreground, treat it as activity so the user
+    // isn't shown as idle the moment they switch back to the tab/PWA.
+    const unsubVisibility = appEvents.onVisibilityChange((isVisible: boolean) => {
+      if (isVisible) handleActivity();
+    });
+
+    return () => {
+      ACTIVITY_EVENTS.forEach((ev) => document.removeEventListener(ev, handleActivity));
+      clearTimer();
+      unsubVisibility();
+    };
+  }, [clearTimer, presenceMode, sendPresence, setAutoIdled, timeoutMs]);
+
+  // Multi-device sync: if another device sets us back to online, clear auto-idle.
+  useEffect(() => {
+    if (!sendPresence) return undefined;
+    const myUserId = mx.getUserId();
+    if (!myUserId) return undefined;
+    const user = mx.getUser(myUserId);
+    if (!user) return undefined;
+
+    const handlePresence: UserEventHandlerMap[UserEvent.Presence] = (_event, u) => {
+      if (u.userId !== myUserId) return;
+      if (u.presence === 'online' && autoIdledRef.current) {
+        debugLog.info('general', 'Remote device set Online — clearing auto-idle');
+        autoIdledRef.current = false;
+        setAutoIdled(false);
+      }
+    };
+
+    user.on(UserEvent.Presence, handlePresence);
+    return () => {
+      user.removeListener(UserEvent.Presence, handlePresence);
+    };
+  }, [mx, sendPresence, setAutoIdled]);
+}

--- a/src/app/hooks/usePresenceAutoIdle.ts
+++ b/src/app/hooks/usePresenceAutoIdle.ts
@@ -4,6 +4,7 @@ import { type MatrixClient, UserEvent, type UserEventHandlerMap } from '$types/m
 import { presenceAutoIdledAtom } from '$state/settings';
 import { appEvents } from '$utils/appEvents';
 import { createDebugLogger } from '$utils/debugLogger';
+import { mobileOrTablet } from '$utils/user-agent';
 
 const debugLog = createDebugLogger('PresenceAutoIdle');
 const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'wheel'] as const;
@@ -55,7 +56,14 @@ export function usePresenceAutoIdle(
       setAutoIdled(true);
     };
 
-    const handleActivity = () => {
+    const handleActivity = (event?: Event) => {
+      // On desktop, cursor movement over the window fires mousemove even when
+      // the window does not have OS focus (e.g. the user is working in another
+      // app). Treat those as non-events so the idle timer can run to completion
+      // without the user having to keep their hands off the mouse entirely.
+      if (!mobileOrTablet() && event?.type === 'mousemove' && !document.hasFocus()) {
+        return;
+      }
       clearTimer();
       if (autoIdledRef.current) {
         debugLog.info('general', 'Activity detected — clearing auto-idle');

--- a/src/app/hooks/useUserPresence.ts
+++ b/src/app/hooks/useUserPresence.ts
@@ -28,7 +28,8 @@ const getUserPresence = (user: User): UserPresence => {
       : rawPresence;
   return {
     presence,
-    status: user.presenceStatusMsg,
+    // Don't leak the internal DND sentinel as a visible status message.
+    status: user.presenceStatusMsg !== 'dnd' ? user.presenceStatusMsg : undefined,
     active: user.currentlyActive,
     lastActiveTs: user.getLastActiveTs(),
   };

--- a/src/app/hooks/useUserPresence.ts
+++ b/src/app/hooks/useUserPresence.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { User, UserEventHandlerMap } from '$types/matrix-sdk';
-import { UserEvent } from '$types/matrix-sdk';
+import type { MatrixEvent, User, UserEventHandlerMap } from '$types/matrix-sdk';
+import { ClientEvent, UserEvent } from '$types/matrix-sdk';
 import { useMatrixClient } from './useMatrixClient';
 
 export enum Presence {
@@ -31,7 +31,21 @@ export const useUserPresence = (userId: string): UserPresence | undefined => {
   useEffect(() => {
     if (!user) {
       setPresence(undefined);
-      return undefined;
+
+      // When the user isn't in the SDK store yet (e.g., presence arrived before
+      // any membership event), listen on the client for incoming events so we
+      // can re-evaluate once a presence event for this user is stored.
+      const handleEvent = (event: MatrixEvent) => {
+        if (event.getType() !== 'm.presence') return;
+        const sender = event.getSender();
+        if (sender !== userId) return;
+        const latestUser = mx.getUser(userId);
+        if (latestUser) setPresence(getUserPresence(latestUser));
+      };
+      mx.on(ClientEvent.Event, handleEvent);
+      return () => {
+        mx.removeListener(ClientEvent.Event, handleEvent);
+      };
     }
     setPresence(getUserPresence(user));
     const updatePresence: UserEventHandlerMap[UserEvent.Presence] = (e, u) => {
@@ -48,7 +62,7 @@ export const useUserPresence = (userId: string): UserPresence | undefined => {
       user.removeListener(UserEvent.CurrentlyActive, updatePresence);
       user.removeListener(UserEvent.LastPresenceTs, updatePresence);
     };
-  }, [user]);
+  }, [mx, user, userId]);
 
   return presence;
 };

--- a/src/app/hooks/useUserPresence.ts
+++ b/src/app/hooks/useUserPresence.ts
@@ -7,6 +7,8 @@ export enum Presence {
   Online = 'online',
   Unavailable = 'unavailable',
   Offline = 'offline',
+  // DND is not a native Matrix state; Sable encodes it as online + status_msg='dnd'.
+  Dnd = 'dnd',
 }
 
 export type UserPresence = {
@@ -16,12 +18,21 @@ export type UserPresence = {
   lastActiveTs?: number;
 };
 
-const getUserPresence = (user: User): UserPresence => ({
-  presence: user.presence as Presence,
-  status: user.presenceStatusMsg,
-  active: user.currentlyActive,
-  lastActiveTs: user.getLastActiveTs(),
-});
+const getUserPresence = (user: User): UserPresence => {
+  const rawPresence = user.presence as Presence;
+  // DND is encoded as online + status_msg 'dnd'. Decode it back so the badge
+  // renders red for any Sable client, not just the sender's own account switcher.
+  const presence =
+    rawPresence === Presence.Online && user.presenceStatusMsg === 'dnd'
+      ? Presence.Dnd
+      : rawPresence;
+  return {
+    presence,
+    status: user.presenceStatusMsg,
+    active: user.currentlyActive,
+    lastActiveTs: user.getLastActiveTs(),
+  };
+};
 
 export const useUserPresence = (userId: string): UserPresence | undefined => {
   const mx = useMatrixClient();
@@ -73,6 +84,7 @@ export const usePresenceLabel = (): Record<Presence, string> =>
       [Presence.Online]: 'Active',
       [Presence.Unavailable]: 'Busy',
       [Presence.Offline]: 'Away',
+      [Presence.Dnd]: 'Do Not Disturb',
     }),
     []
   );

--- a/src/app/hooks/useUserPresence.ts
+++ b/src/app/hooks/useUserPresence.ts
@@ -71,6 +71,25 @@ export const useUserPresence = (userId: string): UserPresence | undefined => {
     user.on(UserEvent.CurrentlyActive, updatePresence);
     user.on(UserEvent.LastPresenceTs, updatePresence);
 
+    // Synapse's MSC4186 simplified sliding sync has no presence extension, so
+    // presence events never arrive over the sync stream.  If lastPresenceTs is
+    // still 0 we have never received presence data for this user — fall back to
+    // a direct REST call so badges appear on first render.
+    if (user.lastPresenceTs === 0) {
+      mx.getPresence(userId)
+        .then((status) => {
+          user.presence = status.presence;
+          user.presenceStatusMsg = status.status_msg;
+          user.currentlyActive = status.currently_active ?? false;
+          user.lastActiveAgo = status.last_active_ago ?? 0;
+          user.lastPresenceTs = Date.now();
+          setPresence(getUserPresence(user));
+        })
+        .catch(() => {
+          // Presence unavailable or disabled on this server — stay offline.
+        });
+    }
+
     return () => {
       user.removeListener(UserEvent.Presence, updatePresence);
       user.removeListener(UserEvent.CurrentlyActive, updatePresence);

--- a/src/app/hooks/useUserPresence.ts
+++ b/src/app/hooks/useUserPresence.ts
@@ -49,7 +49,9 @@ export const useUserPresence = (userId: string): UserPresence | undefined => {
       // can re-evaluate once a presence event for this user is stored.
       const handleEvent = (event: MatrixEvent) => {
         if (event.getType() !== 'm.presence') return;
-        const sender = event.getSender();
+        // MSC4186 sliding sync presence events may carry the user ID in
+        // content.user_id rather than the sender field.
+        const sender = event.getSender() ?? (event.getContent().user_id as string | undefined);
         if (sender !== userId) return;
         const latestUser = mx.getUser(userId);
         if (latestUser) setPresence(getUserPresence(latestUser));

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -873,20 +873,23 @@ function PresenceFeature() {
     // Sliding sync: keep the extension enabled so we always receive others' presence.
     // Only disable it when the master sendPresence toggle is off (full privacy mode).
     getSlidingSyncManager(mx)?.setPresenceEnabled(sendPresence);
-    // Explicitly PUT /presence/{userId}/status so the server knows the exact state:
-    // - MSC4186 servers that have no presence extension see this immediately.
-    // - When 'offline' (Invisible mode), we appear offline to others but still receive
-    //   their presence events because the extension is still enabled above.
-    // Optimistically update own presence in the local SDK store so the member list
-    // badge and status editor reflect the change immediately. MSC4186 servers never
-    // echo own presence back, so we can't rely on the server round-trip for this.
-    getSlidingSyncManager(mx)?.updateOwnPresence(effectiveState, effectiveStatusMsg);
+
+    // Explicitly PUT /presence/{userId}/status so the server knows the exact state.
+    // Do the optimistic update AFTER the network call to avoid inconsistency if it fails.
     mx.setPresence({
       presence: effectiveState,
       status_msg: effectiveStatusMsg,
-    }).catch(() => {
-      // Server doesn't support presence — ignore.
-    });
+    })
+      .then(() => {
+        // Optimistically update own presence in the local SDK store so the member list
+        // badge and status editor reflect the change immediately. MSC4186 servers never
+        // echo own presence back, so we rely on this local update for consistency.
+        getSlidingSyncManager(mx)?.updateOwnPresence(effectiveState, effectiveStatusMsg);
+      })
+      .catch(() => {
+        // Server doesn't support presence or network error — the local SDK store
+        // won't be updated, but that's acceptable since the server state is canonical.
+      });
   }, [mx, sendPresence, presenceMode, presenceStatusMsg, autoIdled]);
 
   return null;

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -845,6 +845,7 @@ function PresenceFeature() {
   const mx = useMatrixClient();
   const [sendPresence] = useSetting(settingsAtom, 'sendPresence');
   const [autoIdlePresence] = useSetting(settingsAtom, 'autoIdlePresence');
+  const [presenceIdleTimeoutMins] = useSetting(settingsAtom, 'presenceIdleTimeoutMins');
 
   useEffect(() => {
     // Classic sync: set_presence query param on every /sync poll.
@@ -859,12 +860,12 @@ function PresenceFeature() {
     }
   }, [mx, sendPresence]);
 
-  // Auto-idle: set presence to unavailable after 5 minutes of inactivity or
+  // Auto-idle: set presence to unavailable after inactivity or
   // when the tab is hidden, and restore online on activity.
   useEffect(() => {
     if (!sendPresence || !autoIdlePresence) return undefined;
 
-    const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+    const IDLE_TIMEOUT_MS = Math.max(1, presenceIdleTimeoutMins) * 60 * 1000;
     let idleTimer: ReturnType<typeof setTimeout> | undefined;
     let isIdle = false;
 
@@ -915,7 +916,7 @@ function PresenceFeature() {
         mx.setPresence({ presence: 'online' }).catch(() => {});
       }
     };
-  }, [mx, sendPresence, autoIdlePresence]);
+  }, [mx, sendPresence, autoIdlePresence, presenceIdleTimeoutMins]);
 
   return null;
 }

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -844,6 +844,7 @@ function HandleDecryptPushEvent() {
 function PresenceFeature() {
   const mx = useMatrixClient();
   const [sendPresence] = useSetting(settingsAtom, 'sendPresence');
+  const [autoIdlePresence] = useSetting(settingsAtom, 'autoIdlePresence');
 
   useEffect(() => {
     // Classic sync: set_presence query param on every /sync poll.
@@ -852,6 +853,64 @@ function PresenceFeature() {
     // Sliding sync: enable/disable the presence extension on the next poll.
     getSlidingSyncManager(mx)?.setPresenceEnabled(sendPresence);
   }, [mx, sendPresence]);
+
+  // Auto-idle: set presence to unavailable after 5 minutes of inactivity or
+  // when the tab is hidden, and restore online on activity.
+  useEffect(() => {
+    if (!sendPresence || !autoIdlePresence) return undefined;
+
+    const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let isIdle = false;
+
+    const goOnline = () => {
+      if (!isIdle) return;
+      isIdle = false;
+      mx.setPresence({ presence: 'online' }).catch(() => {});
+    };
+
+    const goIdle = () => {
+      if (isIdle) return;
+      isIdle = true;
+      mx.setPresence({ presence: 'unavailable' }).catch(() => {});
+    };
+
+    const resetTimer = () => {
+      goOnline();
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(goIdle, IDLE_TIMEOUT_MS);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        clearTimeout(idleTimer);
+        goIdle();
+      } else {
+        resetTimer();
+      }
+    };
+
+    const ACTIVITY_EVENTS: (keyof DocumentEventMap)[] = [
+      'mousemove',
+      'keydown',
+      'pointerdown',
+      'scroll',
+    ];
+
+    ACTIVITY_EVENTS.forEach((e) => document.addEventListener(e, resetTimer, { passive: true }));
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    resetTimer();
+
+    return () => {
+      clearTimeout(idleTimer);
+      ACTIVITY_EVENTS.forEach((e) => document.removeEventListener(e, resetTimer));
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      // Restore online when feature is disabled
+      if (isIdle) {
+        mx.setPresence({ presence: 'online' }).catch(() => {});
+      }
+    };
+  }, [mx, sendPresence, autoIdlePresence]);
 
   return null;
 }

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -877,18 +877,16 @@ function PresenceFeature() {
     // - MSC4186 servers that have no presence extension see this immediately.
     // - When 'offline' (Invisible mode), we appear offline to others but still receive
     //   their presence events because the extension is still enabled above.
+    // Optimistically update own presence in the local SDK store so the member list
+    // badge and status editor reflect the change immediately. MSC4186 servers never
+    // echo own presence back, so we can't rely on the server round-trip for this.
+    getSlidingSyncManager(mx)?.updateOwnPresence(effectiveState, effectiveStatusMsg);
     mx.setPresence({
       presence: effectiveState,
       status_msg: effectiveStatusMsg,
-    })
-      .then(() => {
-        // MSC4186 servers don't echo own presence back; synthesize the update locally so
-        // useUserPresence(myUserId) stays accurate (e.g. own badge in member list).
-        getSlidingSyncManager(mx)?.updateOwnPresence(effectiveState, effectiveStatusMsg);
-      })
-      .catch(() => {
-        // Server doesn't support presence — ignore.
-      });
+    }).catch(() => {
+      // Server doesn't support presence — ignore.
+    });
   }, [mx, sendPresence, presenceMode, presenceStatusMsg, autoIdled]);
 
   return null;

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -61,9 +61,6 @@ import { getBlobCacheStats } from '$hooks/useBlobCache';
 import { lastVisitedRoomIdAtom } from '$state/room/lastRoom';
 import { useSettingsSyncEffect } from '$hooks/useSettingsSync';
 import { usePresenceAutoIdle } from '$hooks/usePresenceAutoIdle';
-import { useInitBookmarks } from '$features/bookmarks/useInitBookmarks';
-import { bookmarksPanelAtom } from '$state/bookmarksPanelAtom';
-import { useReminderSync } from '$features/bookmarks/useReminderSync';
 import { getInboxInvitesPath } from '../pathUtils';
 import { BackgroundNotifications } from './BackgroundNotifications';
 

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import * as Sentry from '@sentry/react';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
@@ -24,7 +24,7 @@ import NotificationSound from '$public/sound/notification.ogg';
 import InviteSound from '$public/sound/invite.ogg';
 import { notificationPermission, setFavicon } from '$utils/dom';
 import { useSetting } from '$state/hooks/settings';
-import { settingsAtom } from '$state/settings';
+import { settingsAtom, presenceAutoIdledAtom } from '$state/settings';
 import { nicknamesAtom } from '$state/nicknames';
 import { mDirectAtom } from '$state/mDirectList';
 import { allInvitesAtom } from '$state/room-list/inviteList';
@@ -60,6 +60,10 @@ import { useCallSignaling } from '$hooks/useCallSignaling';
 import { getBlobCacheStats } from '$hooks/useBlobCache';
 import { lastVisitedRoomIdAtom } from '$state/room/lastRoom';
 import { useSettingsSyncEffect } from '$hooks/useSettingsSync';
+import { usePresenceAutoIdle } from '$hooks/usePresenceAutoIdle';
+import { useInitBookmarks } from '$features/bookmarks/useInitBookmarks';
+import { bookmarksPanelAtom } from '$state/bookmarksPanelAtom';
+import { useReminderSync } from '$features/bookmarks/useReminderSync';
 import { getInboxInvitesPath } from '../pathUtils';
 import { BackgroundNotifications } from './BackgroundNotifications';
 
@@ -844,79 +848,39 @@ function HandleDecryptPushEvent() {
 function PresenceFeature() {
   const mx = useMatrixClient();
   const [sendPresence] = useSetting(settingsAtom, 'sendPresence');
+  const [presenceMode] = useSetting(settingsAtom, 'presenceMode');
   const [autoIdlePresence] = useSetting(settingsAtom, 'autoIdlePresence');
   const [presenceIdleTimeoutMins] = useSetting(settingsAtom, 'presenceIdleTimeoutMins');
+  const [autoIdled] = useAtom(presenceAutoIdledAtom);
+
+  const timeoutMs = autoIdlePresence ? Math.max(1, presenceIdleTimeoutMins) * 60 * 1000 : 0;
+  usePresenceAutoIdle(mx, presenceMode ?? 'online', sendPresence, timeoutMs);
 
   useEffect(() => {
+    // When auto-idled, broadcast as unavailable regardless of the configured mode.
+    const effectiveMode = autoIdled ? 'unavailable' : (presenceMode ?? 'online');
+    // DND broadcasts as online (you're active but don't want to be disturbed) with a status_msg.
+    const activePresence = effectiveMode === 'dnd' ? 'online' : effectiveMode;
+    const effectiveState = sendPresence ? activePresence : 'offline';
+    const broadcasting = effectiveState !== 'offline';
+
     // Classic sync: set_presence query param on every /sync poll.
     // Passing undefined restores the default (online); Offline suppresses broadcasting.
-    mx.setSyncPresence(sendPresence ? undefined : SetPresence.Offline);
-    // Sliding sync: enable/disable the presence extension on the next poll.
+    mx.setSyncPresence(broadcasting ? undefined : SetPresence.Offline);
+    // Sliding sync: keep the extension enabled so we always receive others' presence.
+    // Only disable it when the master sendPresence toggle is off (full privacy mode).
     getSlidingSyncManager(mx)?.setPresenceEnabled(sendPresence);
-    // Explicitly publish online so the server echoes back our presence event,
-    // which lets useUserPresence update the badge immediately.
-    if (sendPresence) {
-      mx.setPresence({ presence: 'online' }).catch(() => {});
-    }
-  }, [mx, sendPresence]);
-
-  // Auto-idle: set presence to unavailable after inactivity or
-  // when the tab is hidden, and restore online on activity.
-  useEffect(() => {
-    if (!sendPresence || !autoIdlePresence) return undefined;
-
-    const IDLE_TIMEOUT_MS = Math.max(1, presenceIdleTimeoutMins) * 60 * 1000;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-    let isIdle = false;
-
-    const goOnline = () => {
-      if (!isIdle) return;
-      isIdle = false;
-      mx.setPresence({ presence: 'online' }).catch(() => {});
-    };
-
-    const goIdle = () => {
-      if (isIdle) return;
-      isIdle = true;
-      mx.setPresence({ presence: 'unavailable' }).catch(() => {});
-    };
-
-    const resetTimer = () => {
-      goOnline();
-      clearTimeout(idleTimer);
-      idleTimer = setTimeout(goIdle, IDLE_TIMEOUT_MS);
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden') {
-        clearTimeout(idleTimer);
-        goIdle();
-      } else {
-        resetTimer();
-      }
-    };
-
-    const ACTIVITY_EVENTS: (keyof DocumentEventMap)[] = [
-      'mousemove',
-      'keydown',
-      'pointerdown',
-      'scroll',
-    ];
-
-    ACTIVITY_EVENTS.forEach((e) => document.addEventListener(e, resetTimer, { passive: true }));
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    resetTimer();
-
-    return () => {
-      clearTimeout(idleTimer);
-      ACTIVITY_EVENTS.forEach((e) => document.removeEventListener(e, resetTimer));
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      // Restore online when feature is disabled
-      if (isIdle) {
-        mx.setPresence({ presence: 'online' }).catch(() => {});
-      }
-    };
-  }, [mx, sendPresence, autoIdlePresence, presenceIdleTimeoutMins]);
+    // Explicitly PUT /presence/{userId}/status so the server knows the exact state:
+    // - MSC4186 servers that have no presence extension see this immediately.
+    // - When 'offline' (Invisible mode), we appear offline to others but still receive
+    //   their presence events because the extension is still enabled above.
+    mx.setPresence({
+      presence: effectiveState,
+      status_msg: sendPresence && effectiveMode === 'dnd' ? 'dnd' : '',
+    }).catch(() => {
+      // Server doesn't support presence — ignore.
+    });
+  }, [mx, sendPresence, presenceMode, autoIdled]);
 
   return null;
 }

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -852,6 +852,11 @@ function PresenceFeature() {
     mx.setSyncPresence(sendPresence ? undefined : SetPresence.Offline);
     // Sliding sync: enable/disable the presence extension on the next poll.
     getSlidingSyncManager(mx)?.setPresenceEnabled(sendPresence);
+    // Explicitly publish online so the server echoes back our presence event,
+    // which lets useUserPresence update the badge immediately.
+    if (sendPresence) {
+      mx.setPresence({ presence: 'online' }).catch(() => {});
+    }
   }, [mx, sendPresence]);
 
   // Auto-idle: set presence to unavailable after 5 minutes of inactivity or

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -851,6 +851,7 @@ function PresenceFeature() {
   const [presenceMode] = useSetting(settingsAtom, 'presenceMode');
   const [autoIdlePresence] = useSetting(settingsAtom, 'autoIdlePresence');
   const [presenceIdleTimeoutMins] = useSetting(settingsAtom, 'presenceIdleTimeoutMins');
+  const [presenceStatusMsg] = useSetting(settingsAtom, 'presenceStatusMsg');
   const [autoIdled] = useAtom(presenceAutoIdledAtom);
 
   const timeoutMs = autoIdlePresence ? Math.max(1, presenceIdleTimeoutMins) * 60 * 1000 : 0;
@@ -863,6 +864,8 @@ function PresenceFeature() {
     const activePresence = effectiveMode === 'dnd' ? 'online' : effectiveMode;
     const effectiveState = sendPresence ? activePresence : 'offline';
     const broadcasting = effectiveState !== 'offline';
+    // DND overrides the user's custom status message with the 'dnd' sentinel.
+    const effectiveStatusMsg = sendPresence && effectiveMode === 'dnd' ? 'dnd' : presenceStatusMsg;
 
     // Classic sync: set_presence query param on every /sync poll.
     // Passing undefined restores the default (online); Offline suppresses broadcasting.
@@ -876,11 +879,17 @@ function PresenceFeature() {
     //   their presence events because the extension is still enabled above.
     mx.setPresence({
       presence: effectiveState,
-      status_msg: sendPresence && effectiveMode === 'dnd' ? 'dnd' : '',
-    }).catch(() => {
-      // Server doesn't support presence — ignore.
-    });
-  }, [mx, sendPresence, presenceMode, autoIdled]);
+      status_msg: effectiveStatusMsg,
+    })
+      .then(() => {
+        // MSC4186 servers don't echo own presence back; synthesize the update locally so
+        // useUserPresence(myUserId) stays accurate (e.g. own badge in member list).
+        getSlidingSyncManager(mx)?.updateOwnPresence(effectiveState, effectiveStatusMsg);
+      })
+      .catch(() => {
+        // Server doesn't support presence — ignore.
+      });
+  }, [mx, sendPresence, presenceMode, presenceStatusMsg, autoIdled]);
 
   return null;
 }

--- a/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
+++ b/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
@@ -1,7 +1,8 @@
-import type { MouseEvent, MouseEventHandler } from 'react';
+import type { MouseEvent, MouseEventHandler, ReactNode } from 'react';
 import { useCallback, useState } from 'react';
 import type { RectCords } from 'folds';
 import {
+  Badge,
   Box,
   Button,
   Dialog,
@@ -45,8 +46,10 @@ import { createLogger } from '$utils/debug';
 import { createDebugLogger } from '$utils/debugLogger';
 import { useClientConfig } from '$hooks/useClientConfig';
 import { UnreadBadge, UnreadBadgeCenter } from '$components/unread-badge';
-import { Presence, useUserPresence } from '$hooks/useUserPresence';
+import type { Presence } from '$hooks/useUserPresence';
 import { AvatarPresence, PresenceBadge } from '$components/presence';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom, presenceAutoIdledAtom } from '$state/settings';
 
 const log = createLogger('AccountSwitcherTab');
 const debugLog = createDebugLogger('AccountSwitcherTab');
@@ -176,7 +179,26 @@ export function AccountSwitcherTab() {
     ? (mxcUrlToHttp(mx, activeProfile.avatarUrl, useAuthentication, 96, 96, 'crop') ?? undefined)
     : undefined;
   const activeDisplayName = activeProfile.displayName;
-  const myPresence = useUserPresence(myUserId);
+
+  // Own presence badge is driven from settings state rather than the SDK's User object.
+  // The SDK won't echo your own presence back on MSC4186 sliding sync, so reading
+  // user.presence would leave the badge stuck at the SDK default forever.
+  const [sendPresence, setSendPresence] = useSetting(settingsAtom, 'sendPresence');
+  const [presenceMode, setPresenceMode] = useSetting(settingsAtom, 'presenceMode');
+  const autoIdled = useAtomValue(presenceAutoIdledAtom);
+  const setAutoIdled = useSetAtom(presenceAutoIdledAtom);
+  // The effective mode for badge display: if auto-idled, show unavailable regardless of selected mode.
+  const effectiveDisplayMode = autoIdled ? 'unavailable' : (presenceMode ?? 'online');
+  let myOwnPresenceBadge: ReactNode;
+  if (sendPresence) {
+    myOwnPresenceBadge =
+      effectiveDisplayMode === 'dnd' ? (
+        // DND: solid red badge (broadcasts as online with status_msg 'dnd')
+        <Badge size="200" variant="Critical" fill="Solid" radii="Pill" />
+      ) : (
+        <PresenceBadge presence={effectiveDisplayMode as Presence} size="200" />
+      );
+  }
 
   const sessionProfiles = useSessionProfiles(sessions);
 
@@ -272,14 +294,7 @@ export function AccountSwitcherTab() {
     <SidebarItem active={!!menuAnchor}>
       <SidebarItemTooltip tooltip={label}>
         {(triggerRef) => (
-          <AvatarPresence
-            badge={
-              myPresence &&
-              myPresence.presence !== Presence.Offline && (
-                <PresenceBadge presence={myPresence.presence} size="200" />
-              )
-            }
-          >
+          <AvatarPresence badge={myOwnPresenceBadge}>
             <SidebarAvatar
               as="button"
               ref={triggerRef}
@@ -362,6 +377,63 @@ export function AccountSwitcherTab() {
                 >
                   <Text size="T300">Add Account</Text>
                 </MenuItem>
+                <Line variant="Surface" size="300" style={{ margin: `${config.space.S100} 0` }} />
+                <Text size="L400" style={{ padding: `${config.space.S100} ${config.space.S200}` }}>
+                  Status
+                </Text>
+                {(
+                  [
+                    { label: 'Online', desc: undefined, mode: 'online' as const },
+                    { label: 'Idle', desc: undefined, mode: 'unavailable' as const },
+                    { label: 'Do Not Disturb', desc: undefined, mode: 'dnd' as const },
+                    {
+                      label: 'Invisible',
+                      desc: 'You will appear offline',
+                      mode: 'offline' as const,
+                    },
+                  ] as const
+                ).map(({ label: statusLabel, desc, mode }) => {
+                  const isSelected = sendPresence && (presenceMode ?? 'online') === mode;
+                  const badge =
+                    mode === 'dnd' ? (
+                      <Badge size="300" variant="Critical" fill="Solid" radii="Pill" />
+                    ) : (
+                      <PresenceBadge presence={mode as Presence} size="300" />
+                    );
+                  return (
+                    <MenuItem
+                      key={mode}
+                      size="300"
+                      radii="300"
+                      before={badge}
+                      after={
+                        isSelected ? (
+                          <Icon
+                            size="200"
+                            src={Icons.Check}
+                            style={{ color: 'var(--mx-c-success)' }}
+                          />
+                        ) : undefined
+                      }
+                      onClick={() => {
+                        setPresenceMode(mode);
+                        // Clear auto-idle so the badge updates immediately on manual selection.
+                        setAutoIdled(false);
+                        // Re-enable presence broadcasting if the master toggle was off.
+                        if (!sendPresence) setSendPresence(true);
+                      }}
+                    >
+                      <Box direction="Column">
+                        <Text size="T300">{statusLabel}</Text>
+                        {desc && (
+                          <Text size="T200" priority="300">
+                            {desc}
+                          </Text>
+                        )}
+                      </Box>
+                    </MenuItem>
+                  );
+                })}
                 <Line variant="Surface" size="300" style={{ margin: `${config.space.S100} 0` }} />
                 <MenuItem
                   size="300"

--- a/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
+++ b/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
@@ -45,6 +45,8 @@ import { createLogger } from '$utils/debug';
 import { createDebugLogger } from '$utils/debugLogger';
 import { useClientConfig } from '$hooks/useClientConfig';
 import { UnreadBadge, UnreadBadgeCenter } from '$components/unread-badge';
+import { Presence, useUserPresence } from '$hooks/useUserPresence';
+import { AvatarPresence, PresenceBadge } from '$components/presence';
 
 const log = createLogger('AccountSwitcherTab');
 const debugLog = createDebugLogger('AccountSwitcherTab');
@@ -174,6 +176,7 @@ export function AccountSwitcherTab() {
     ? (mxcUrlToHttp(mx, activeProfile.avatarUrl, useAuthentication, 96, 96, 'crop') ?? undefined)
     : undefined;
   const activeDisplayName = activeProfile.displayName;
+  const myPresence = useUserPresence(myUserId);
 
   const sessionProfiles = useSessionProfiles(sessions);
 
@@ -269,19 +272,28 @@ export function AccountSwitcherTab() {
     <SidebarItem active={!!menuAnchor}>
       <SidebarItemTooltip tooltip={label}>
         {(triggerRef) => (
-          <SidebarAvatar
-            as="button"
-            ref={triggerRef}
-            onClick={handleToggle}
-            outlined={sessions.length > 1}
+          <AvatarPresence
+            badge={
+              myPresence &&
+              myPresence.presence !== Presence.Offline && (
+                <PresenceBadge presence={myPresence.presence} size="200" />
+              )
+            }
           >
-            <UserAvatar
-              userId={activeSession.userId}
-              src={activeAvatarUrl}
-              alt={label}
-              renderFallback={() => <Text size="H4">{nameInitials(label)}</Text>}
-            />
-          </SidebarAvatar>
+            <SidebarAvatar
+              as="button"
+              ref={triggerRef}
+              onClick={handleToggle}
+              outlined={sessions.length > 1}
+            >
+              <UserAvatar
+                userId={activeSession.userId}
+                src={activeAvatarUrl}
+                alt={label}
+                renderFallback={() => <Text size="H4">{nameInitials(label)}</Text>}
+              />
+            </SidebarAvatar>
+          </AvatarPresence>
         )}
       </SidebarItemTooltip>
       {(totalBackgroundUnread > 0 || anyBackgroundHighlight) && (

--- a/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
+++ b/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
@@ -191,13 +191,7 @@ export function AccountSwitcherTab() {
   const effectiveDisplayMode = autoIdled ? 'unavailable' : (presenceMode ?? 'online');
   let myOwnPresenceBadge: ReactNode;
   if (sendPresence) {
-    myOwnPresenceBadge =
-      effectiveDisplayMode === 'dnd' ? (
-        // DND: solid red badge (broadcasts as online with status_msg 'dnd')
-        <Badge size="200" variant="Critical" fill="Solid" radii="Pill" />
-      ) : (
-        <PresenceBadge presence={effectiveDisplayMode as Presence} size="200" />
-      );
+    myOwnPresenceBadge = <PresenceBadge presence={effectiveDisplayMode as Presence} size="200" />;
   }
 
   const sessionProfiles = useSessionProfiles(sessions);

--- a/src/app/pages/client/sidebar/DirectDMsList.tsx
+++ b/src/app/pages/client/sidebar/DirectDMsList.tsx
@@ -22,6 +22,8 @@ import { getCanonicalAliasOrRoomId, mxcUrlToHttp } from '$utils/matrix';
 import { useSelectedRoom } from '$hooks/router/useSelectedRoom';
 import { useGroupDMMembers } from '$hooks/useGroupDMMembers';
 import { useSidebarDirectRoomIds } from './useSidebarDirectRoomIds';
+import { Presence, useUserPresence } from '$hooks/useUserPresence';
+import { AvatarPresence, PresenceBadge } from '$components/presence';
 import * as css from './DirectDMsList.css';
 
 const MAX_GROUP_MEMBERS = 3;
@@ -43,6 +45,9 @@ function DMItem({ room, selected }: DMItemProps) {
 
   // Check if this is a group DM (more than 2 members)
   const isGroupDM = room.getJoinedMemberCount() > 2;
+
+  const dmUserId = !isGroupDM ? room.getAvatarFallbackMember()?.userId : undefined;
+  const dmPresence = useUserPresence(dmUserId ?? '');
 
   // Get member info for group DMs using m.direct and profile API (doesn't require full room state)
   // Members are sorted by who last sent messages (most recent first)
@@ -135,9 +140,19 @@ function DMItem({ room, selected }: DMItemProps) {
     <SidebarItem active={selected}>
       <SidebarItemTooltip tooltip={room.name}>
         {(triggerRef) => (
-          <SidebarAvatar as="button" ref={triggerRef} outlined onClick={handleClick} size="400">
-            {renderAvatar()}
-          </SidebarAvatar>
+          <AvatarPresence
+            badge={
+              !isGroupDM &&
+              dmPresence &&
+              dmPresence.presence !== Presence.Offline && (
+                <PresenceBadge presence={dmPresence.presence} size="200" />
+              )
+            }
+          >
+            <SidebarAvatar as="button" ref={triggerRef} outlined onClick={handleClick} size="400">
+              {renderAvatar()}
+            </SidebarAvatar>
+          </AvatarPresence>
         )}
       </SidebarItemTooltip>
       {unread && (unread.total > 0 || unread.highlight > 0) && (

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -79,6 +79,7 @@ export interface Settings {
   isWidgetDrawer: boolean;
   memberSortFilterIndex: number;
   enterForNewline: boolean;
+  isMarkdown: boolean;
   editorToolbar: boolean;
   composerToolbarOpen: boolean;
   messageLayout: MessageLayout;
@@ -132,6 +133,7 @@ export interface Settings {
   // Sable features!
   sendPresence: boolean;
   autoIdlePresence: boolean;
+  presenceIdleTimeoutMins: number;
   mobileGestures: boolean;
   rightSwipeAction: RightSwipeAction;
   hideMembershipInReadOnly: boolean;
@@ -211,6 +213,7 @@ export const defaultSettings: Settings = {
   isWidgetDrawer: false,
   memberSortFilterIndex: 0,
   enterForNewline: false,
+  isMarkdown: true,
   editorToolbar: false,
   composerToolbarOpen: false,
   messageLayout: 0,
@@ -265,6 +268,7 @@ export const defaultSettings: Settings = {
   // Sable features!
   sendPresence: true,
   autoIdlePresence: true,
+  presenceIdleTimeoutMins: 5,
   mobileGestures: true,
   rightSwipeAction: RightSwipeAction.Reply,
   hideMembershipInReadOnly: true,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -132,6 +132,7 @@ export interface Settings {
 
   // Sable features!
   sendPresence: boolean;
+  presenceMode: 'online' | 'unavailable' | 'dnd' | 'offline';
   autoIdlePresence: boolean;
   presenceIdleTimeoutMins: number;
   mobileGestures: boolean;
@@ -267,6 +268,7 @@ export const defaultSettings: Settings = {
 
   // Sable features!
   sendPresence: true,
+  presenceMode: 'online',
   autoIdlePresence: true,
   presenceIdleTimeoutMins: 5,
   mobileGestures: true,
@@ -475,6 +477,10 @@ function sanitizeSettingsKey(key: keyof Settings, val: unknown): unknown {
         val === CaptionPosition.Below
         ? val
         : undefined;
+    case 'presenceMode':
+      return val === 'online' || val === 'unavailable' || val === 'dnd' || val === 'offline'
+        ? val
+        : undefined;
     case 'rightSwipeAction':
       return val === RightSwipeAction.Members || val === RightSwipeAction.Reply ? val : undefined;
     case 'renderUserCards':
@@ -566,6 +572,12 @@ export const getSettings = (): Settings =>
 export const setSettings = (settings: Settings) => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 };
+
+/**
+ * Ephemeral atom — true when the auto-idle hook has transitioned the user to idle.
+ * Not persisted to localStorage; resets to false on every page load.
+ */
+export const presenceAutoIdledAtom = atom(false);
 
 export const settingsAtom = atom<Settings, [Settings], undefined>(
   (get) => get(baseSettings),

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -135,6 +135,8 @@ export interface Settings {
   presenceMode: 'online' | 'unavailable' | 'dnd' | 'offline';
   autoIdlePresence: boolean;
   presenceIdleTimeoutMins: number;
+  /** User-set status message, cached locally so it survives mode changes and sliding-sync restarts. */
+  presenceStatusMsg: string;
   mobileGestures: boolean;
   rightSwipeAction: RightSwipeAction;
   hideMembershipInReadOnly: boolean;
@@ -271,6 +273,7 @@ export const defaultSettings: Settings = {
   presenceMode: 'online',
   autoIdlePresence: true,
   presenceIdleTimeoutMins: 5,
+  presenceStatusMsg: '',
   mobileGestures: true,
   rightSwipeAction: RightSwipeAction.Reply,
   hideMembershipInReadOnly: true,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -131,6 +131,7 @@ export interface Settings {
 
   // Sable features!
   sendPresence: boolean;
+  autoIdlePresence: boolean;
   mobileGestures: boolean;
   rightSwipeAction: RightSwipeAction;
   hideMembershipInReadOnly: boolean;
@@ -263,6 +264,7 @@ export const defaultSettings: Settings = {
 
   // Sable features!
   sendPresence: true,
+  autoIdlePresence: true,
   mobileGestures: true,
   rightSwipeAction: RightSwipeAction.Reply,
   hideMembershipInReadOnly: true,

--- a/src/app/utils/appEvents.ts
+++ b/src/app/utils/appEvents.ts
@@ -1,5 +1,29 @@
-export const appEvents = {
-  onVisibilityHidden: null as (() => void) | null,
+export type VisibilityChangeHandler = (isVisible: boolean) => void;
+type VisibilityHiddenHandler = () => void;
 
-  onVisibilityChange: null as ((isVisible: boolean) => void) | null,
+const visibilityChangeHandlers = new Set<VisibilityChangeHandler>();
+const visibilityHiddenHandlers = new Set<VisibilityHiddenHandler>();
+
+export const appEvents = {
+  onVisibilityHidden(handler: VisibilityHiddenHandler): () => void {
+    visibilityHiddenHandlers.add(handler);
+    return () => {
+      visibilityHiddenHandlers.delete(handler);
+    };
+  },
+
+  emitVisibilityHidden(): void {
+    visibilityHiddenHandlers.forEach((h) => h());
+  },
+
+  onVisibilityChange(handler: VisibilityChangeHandler): () => void {
+    visibilityChangeHandlers.add(handler);
+    return () => {
+      visibilityChangeHandlers.delete(handler);
+    };
+  },
+
+  emitVisibilityChange(isVisible: boolean): void {
+    visibilityChangeHandlers.forEach((h) => h(isVisible));
+  },
 };

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -578,6 +578,33 @@ export class SlidingSyncManager {
     this.presenceExtension.setEnabled(enabled);
   }
 
+  /**
+   * Synthesizes an own-presence update into the SDK store.
+   * MSC4186 servers never echo back the client's own m.presence events, so after
+   * calling mx.setPresence() we manually build a synthetic event and feed it into
+   * the SDK's User object — exactly what ExtensionPresence.onResponse does for others.
+   */
+  public updateOwnPresence(presence: string, statusMsg: string): void {
+    const userId = this.mx.getUserId();
+    if (!userId) return;
+    const mapper = this.mx.getEventMapper();
+    const rawEvent = {
+      type: 'm.presence',
+      sender: userId,
+      content: { presence, status_msg: statusMsg, currently_active: presence === 'online' },
+    };
+    const event = mapper(rawEvent as Parameters<typeof mapper>[0]);
+    let user = this.mx.store.getUser(userId);
+    if (user) {
+      user.setPresenceEvent(event);
+    } else {
+      user = User.createUser(userId, this.mx);
+      user.setPresenceEvent(event);
+      this.mx.store.storeUser(user);
+    }
+    this.mx.emit(ClientEvent.Event, event);
+  }
+
   public getDiagnostics(): SlidingSyncDiagnostics {
     return {
       proxyBaseUrl: this.proxyBaseUrl,

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -200,8 +200,11 @@ const getListEndIndex = (list: MSC3575List | null): number => {
 };
 
 // MSC4186 presence extension: requests `extensions.presence` in every sliding sync
-// poll and feeds received `m.presence` events into the SDK's User objects so that
-// components using `useUserPresence` see live updates (same path as regular /sync).
+// poll.  NOTE: Synapse's MSC4186 implementation does not currently support this
+// extension (its get_extensions_response only handles to_device, e2ee, account_data,
+// receipts, typing, and thread_subscriptions).  The extension is kept here so that
+// clients automatically benefit if/when server support is added; live presence for
+// now is handled by the direct REST fallback in useUserPresence.
 class ExtensionPresence implements Extension<{ enabled: boolean }, { events?: object[] }> {
   private enabled = true;
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -639,51 +639,27 @@ function validMediaRequest(url: string, baseUrl: string): boolean {
   });
 }
 
-/** Cache for authenticated Matrix media responses — keyed by URL. */
-const SW_MEDIA_CACHE = 'sable-media-sw-v1';
-
 function fetchConfig(token: string): RequestInit {
   return {
     headers: {
       Authorization: `Bearer ${token}`,
     },
-    // Use 'no-cache' to ensure we always check with the server on the first
-    // miss; successful responses are stored in SW_MEDIA_CACHE so avatars,
-    // stickers and other static media don't hit the network on every remount.
+    // Use 'no-cache' to ensure we check with the server on each request
+    // This prevents stale/expired token responses from being cached
     cache: 'no-cache',
   };
 }
 
-/**
- * Fetch media with auth, returning a cached response if available.
- * Successful (2xx) responses are written to SW_MEDIA_CACHE; errors are never
- * cached so that a transient 401/404 doesn't permanently block a resource.
- */
-async function fetchMediaWithCache(
-  url: string,
-  accessToken: string,
-  redirect: RequestRedirect
-): Promise<Response> {
-  let cache: Cache | undefined;
-  try {
-    cache = await self.caches.open(SW_MEDIA_CACHE);
-    const cached = await cache.match(url);
-    if (cached) return cached;
-  } catch {
-    // caches may be unavailable (e.g. in private browsing on some browsers)
-  }
-
-  const response = await fetch(url, { ...fetchConfig(accessToken), redirect });
-
-  if (cache && response.ok) {
-    // Store a clone — the original body is consumed by the browser.
-    // Failures are intentionally not cached.
-    cache.put(url, response.clone()).catch(() => {
-      // Ignore quota / write errors.
-    });
-  }
-
-  return response;
+function mediaFetchConfig(token: string): RequestInit {
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    // MXC URLs are content-addressed and never change; use the browser's
+    // default HTTP cache so identical media requests are served from cache
+    // instead of hitting the network on every render.
+    cache: 'default',
+  };
 }
 
 self.addEventListener('message', (event: ExtendableMessageEvent) => {
@@ -716,7 +692,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 
   const session = clientId ? sessions.get(clientId) : undefined;
   if (session && validMediaRequest(url, session.baseUrl)) {
-    event.respondWith(fetchMediaWithCache(url, session.accessToken, redirect));
+    event.respondWith(fetch(url, { ...mediaFetchConfig(session.accessToken), redirect }));
     return;
   }
 
@@ -736,7 +712,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
       ? preloadedSession
       : undefined);
   if (byBaseUrl) {
-    event.respondWith(fetchMediaWithCache(url, byBaseUrl.accessToken, redirect));
+    event.respondWith(fetch(url, { ...mediaFetchConfig(byBaseUrl.accessToken), redirect }));
     return;
   }
 
@@ -746,7 +722,10 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     event.respondWith(
       loadPersistedSession().then((persisted) => {
         if (persisted && validMediaRequest(url, persisted.baseUrl)) {
-          return fetchMediaWithCache(url, persisted.accessToken, redirect);
+          return fetch(url, {
+            ...mediaFetchConfig(persisted.accessToken),
+            redirect,
+          });
         }
         return fetch(event.request);
       })
@@ -758,13 +737,13 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     requestSessionWithTimeout(clientId).then(async (s) => {
       // Primary: session received from the live client window.
       if (s && validMediaRequest(url, s.baseUrl)) {
-        return fetchMediaWithCache(url, s.accessToken, redirect);
+        return fetch(url, { ...mediaFetchConfig(s.accessToken), redirect });
       }
       // Fallback: try the persisted session (helps when SW restarts on iOS and
       // the client window hasn't responded to requestSession yet).
       const persisted = await loadPersistedSession();
       if (persisted && validMediaRequest(url, persisted.baseUrl)) {
-        return fetchMediaWithCache(url, persisted.accessToken, redirect);
+        return fetch(url, { ...mediaFetchConfig(persisted.accessToken), redirect });
       }
       console.warn(
         '[SW fetch] No valid session for media request',

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -639,13 +639,51 @@ function validMediaRequest(url: string, baseUrl: string): boolean {
   });
 }
 
+/** Cache for authenticated Matrix media responses — keyed by URL. */
+const SW_MEDIA_CACHE = 'sable-media-sw-v1';
+
 function fetchConfig(token: string): RequestInit {
   return {
     headers: {
       Authorization: `Bearer ${token}`,
     },
-    cache: 'default',
+    // Use 'no-cache' to ensure we always check with the server on the first
+    // miss; successful responses are stored in SW_MEDIA_CACHE so avatars,
+    // stickers and other static media don't hit the network on every remount.
+    cache: 'no-cache',
   };
+}
+
+/**
+ * Fetch media with auth, returning a cached response if available.
+ * Successful (2xx) responses are written to SW_MEDIA_CACHE; errors are never
+ * cached so that a transient 401/404 doesn't permanently block a resource.
+ */
+async function fetchMediaWithCache(
+  url: string,
+  accessToken: string,
+  redirect: RequestRedirect
+): Promise<Response> {
+  let cache: Cache | undefined;
+  try {
+    cache = await self.caches.open(SW_MEDIA_CACHE);
+    const cached = await cache.match(url);
+    if (cached) return cached;
+  } catch {
+    // caches may be unavailable (e.g. in private browsing on some browsers)
+  }
+
+  const response = await fetch(url, { ...fetchConfig(accessToken), redirect });
+
+  if (cache && response.ok) {
+    // Store a clone — the original body is consumed by the browser.
+    // Failures are intentionally not cached.
+    cache.put(url, response.clone()).catch(() => {
+      // Ignore quota / write errors.
+    });
+  }
+
+  return response;
 }
 
 self.addEventListener('message', (event: ExtendableMessageEvent) => {
@@ -678,7 +716,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 
   const session = clientId ? sessions.get(clientId) : undefined;
   if (session && validMediaRequest(url, session.baseUrl)) {
-    event.respondWith(fetch(url, { ...fetchConfig(session.accessToken), redirect }));
+    event.respondWith(fetchMediaWithCache(url, session.accessToken, redirect));
     return;
   }
 
@@ -698,7 +736,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
       ? preloadedSession
       : undefined);
   if (byBaseUrl) {
-    event.respondWith(fetch(url, { ...fetchConfig(byBaseUrl.accessToken), redirect }));
+    event.respondWith(fetchMediaWithCache(url, byBaseUrl.accessToken, redirect));
     return;
   }
 
@@ -708,10 +746,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     event.respondWith(
       loadPersistedSession().then((persisted) => {
         if (persisted && validMediaRequest(url, persisted.baseUrl)) {
-          return fetch(url, {
-            ...fetchConfig(persisted.accessToken),
-            redirect,
-          });
+          return fetchMediaWithCache(url, persisted.accessToken, redirect);
         }
         return fetch(event.request);
       })
@@ -723,13 +758,13 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     requestSessionWithTimeout(clientId).then(async (s) => {
       // Primary: session received from the live client window.
       if (s && validMediaRequest(url, s.baseUrl)) {
-        return fetch(url, { ...fetchConfig(s.accessToken), redirect });
+        return fetchMediaWithCache(url, s.accessToken, redirect);
       }
       // Fallback: try the persisted session (helps when SW restarts on iOS and
       // the client window hasn't responded to requestSession yet).
       const persisted = await loadPersistedSession();
       if (persisted && validMediaRequest(url, persisted.baseUrl)) {
-        return fetch(url, { ...fetchConfig(persisted.accessToken), redirect });
+        return fetchMediaWithCache(url, persisted.accessToken, redirect);
       }
       console.warn(
         '[SW fetch] No valid session for media request',

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -642,6 +642,27 @@ function validMediaRequest(url: string, baseUrl: string): boolean {
 /** Cache for authenticated Matrix media responses — keyed by URL. */
 const SW_MEDIA_CACHE = 'sable-media-sw-v1';
 
+// iOS/Android devices have limited Cache API quota. Use a smaller entry cap on
+// mobile to prevent storage pressure that causes iOS to evict the PWA origin.
+const isMobileSW = /iPhone|iPad|iPod|Android/i.test(self.navigator.userAgent);
+/** Maximum number of entries kept in the SW media cache (FIFO eviction). */
+const SW_MEDIA_CACHE_MAX_ENTRIES = isMobileSW ? 200 : 1000;
+
+/**
+ * Evict oldest SW media cache entries when the count exceeds the platform limit.
+ * Cache API returns keys in insertion order so slicing from the front gives FIFO.
+ */
+async function evictSwMediaCacheIfNeeded(cache: Cache): Promise<void> {
+  try {
+    const keys = await cache.keys();
+    if (keys.length <= SW_MEDIA_CACHE_MAX_ENTRIES) return;
+    const toDelete = keys.slice(0, keys.length - SW_MEDIA_CACHE_MAX_ENTRIES);
+    await Promise.all(toDelete.map((req) => cache.delete(req)));
+  } catch {
+    // best-effort
+  }
+}
+
 function fetchConfig(token: string): RequestInit {
   return {
     headers: {
@@ -678,7 +699,8 @@ async function fetchMediaWithCache(
   if (cache && response.ok) {
     // Store a clone — the original body is consumed by the browser.
     // Failures are intentionally not cached.
-    cache.put(url, response.clone()).catch(() => {
+    const c = cache;
+    cache.put(url, response.clone()).then(() => evictSwMediaCacheIfNeeded(c)).catch(() => {
       // Ignore quota / write errors.
     });
   }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -642,27 +642,6 @@ function validMediaRequest(url: string, baseUrl: string): boolean {
 /** Cache for authenticated Matrix media responses — keyed by URL. */
 const SW_MEDIA_CACHE = 'sable-media-sw-v1';
 
-// iOS/Android devices have limited Cache API quota. Use a smaller entry cap on
-// mobile to prevent storage pressure that causes iOS to evict the PWA origin.
-const isMobileSW = /iPhone|iPad|iPod|Android/i.test(self.navigator.userAgent);
-/** Maximum number of entries kept in the SW media cache (FIFO eviction). */
-const SW_MEDIA_CACHE_MAX_ENTRIES = isMobileSW ? 200 : 1000;
-
-/**
- * Evict oldest SW media cache entries when the count exceeds the platform limit.
- * Cache API returns keys in insertion order so slicing from the front gives FIFO.
- */
-async function evictSwMediaCacheIfNeeded(cache: Cache): Promise<void> {
-  try {
-    const keys = await cache.keys();
-    if (keys.length <= SW_MEDIA_CACHE_MAX_ENTRIES) return;
-    const toDelete = keys.slice(0, keys.length - SW_MEDIA_CACHE_MAX_ENTRIES);
-    await Promise.all(toDelete.map((req) => cache.delete(req)));
-  } catch {
-    // best-effort
-  }
-}
-
 function fetchConfig(token: string): RequestInit {
   return {
     headers: {
@@ -699,8 +678,7 @@ async function fetchMediaWithCache(
   if (cache && response.ok) {
     // Store a clone — the original body is consumed by the browser.
     // Failures are intentionally not cached.
-    const c = cache;
-    cache.put(url, response.clone()).then(() => evictSwMediaCacheIfNeeded(c)).catch(() => {
+    cache.put(url, response.clone()).catch(() => {
       // Ignore quota / write errors.
     });
   }


### PR DESCRIPTION
### Description

Adds live presence support across the sidebar and account switcher with a Discord-style status picker and auto-idle behaviour.

- **Presence badges** — online / idle / DND / offline badges on DM avatars in the compact sidebar rail and the account switcher avatar. Sliding sync does not deliver `m.presence` events, so `useUserPresence` bootstraps by falling back to `GET /presence/{userId}/status` (404 silently ignored).
- **Status picker** — Online, Idle, Do Not Disturb, Invisible in the account switcher. Persisted as `presenceMode` setting across sessions.
- **Auto-idle** — after a configurable inactivity window (default 5 min, `presenceAutoIdleTimeoutMs` in `config.json`) the client broadcasts Idle and restores the previous status on activity.
- **Fixes** — optimistic badge update on status change, own-presence sync after network call succeeds, idle timer correctly ignores `mousemove` without OS focus (desktop idle fix), REST API fallback when the MSC4186 sliding sync extension has no presence data.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The REST fallback calls `GET /presence/{userId}/status` and maps the `presence` field to the badge variant. The idle timer subscribes to `mousemove` and `keydown` on `document`, resets on activity, and only fires the Idle broadcast when `document.hasFocus()` to avoid treating background tabs as idle. The optimistic update sets local badge state immediately and rolls back if the `PUT /presence` call fails.