### PR TITLE
Replace spoilered text with '[Spoiler]' in plain text fallback

### DIFF
--- a/.changeset/msc4454.md
+++ b/.changeset/msc4454.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+spoilered text now gets replaced with `[Spoiler]` in the plain text fallback, as per MSC4454

--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -228,7 +228,7 @@ export const toPlainText = (
     }
     return isMarkdown
       ? unescapeMarkdownBlockSequences(text, unescapeMarkdownInlineSequences)
-      : node.text;
+      : text;
   }
 
   const children = node.children.map((n) => toPlainText(n, isMarkdown)).join('');

--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -196,6 +196,8 @@ const elementToPlainText = (node: CustomElement, children: string): string => {
   }
 };
 
+const SPOILERINPUTREGEX = /\|\|.+?\|\|/g;
+
 /**
  * convert slate internal representation to a plain text string that can be sent to the server
  * @param node the slate node
@@ -213,8 +215,9 @@ export const toPlainText = (
   if (Array.isArray(node))
     return node.map((n) => toPlainText(n, isMarkdown, stripNickname, nickNameReplacement)).join('');
   if (Text.isText(node)) {
+    let { text } = node;
+    text = text.replaceAll(SPOILERINPUTREGEX, '[Spoiler]');
     if (stripNickname && nickNameReplacement) {
-      let { text } = node;
       nickNameReplacement?.keys().forEach((key) => {
         const replacement = nickNameReplacement.get(key) ?? '';
         text = text.replaceAll(key, replacement);
@@ -224,7 +227,7 @@ export const toPlainText = (
         : text;
     }
     return isMarkdown
-      ? unescapeMarkdownBlockSequences(node.text, unescapeMarkdownInlineSequences)
+      ? unescapeMarkdownBlockSequences(text, unescapeMarkdownInlineSequences)
       : node.text;
   }
 


### PR DESCRIPTION
### Description

This pull request updates the plain text conversion logic to better handle spoilered text, ensuring that spoiler formatting is replaced with `[Spoiler]` in plain text fallbacks as per [MSC4454](https://github.com/matrix-org/matrix-spec-proposals/pull/4454).

**Spoiler handling improvements:**

- Spoilered text (delimited by `||`) is now replaced with `[Spoiler]` in the plain text output, matching the MSC4454 specification. 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

No AI involved
