### PR TITLE
Fix empty list rendering on Firefox and the bug of editing lists with empty items

### DIFF
--- a/.changeset/fix-weird-empty-items-list.md
+++ b/.changeset/fix-weird-empty-items-list.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix lists with empty items looking wrong on FireFox

--- a/src/app/components/editor/input.ts
+++ b/src/app/components/editor/input.ts
@@ -139,6 +139,7 @@ const getInlineElement = (node: ChildNode, processText: ProcessTextCallback): In
   }
 
   if (isTag(node)) {
+    if (node.name === 'p' && node?.children?.length === 0) return [{ text: '' }];
     const markType = getInlineNodeMarkType(node);
     if (markType) {
       return getInlineMarkElement(markType, node, (child) => {

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -106,10 +106,15 @@ export function MText({
   const customBody =
     typeof content.formatted_body === 'string' ? content.formatted_body : undefined;
 
+  const cleanedMessage = useMemo(
+    () => customBody?.replace(/<li>(<p><\/p>)?<\/li>/gi, '<li><br></li>'),
+    [customBody]
+  );
+
   const trimmedBody = useMemo(() => trimReplyFromBody(body), [body]);
   const unwrappedForwardedContent = useMemo(
-    () => unwrapForwardedContent(customBody ?? body),
-    [customBody, body]
+    () => unwrapForwardedContent(cleanedMessage ?? customBody ?? body),
+    [cleanedMessage, customBody, body]
   );
 
   const isForwarded = useMemo(() => {
@@ -121,8 +126,9 @@ export function MText({
    * For the unwrapping of per-message profile fallbacks, we look for <strong> tags with the data-mx-profile-fallback attribute
    */
   const unwrappedPerMessageProfileMessage = useMemo(
-    () => customBody?.replace(/<strong[^>]*data-mx-profile-fallback[^>]*>(.*?):\s*<\/strong>/i, ''),
-    [customBody]
+    () =>
+      cleanedMessage?.replace(/<strong[^>]*data-mx-profile-fallback[^>]*>(.*?):\s*<\/strong>/i, ''),
+    [cleanedMessage]
   );
 
   const isJumbo = useMemo(() => {
@@ -189,13 +195,13 @@ export function MText({
   return (
     <>
       <MessageTextBody
-        preWrap={typeof customBody !== 'string'}
+        preWrap={typeof cleanedMessage !== 'string'}
         jumboEmoji={isJumbo ? jumboEmojiSize : 'none'}
         style={style}
       >
         {renderBody({
           body: trimmedBody,
-          customBody: typeof customBody === 'string' ? customBody : undefined,
+          customBody: typeof cleanedMessage === 'string' ? cleanedMessage : undefined,
         })}
         {edited && <MessageEditedContent />}
       </MessageTextBody>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #711 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
The Gods have bestowed me with the wisdom of how to fix this