### PR TITLE
Fix of wrong alignment with mixed RTL and LTR text

### DIFF
--- a/.changeset/fix_rtlltr_mixed_text_formatting_and_alignment_in_messages.md
+++ b/.changeset/fix_rtlltr_mixed_text_formatting_and_alignment_in_messages.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix RTL/LTR mixed text formatting and alignment in messages

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -280,7 +280,7 @@ export const Reply = as<'div', ReplyProps>(
           onClick={replyEvent !== null && !isBlockedSender ? onClick : undefined}
         >
           {replyEvent !== undefined && !isPendingDecrypt ? (
-            <Text size="T300" truncate>
+            <Text size="T300" truncate style={{ unicodeBidi: 'plaintext' }}>
               {replyContent}
             </Text>
           ) : (

--- a/src/app/components/message/layout/Base.tsx
+++ b/src/app/components/message/layout/Base.tsx
@@ -48,6 +48,7 @@ export const MessageTextBody = as<'div', css.MessageTextBodyVariants & { notice?
       className={classNames(css.MessageTextBody({ preWrap, jumboEmoji, emote }), className)}
       {...props}
       ref={ref}
+      dir="auto"
     >
       {children}
     </Text>

--- a/src/app/components/message/layout/layout.css.ts
+++ b/src/app/components/message/layout/layout.css.ts
@@ -229,6 +229,8 @@ export const PronounPill = style({
 
 export const MessageTextBody = recipe({
   base: {
+    unicodeBidi: 'plaintext',
+    alignSelf: 'start',
     wordBreak: 'break-word',
     fontSize: '1rem !important', // Override folds Text component to enable page zoom scaling
   },


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This PR resolves formatting and alignment issues with mixed RTL (Right-to-Left) and LTR (Left-to-Right) text within messages. Previously, mixed text direction caused display inconsistencies in the main message body and the reply content area.

**Changes made:**
* Added `dir="auto"` to the base message `Text` component, allowing the browser to automatically determine the base text direction according to the first strongly-typed character of the message.
* Applied `unicode-bidi: plaintext` to the message content CSS and the `Text` component inside the reply content. This ensures the browser dynamically evaluates and handles the text direction based on the actual characters used rather than inheriting the container's direction.
* Set `align-self: start` on the message content. This ensures that even for RTL messages, the content block anchors appropriately to the left side (start) of the view, while still preserving the correct internal text direction.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- No AI was used in the creation of this code. -->