### PR TITLE
Fix: user moderation offset padding

### DIFF
--- a/src/app/components/user-profile/UserModeration.tsx
+++ b/src/app/components/user-profile/UserModeration.tsx
@@ -254,7 +254,7 @@ export function UserModeration({ userId, canKick, canBan, canInvite }: UserModer
 
   return (
     <Box direction="Column" gap="400" style={{ padding: config.space.S200 }}>
-      <Box direction="Column" gap="200" >
+      <Box direction="Column" gap="200">
         <Box grow="Yes" direction="Column" gap="100">
           <Text size="L400" align="Center">
             Moderation

--- a/src/app/components/user-profile/UserModeration.tsx
+++ b/src/app/components/user-profile/UserModeration.tsx
@@ -253,8 +253,8 @@ export function UserModeration({ userId, canKick, canBan, canInvite }: UserModer
   if (!canBan && !canKick && !canInvite) return null;
 
   return (
-    <Box direction="Column" gap="400">
-      <Box direction="Column" gap="200">
+    <Box direction="Column" gap="400" style={{ padding: config.space.S200 }}>
+      <Box direction="Column" gap="200" >
         <Box grow="Yes" direction="Column" gap="100">
           <Text size="L400" align="Center">
             Moderation


### PR DESCRIPTION
## Fix: user moderation controls offset in profile card #740 

### Description
Add padding around the moderation controls in the profile card so the controls are no longer visually offset

| Before | After   |
|---|---|
| <img width="349" height="390" alt="Screenshot 2026-05-05 at 12 19 42 PM" src="https://github.com/user-attachments/assets/0e7ddf86-aad3-4723-8ab0-3597ef614519" />|  <img width="357" height="408" alt="Screenshot 2026-05-05 at 12 19 08 PM" src="https://github.com/user-attachments/assets/dabb3e46-5a2a-477e-8f8d-f1deb17d8138" /> |

Fixed #740 

### Files changed: 
- `src/app/components/user-profile/UserModeration.tsx`

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### How I tested
- verified the profile card where moderation actions are available, and the moderation controls now have the expected spacing.