### PR TITLE
Fix emoticon not properly converting when editing messages

### DIFF
--- a/.changeset/fix-emojis-edits.md
+++ b/.changeset/fix-emojis-edits.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix editing messages with custom emojis being converted into html tags.

--- a/src/app/components/editor/input.ts
+++ b/src/app/components/editor/input.ts
@@ -1,19 +1,67 @@
 import type { Descendant } from 'slate';
 
+import {
+  MX_EMOTICON_MD_END,
+  MX_EMOTICON_MD_SEP,
+  MX_EMOTICON_MD_START,
+  validateMxcUrl,
+} from '$plugins/markdown/extensions/matrix-emoticon';
 import { BlockType } from './types';
 import type { ParagraphElement } from './slate';
+import { createEmoticonElement } from './utils';
+
+/** Matches placeholders emitted by htmlToMarkdown for &lt;img data-mx-emoticon&gt;. */
+const MX_EMOTICON_MD_TOKEN = new RegExp(
+  `${MX_EMOTICON_MD_START}([^${MX_EMOTICON_MD_SEP}]+)${MX_EMOTICON_MD_SEP}([^${MX_EMOTICON_MD_END}]+)${MX_EMOTICON_MD_END}`,
+  'g'
+);
+
+function mergeAdjacentTextNodes(
+  children: ParagraphElement['children']
+): ParagraphElement['children'] {
+  const out: ParagraphElement['children'] = [];
+  for (const c of children) {
+    if ('type' in c) {
+      out.push(c);
+      continue;
+    }
+    const prev = out[out.length - 1];
+    if (prev && !('type' in prev)) {
+      prev.text += c.text;
+    } else {
+      out.push({ ...c });
+    }
+  }
+  return out.length > 0 ? out : [{ text: '' }];
+}
+
+function lineToParagraphChildren(line: string): ParagraphElement['children'] {
+  MX_EMOTICON_MD_TOKEN.lastIndex = 0;
+  const parts: ParagraphElement['children'] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = MX_EMOTICON_MD_TOKEN.exec(line)) !== null) {
+    if (match.index > last) {
+      parts.push({ text: line.slice(last, match.index) });
+    }
+    const [, src, shortcode] = match;
+    if (src && shortcode && validateMxcUrl(src)) {
+      parts.push(createEmoticonElement(src, shortcode));
+    } else if (shortcode) {
+      parts.push({ text: `:${shortcode.replace(/^:|:$/g, '')}:` });
+    }
+    last = MX_EMOTICON_MD_TOKEN.lastIndex;
+  }
+  if (last < line.length) {
+    parts.push({ text: line.slice(last) });
+  }
+  return mergeAdjacentTextNodes(parts);
+}
 
 export const plainToEditorInput = (text: string): Descendant[] => {
-  const editorNodes: Descendant[] = text.split('\n').map((lineText) => {
-    const paragraphNode: ParagraphElement = {
-      type: BlockType.Paragraph,
-      children: [
-        {
-          text: lineText,
-        },
-      ],
-    };
-    return paragraphNode;
-  });
-  return editorNodes;
+  const lines = text.split('\n');
+  return lines.map((lineText) => ({
+    type: BlockType.Paragraph,
+    children: lineToParagraphChildren(lineText),
+  }));
 };

--- a/src/app/plugins/markdown/bidirectional.test.ts
+++ b/src/app/plugins/markdown/bidirectional.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { encodeMxEmoticonForMarkdownPlaceholder } from './extensions/matrix-emoticon';
 import { markdownToHtml } from './markdownToHtml';
 import { htmlToMarkdown } from './htmlToMarkdown';
 import { injectDataMd } from './injectDataMd';
@@ -108,12 +109,14 @@ describe('bidirectional round-trip', () => {
     expect(result).toContain('k.');
   });
 
-  it('round-trips img[data-mx-emoticon] tags', () => {
+  it('preserves mx emoticons as editor placeholders (mxc URI + shortcode)', () => {
     const html = '<img data-mx-emoticon src="mxc://example.org/emote" alt=":blobcat:" />';
     const injected = injectDataMd(html);
     const result = htmlToMarkdown(injected);
-    expect(result).toContain('<img');
-    expect(result).toContain('data-mx-emoticon');
-    expect(result).toContain('mxc://');
+    expect(result).not.toContain('<img');
+    expect(result).toContain(
+      encodeMxEmoticonForMarkdownPlaceholder('mxc://example.org/emote', 'blobcat')
+    );
+    expect(result).toContain('mxc://example.org/emote');
   });
 });

--- a/src/app/plugins/markdown/extensions/matrix-emoticon.ts
+++ b/src/app/plugins/markdown/extensions/matrix-emoticon.ts
@@ -1,5 +1,14 @@
 import type { TokenizerExtension, RendererExtension } from 'marked';
 
+/** Delimiters for round-tripping Matrix emoticons from HTML through markdown into the Slate composer. */
+export const MX_EMOTICON_MD_START = '\uE000';
+export const MX_EMOTICON_MD_SEP = '\uE001';
+export const MX_EMOTICON_MD_END = '\uE002';
+
+export function encodeMxEmoticonForMarkdownPlaceholder(src: string, shortcode: string): string {
+  return `${MX_EMOTICON_MD_START}${src}${MX_EMOTICON_MD_SEP}${shortcode}${MX_EMOTICON_MD_END}`;
+}
+
 /**
  * Validates that a URL is a proper mxc:// URI.
  * Returns true if valid, false otherwise.

--- a/src/app/plugins/markdown/htmlToMarkdown.test.ts
+++ b/src/app/plugins/markdown/htmlToMarkdown.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import {
+  MX_EMOTICON_MD_END,
+  MX_EMOTICON_MD_SEP,
+  MX_EMOTICON_MD_START,
+} from './extensions/matrix-emoticon';
+import { plainToEditorInput } from '$components/editor/input';
+import { BlockType } from '$components/editor/types';
 import { htmlToMarkdown } from './htmlToMarkdown';
 
 describe('htmlToMarkdown', () => {
@@ -80,5 +87,33 @@ describe('htmlToMarkdown', () => {
   it('escapes markdown special characters in text', () => {
     const result = htmlToMarkdown('<p>Hello *world*</p>');
     expect(result).toContain('\\*');
+  });
+
+  it('encodes mx emoticons as private-use placeholders instead of literal img snippets', () => {
+    const src = 'mxc://matrix.org/emote';
+    const html = `<p>hi<img data-mx-emoticon src="${src}" alt="blobcat" title="blobcat" height="32" />bye</p>`;
+    const md = htmlToMarkdown(html);
+    expect(md).not.toContain('<img');
+    expect(md).toContain(
+      `${MX_EMOTICON_MD_START}${src}${MX_EMOTICON_MD_SEP}blobcat${MX_EMOTICON_MD_END}`
+    );
+  });
+
+  it('plainToEditorInput expands emoticon placeholders into Slate emoticon elements', () => {
+    const src = 'mxc://matrix.org/emote';
+    const md = `before${MX_EMOTICON_MD_START}${src}${MX_EMOTICON_MD_SEP}blobcat${MX_EMOTICON_MD_END}after`;
+    const doc = plainToEditorInput(md);
+    expect(doc).toHaveLength(1);
+    const p = doc[0] as { type: BlockType; children: unknown[] };
+    expect(p.type).toBe(BlockType.Paragraph);
+    expect(p.children).toEqual([
+      { text: 'before' },
+      expect.objectContaining({
+        type: BlockType.Emoticon,
+        key: src,
+        shortcode: 'blobcat',
+      }),
+      { text: 'after' },
+    ]);
   });
 });

--- a/src/app/plugins/markdown/htmlToMarkdown.ts
+++ b/src/app/plugins/markdown/htmlToMarkdown.ts
@@ -1,7 +1,10 @@
 import parse from 'html-dom-parser';
 import type { ChildNode, Element } from 'domhandler';
 import { isText, isTag } from 'domhandler';
-import { validateMxcUrl } from './extensions/matrix-emoticon';
+import {
+  encodeMxEmoticonForMarkdownPlaceholder,
+  validateMxcUrl,
+} from './extensions/matrix-emoticon';
 import { escapeMarkdownInlineSequences } from './utils';
 
 /**
@@ -338,11 +341,16 @@ function processImage(node: Element): string {
   }
 
   const src = node.attribs.src ?? '';
-  const alt = node.attribs.alt ?? '';
+  const alt = node.attribs.alt ?? node.attribs.title ?? '';
 
   if (!validateMxcUrl(src)) {
     return '';
   }
 
-  return `<img data-mx-emoticon src="${src}" alt="${alt}" />`;
+  const shortcode = alt.replace(/^:|:$/g, '');
+  if (!shortcode) {
+    return '';
+  }
+
+  return encodeMxEmoticonForMarkdownPlaceholder(src, shortcode);
 }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix emoticon not properly converting when editing messages

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

Tests were AI generated