### PR TITLE
Fix tweak favoriting behavior

### DIFF
--- a/.changeset/fix-tweak-favoriting-behavior.md
+++ b/.changeset/fix-tweak-favoriting-behavior.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed tweak automatic favoriting behavior when entering/leaving the catalog.

--- a/src/app/components/url-preview/TweakPreviewUrlCard.tsx
+++ b/src/app/components/url-preview/TweakPreviewUrlCard.tsx
@@ -198,7 +198,6 @@ export function TweakPreviewUrlCard({ url }: { url: string }) {
         const nextEnabled = enabledTweakFullUrls.filter((u) => u !== url);
         patchSettings({
           themeRemoteEnabledTweakFullUrls: nextEnabled,
-          themeRemoteTweakFavorites: pruneTweakFavorites(tweakFavorites, nextEnabled),
         });
       }
     },

--- a/src/app/features/settings/cosmetics/ThemeCatalogSettings.tsx
+++ b/src/app/features/settings/cosmetics/ThemeCatalogSettings.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
+import { type ChangeEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTimeoutToggle } from '$hooks/useTimeoutToggle';
 import { copyToClipboard, downloadTextFile } from '$utils/dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -214,6 +214,9 @@ export function ThemeCatalogSettings({
   const [browseOpen, setBrowseOpen] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
 
+  const appearanceCatalogBrowseWasOpenRef = useRef(false);
+  const tweakFavoritesSnapshotAtAppearanceCatalogOpenRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     if (isAppearanceMode) {
       onBrowseOpenChange?.(browseOpen);
@@ -247,6 +250,19 @@ export function ThemeCatalogSettings({
     settingsAtom,
     'themeChatAutoPreviewAnyUrl'
   );
+
+  useEffect(() => {
+    if (!isAppearanceMode) {
+      appearanceCatalogBrowseWasOpenRef.current = false;
+      return;
+    }
+    if (browseOpen && !appearanceCatalogBrowseWasOpenRef.current) {
+      tweakFavoritesSnapshotAtAppearanceCatalogOpenRef.current = new Set(
+        tweakFavorites.map((f) => f.fullUrl.trim()).filter(Boolean)
+      );
+    }
+    appearanceCatalogBrowseWasOpenRef.current = browseOpen;
+  }, [browseOpen, isAppearanceMode, tweakFavorites]);
 
   const [themeSearch, setThemeSearch] = useState('');
   const [tweakSearch, setTweakSearch] = useState('');
@@ -779,7 +795,15 @@ export function ThemeCatalogSettings({
   }, [patchSettings]);
 
   const setTweakApplied = useCallback(
-    async (fullUrl: string, apply: boolean, hint?: { displayName?: string; basename?: string }) => {
+    async (
+      fullUrl: string,
+      apply: boolean,
+      hint?: {
+        displayName?: string;
+        basename?: string;
+        pruneUnpinnedFavoriteOnDisable?: boolean;
+      }
+    ) => {
       const trimmed = fullUrl.trim();
       if (!trimmed) return;
 
@@ -811,10 +835,25 @@ export function ThemeCatalogSettings({
         });
       } else {
         const nextEnabled = enabledTweakFullUrls.filter((u) => u !== trimmed);
-        patchSettings({
-          themeRemoteEnabledTweakFullUrls: nextEnabled,
-          themeRemoteTweakFavorites: pruneTweakFavorites(tweakFavorites, nextEnabled),
-        });
+        if (hint?.pruneUnpinnedFavoriteOnDisable) {
+          const enabledSet = new Set(nextEnabled);
+          const inLibraryBeforeThisCatalogVisit =
+            tweakFavoritesSnapshotAtAppearanceCatalogOpenRef.current;
+          const nextTweakFavs = tweakFavorites.filter(
+            (f) =>
+              f.pinned === true ||
+              enabledSet.has(f.fullUrl) ||
+              inLibraryBeforeThisCatalogVisit.has(f.fullUrl.trim())
+          );
+          patchSettings({
+            themeRemoteEnabledTweakFullUrls: nextEnabled,
+            themeRemoteTweakFavorites: nextTweakFavs,
+          });
+        } else {
+          patchSettings({
+            themeRemoteEnabledTweakFullUrls: nextEnabled,
+          });
+        }
       }
     },
     [enabledTweakFullUrls, patchSettings, prefetchFull, pruneTweakFavorites, tweakFavorites]
@@ -1468,6 +1507,7 @@ export function ThemeCatalogSettings({
                             setTweakApplied(row.fullUrl, v, {
                               displayName: row.displayName,
                               basename: row.basename,
+                              pruneUnpinnedFavoriteOnDisable: true,
                             })
                           }
                         />


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Disabling a tweak that was automatically favorited no longer unfavorites.
Disabling a tweak inside of the catalog menu that was favorited manually or was from a previous tweak browsing session no longer automatically unfavorites.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
