### PR TITLE
Add console scam warning

### DIFF
--- a/src/app/utils/consolePasteScamWarning.ts
+++ b/src/app/utils/consolePasteScamWarning.ts
@@ -1,0 +1,58 @@
+// This is probably not very accurate, but doesn't really matter I suppose
+function isDockedDevtoolsLikely(): boolean {
+  const gapW = window.outerWidth - window.innerWidth;
+  const gapH = window.outerHeight - window.innerHeight;
+  const threshold = 160;
+  return gapW >= threshold || gapH >= threshold;
+}
+
+export function installConsolePasteScamWarning(): void {
+  const BANNER_STYLE =
+    "font-size:56px;font-weight:900;color:#ff0033;background:#1a0006;padding:16px 24px;border:6px solid #ff0033;line-height:1.1;";
+  const BODY_STYLE =
+    "font-size:22px;font-weight:700;color:#ffb3c1;background:#120008;padding:14px 20px;line-height:1.35;max-width:920px;";
+  const CONTRIBUTE_STYLE =
+    "font-size:18px;font-weight:600;color:#a8d4ff;background:#0a1520;padding:12px 20px;line-height:1.35;max-width:920px;";
+
+  const spamWarnings = () => {
+    const repeat = 5;
+    const betweenPairsMs = 120;
+
+    const emitPair = (index: number) => {
+      console.warn("%cSTOP", BANNER_STYLE);
+      console.warn(
+        "%cIf anyone told you to paste code or text here, you are being scammed. Close this window, do not paste anything, and report their account.",
+        BODY_STYLE,
+      );
+      if (index + 1 < repeat) {
+        window.setTimeout(() => {
+          emitPair(index + 1);
+        }, betweenPairsMs);
+      } else {
+        window.setTimeout(() => {
+          console.warn(
+            "%cIf you know what you're doing, check out our GitHub and contribute: https://github.com/SableClient/Sable",
+            CONTRIBUTE_STYLE,
+          );
+        }, betweenPairsMs);
+      }
+    };
+
+    emitPair(0);
+  };
+
+  let devtoolsWasOpen = false;
+
+  const check = () => {
+    const devtoolsLikelyOpen = isDockedDevtoolsLikely();
+    if (devtoolsLikelyOpen && !devtoolsWasOpen) {
+      spamWarnings();
+    }
+    devtoolsWasOpen = devtoolsLikelyOpen;
+  };
+
+  window.setInterval(check, 1500);
+  window.addEventListener("resize", () => queueMicrotask(check));
+
+  queueMicrotask(check);
+}

--- a/src/app/utils/consolePasteScamWarning.ts
+++ b/src/app/utils/consolePasteScamWarning.ts
@@ -15,8 +15,8 @@ export function installConsolePasteScamWarning(): void {
     "font-size:18px;font-weight:600;color:#a8d4ff;background:#0a1520;padding:12px 20px;line-height:1.35;max-width:920px;";
 
   const spamWarnings = () => {
-    const repeat = 5;
-    const betweenPairsMs = 120;
+    const repeat = 15;
+    const betweenPairsMs = 300;
 
     const emitPair = (index: number) => {
       console.warn("%cSTOP", BANNER_STYLE);

--- a/src/app/utils/consolePasteScamWarning.ts
+++ b/src/app/utils/consolePasteScamWarning.ts
@@ -8,21 +8,21 @@ function isDockedDevtoolsLikely(): boolean {
 
 export function installConsolePasteScamWarning(): void {
   const BANNER_STYLE =
-    "font-size:56px;font-weight:900;color:#ff0033;background:#1a0006;padding:16px 24px;border:6px solid #ff0033;line-height:1.1;";
+    'font-size:56px;font-weight:900;color:#ff0033;background:#1a0006;padding:16px 24px;border:6px solid #ff0033;line-height:1.1;';
   const BODY_STYLE =
-    "font-size:22px;font-weight:700;color:#ffb3c1;background:#120008;padding:14px 20px;line-height:1.35;max-width:920px;";
+    'font-size:22px;font-weight:700;color:#ffb3c1;background:#120008;padding:14px 20px;line-height:1.35;max-width:920px;';
   const CONTRIBUTE_STYLE =
-    "font-size:18px;font-weight:600;color:#a8d4ff;background:#0a1520;padding:12px 20px;line-height:1.35;max-width:920px;";
+    'font-size:18px;font-weight:600;color:#a8d4ff;background:#0a1520;padding:12px 20px;line-height:1.35;max-width:920px;';
 
   const spamWarnings = () => {
     const repeat = 15;
     const betweenPairsMs = 300;
 
     const emitPair = (index: number) => {
-      console.warn("%cSTOP", BANNER_STYLE);
+      console.warn('%cSTOP', BANNER_STYLE);
       console.warn(
-        "%cIf anyone told you to paste code or text here, you are being scammed. Close this window, do not paste anything, and report their account.",
-        BODY_STYLE,
+        '%cIf anyone told you to paste code or text here, you are being scammed. Close this window, do not paste anything, and report their account.',
+        BODY_STYLE
       );
       if (index + 1 < repeat) {
         window.setTimeout(() => {
@@ -32,7 +32,7 @@ export function installConsolePasteScamWarning(): void {
         window.setTimeout(() => {
           console.warn(
             "%cIf you know what you're doing, check out our GitHub and contribute: https://github.com/SableClient/Sable",
-            CONTRIBUTE_STYLE,
+            CONTRIBUTE_STYLE
           );
         }, betweenPairsMs);
       }
@@ -52,7 +52,7 @@ export function installConsolePasteScamWarning(): void {
   };
 
   window.setInterval(check, 1500);
-  window.addEventListener("resize", () => queueMicrotask(check));
+  window.addEventListener('resize', () => queueMicrotask(check));
 
   queueMicrotask(check);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,8 +22,10 @@ import type { Sessions } from './app/state/sessions';
 import { getFallbackSession, MATRIX_SESSIONS_KEY, ACTIVE_SESSION_KEY } from './app/state/sessions';
 import { createLogger } from './app/utils/debug';
 import { getLocalStorageItem } from './app/state/utils/atomWithLocalStorage';
+import { installConsolePasteScamWarning } from './app/utils/consolePasteScamWarning';
 
 enableMapSet();
+installConsolePasteScamWarning();
 const log = createLogger('index');
 
 document.body.classList.add(configClass, varsClass);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a bunch of messages warning about pasting into console. Currently set to repeat 15 times with 300 ms delay, maybe excessive? Noticed that when the client starts a *lot* of messages get spammed into console that quickly bury the warning message, so... extra is probably better than accidentally missing it when someone has console open before the page loads fully.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/2bdb0075-525a-4d96-929d-a94594ff9560" />

Internal since I don't think this matters too much to anyone.

Checks for console open by comparing the window size to the inner size, triggered on any window resize and running every couple seconds in the background.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
