### PR TITLE
Fix greedy math parsing

### DIFF
--- a/.changeset/fix-greedy-math.md
+++ b/.changeset/fix-greedy-math.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Updated the math detection to only trigger when the first $ is not followed by whitespace and the final $ is not immediately followed by a digit and does not have a space before it.

--- a/.changeset/fix-greedy-math.md
+++ b/.changeset/fix-greedy-math.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-Updated the math detection to only trigger when the first $ is not followed by whitespace and the final $ is not immediately followed by a digit and does not have a space before it.
+Updated the math detection to avoid accidental detection when talking about math or spamming dollar signs.

--- a/src/app/plugins/markdown/extensions/matrix-math.ts
+++ b/src/app/plugins/markdown/extensions/matrix-math.ts
@@ -163,6 +163,37 @@ function escapeHtml(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
+/**
+ * Inline math delimiters use `$...$` but must not greedily pair across dollar amounts
+ * (e.g. "$10 ... $20"). We only treat a pair as math when:
+ * - the opening `$` is not followed by whitespace, and
+ * - the closing `$` is not preceded by whitespace, and
+ * - the closing `$` is not immediately followed by an ASCII digit.
+ */
+function tryTokenizeInlineMath(
+  src: string
+): { type: 'math'; raw: string; latex: string } | undefined {
+  if (!src.startsWith('$') || src.startsWith('$$')) {
+    return undefined;
+  }
+  if (src.length < 3 || /\s/.test(src.charAt(1))) {
+    return undefined;
+  }
+  for (let j = 1; j < src.length; j++) {
+    if (src.charAt(j) !== '$') continue;
+    const before = src.charAt(j - 1);
+    if (/\s/.test(before)) continue;
+    const after = j + 1 < src.length ? src.charAt(j + 1) : '';
+    if (after !== '' && /[0-9]/.test(after)) continue;
+    return {
+      type: 'math',
+      raw: src.slice(0, j + 1),
+      latex: src.slice(1, j),
+    };
+  }
+  return undefined;
+}
+
 // Inline math: $...$
 export const matrixMathExtension = {
   name: 'math',
@@ -171,15 +202,7 @@ export const matrixMathExtension = {
     return src.indexOf('$');
   },
   tokenizer(src: string) {
-    const match = /^\$([^$]+)\$/.exec(src);
-    if (match) {
-      return {
-        type: 'math',
-        raw: match[0],
-        latex: match[1],
-      };
-    }
-    return undefined;
+    return tryTokenizeInlineMath(src);
   },
   renderer(token) {
     return `<span data-mx-maths="${escapeHtml(token.latex)}">${token.latex}</span>`;

--- a/src/app/plugins/markdown/extensions/matrix-math.ts
+++ b/src/app/plugins/markdown/extensions/matrix-math.ts
@@ -1,6 +1,6 @@
 import type { TokenizerExtension, RendererExtension } from 'marked';
 
-/** Private-use char so math extensions do not match `$` / `$$` inside code spans. Not U+E000–U+E002 (emoticon placeholders). */
+/** Private-use char so math extensions do not match `$` / `$$` inside code spans. Not U+E000–U+E002 (emoticon placeholders). {@link shieldDollarRunsForMarked} uses U+E021–U+E022. */
 export const MATH_CODE_DOLLAR_MASK = '\uE020';
 
 function findSameLineFenceClose(md: string, from: number, tick: string, minLen: number): number {
@@ -155,12 +155,43 @@ export function unmaskMathCodeDollarPlaceholders(html: string): string {
   return html.replaceAll(MATH_CODE_DOLLAR_MASK, '$');
 }
 
+const MARKED_MATH_BLOCK_SHIELD = '\uE021';
+const MARKED_MATH_BLOCK_SHIELD_END = '\uE022';
+
+export function shieldDollarRunsForMarked(markdown: string): string {
+  const blocks: string[] = [];
+  const blockRe = /\$\$([^$]+)\$\$\n?/g;
+  let m: RegExpExecArray | null;
+  let shielded = '';
+  let last = 0;
+  while ((m = blockRe.exec(markdown)) !== null) {
+    shielded += markdown.slice(last, m.index);
+    blocks.push(m[0]);
+    shielded += `${MARKED_MATH_BLOCK_SHIELD}${blocks.length - 1}${MARKED_MATH_BLOCK_SHIELD_END}`;
+    last = m.index + m[0].length;
+  }
+  shielded += markdown.slice(last);
+
+  shielded = shielded.replace(/\${2,}/g, (run) => run.replace(/\$/g, () => '\\$'));
+
+  return shielded.replace(
+    new RegExp(`${MARKED_MATH_BLOCK_SHIELD}(\\d+)${MARKED_MATH_BLOCK_SHIELD_END}`, 'g'),
+    (_, i) => blocks[parseInt(i, 10)] ?? ''
+  );
+}
+
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+function isIgnorableMathContent(latex: string): boolean {
+  const t = latex.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+  if (t === '') return true;
+  return /^\$+$/.test(t);
 }
 
 /**
@@ -173,7 +204,10 @@ function escapeHtml(text: string): string {
 function tryTokenizeInlineMath(
   src: string
 ): { type: 'math'; raw: string; latex: string } | undefined {
-  if (!src.startsWith('$') || src.startsWith('$$')) {
+  if (!src.startsWith('$')) {
+    return undefined;
+  }
+  if (src.startsWith('$$') && (src.length < 3 || src.charAt(2) !== '$')) {
     return undefined;
   }
   if (src.length < 3 || /\s/.test(src.charAt(1))) {
@@ -185,10 +219,13 @@ function tryTokenizeInlineMath(
     if (/\s/.test(before)) continue;
     const after = j + 1 < src.length ? src.charAt(j + 1) : '';
     if (after !== '' && /[0-9]/.test(after)) continue;
+    const latex = src.slice(1, j);
+    if (isIgnorableMathContent(latex)) continue;
+    if (latex.trimStart().startsWith('$$')) continue;
     return {
       type: 'math',
       raw: src.slice(0, j + 1),
-      latex: src.slice(1, j),
+      latex,
     };
   }
   return undefined;
@@ -219,10 +256,12 @@ export const matrixMathBlockExtension = {
   tokenizer(src: string) {
     const match = /^\$\$([^$]+)\$\$\n?/.exec(src);
     if (match) {
+      const latex = match[1]?.trim() ?? '';
+      if (isIgnorableMathContent(latex)) return undefined;
       return {
         type: 'mathBlock',
         raw: match[0],
-        latex: match[1]?.trim() ?? '',
+        latex,
       };
     }
     return undefined;

--- a/src/app/plugins/markdown/extensions/matrix.test.ts
+++ b/src/app/plugins/markdown/extensions/matrix.test.ts
@@ -48,6 +48,23 @@ describe('matrixMathExtension (inline)', () => {
   it('does not parse unmatched $', () => {
     expect(parse('No $ math here')).not.toContain('data-mx-maths');
   });
+
+  it('does not parse dollar amounts in a sentence as inline math', () => {
+    const input = 'I just bought something for $10 on sale, it was originally $20!';
+    const result = parse(input);
+    expect(result).not.toContain('data-mx-maths');
+    expect(result).toContain('$10');
+    expect(result).toContain('$20');
+  });
+
+  it('does not treat $ as math when the opening is followed by whitespace', () => {
+    expect(parse('$ E = mc^2$')).not.toContain('data-mx-maths');
+  });
+
+  it('still parses valid inline math', () => {
+    expect(parse('$E = mc^2$')).toContain('data-mx-maths');
+    expect(parse('$2+2$')).toContain('data-mx-maths');
+  });
 });
 
 describe('matrixMathBlockExtension (block)', () => {

--- a/src/app/plugins/markdown/extensions/matrix.test.ts
+++ b/src/app/plugins/markdown/extensions/matrix.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { marked } from 'marked';
 import { matrixSpoilerExtension } from './matrix-spoiler';
-import { matrixMathExtension, matrixMathBlockExtension } from './matrix-math';
+import {
+  matrixMathBlockExtension,
+  matrixMathExtension,
+  shieldDollarRunsForMarked,
+} from './matrix-math';
 import { matrixSubscriptExtension } from './matrix-subscript';
 
 function parse(input: string): string {
@@ -13,7 +17,7 @@ function parse(input: string): string {
       matrixSubscriptExtension,
     ],
   });
-  return processor.parse(input) as string;
+  return processor.parse(shieldDollarRunsForMarked(input)) as string;
 }
 
 describe('matrixSpoilerExtension', () => {
@@ -64,6 +68,19 @@ describe('matrixMathExtension (inline)', () => {
   it('still parses valid inline math', () => {
     expect(parse('$E = mc^2$')).toContain('data-mx-maths');
     expect(parse('$2+2$')).toContain('data-mx-maths');
+  });
+
+  it('does not parse inline math when inner trims to empty (e.g. zero-width only)', () => {
+    expect(parse(`empty $\u200B$ here`)).not.toContain('data-mx-maths');
+  });
+
+  it('does not parse long runs of dollar signs as inline math', () => {
+    expect(parse('hey $$$$$$$ there')).not.toContain('data-mx-maths');
+  });
+
+  it('does not parse block math when inner is only whitespace or dollars', () => {
+    expect(parse('$$  $$')).not.toContain('data-mx-maths');
+    expect(parse('$$ $ $$')).not.toContain('data-mx-maths');
   });
 });
 

--- a/src/app/plugins/markdown/markdownToHtml.test.ts
+++ b/src/app/plugins/markdown/markdownToHtml.test.ts
@@ -57,6 +57,17 @@ describe('markdownToHtml', () => {
     expect(result).toContain('$20');
   });
 
+  it('does not treat empty or dollar-only block math as KaTeX', () => {
+    expect(markdownToHtml('$$   $$')).not.toContain('data-mx-maths');
+    expect(markdownToHtml('$$ $ $$')).not.toContain('data-mx-maths');
+  });
+
+  it('does not parse five consecutive dollar signs in a sentence as math', () => {
+    const result = markdownToHtml('hey $$$$$ there');
+    expect(result).not.toContain('data-mx-maths');
+    expect(result).toContain('$$$$$');
+  });
+
   it('does not parse dollars inside fenced code as math', () => {
     expect(markdownToHtml('```\n$$test$$\n```')).not.toContain('data-mx-maths');
     expect(markdownToHtml('```\n$$test$$\n```')).toContain('$$test$$');

--- a/src/app/plugins/markdown/markdownToHtml.test.ts
+++ b/src/app/plugins/markdown/markdownToHtml.test.ts
@@ -48,6 +48,15 @@ describe('markdownToHtml', () => {
     expect(result).toContain('E = mc^2');
   });
 
+  it('does not mangle messages with dollar amounts', () => {
+    const result = markdownToHtml(
+      'I just bought something for $10 on sale, it was originally $20!'
+    );
+    expect(result).not.toContain('data-mx-maths');
+    expect(result).toContain('$10');
+    expect(result).toContain('$20');
+  });
+
   it('does not parse dollars inside fenced code as math', () => {
     expect(markdownToHtml('```\n$$test$$\n```')).not.toContain('data-mx-maths');
     expect(markdownToHtml('```\n$$test$$\n```')).toContain('$$test$$');

--- a/src/app/plugins/markdown/markdownToHtml.ts
+++ b/src/app/plugins/markdown/markdownToHtml.ts
@@ -5,6 +5,7 @@ import {
   matrixMathExtension,
   matrixMathBlockExtension,
   maskDollarSignsInsideMarkdownCode,
+  shieldDollarRunsForMarked,
   unmaskMathCodeDollarPlaceholders,
 } from './extensions/matrix-math';
 import { matrixSubscriptExtension } from './extensions/matrix-subscript';
@@ -65,7 +66,7 @@ export function markdownToHtml(markdown: string): string {
 
   const preprocessed = preprocessEmoticon(blockquotePrefixed);
 
-  const mathInput = maskDollarSignsInsideMarkdownCode(preprocessed);
+  const mathInput = shieldDollarRunsForMarked(maskDollarSignsInsideMarkdownCode(preprocessed));
 
   // Parse markdown to HTML using marked with our Matrix extensions
   const html = processor.parse(mathInput) as string;


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes talking about dollar amounts being spammed by requiring no whitespace after the first $ and no whitespace before the second $ and no number after.
Fixes $$$$$$$$$$$$$$$ being parsed as a bunch of weird latex blocks instead of nonsense.

Fixes #769 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

Tests were AI generated