### PR TITLE
Fix room names being overridden when only 1 other person is present

### DIFF
--- a/.changeset/fix-room-names-overridden-when-1.md
+++ b/.changeset/fix-room-names-overridden-when-1.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix room names being overriden when only 1 other person is in a room.

--- a/src/app/hooks/useRoomMeta.ts
+++ b/src/app/hooks/useRoomMeta.ts
@@ -1,7 +1,9 @@
+import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
 import type { RoomJoinRulesEventContent, Room } from '$types/matrix-sdk';
 import { RoomEvent, RoomStateEvent, EventType } from '$types/matrix-sdk';
 
+import { mDirectAtom } from '$state/mDirectList';
 import { useStateEvent } from './useStateEvent';
 import { useNickname } from './useNickname';
 
@@ -20,6 +22,8 @@ export const useRoomAvatar = (room: Room, dm?: boolean): string | undefined => {
 export const useRoomName = (room: Room): string => {
   const dmUserId = room.guessDMUserId();
   const dmNickname = useNickname(dmUserId || '');
+  const mDirects = useAtomValue(mDirectAtom);
+  const isDmTagged = mDirects.has(room.roomId);
   const [name, setName] = useState(room.name);
 
   useEffect(() => {
@@ -28,11 +32,7 @@ export const useRoomName = (room: Room): string => {
         room.recalculate();
       }
 
-      // small room = dm i promise trust
-      const memberCount = room.getJoinedMemberCount();
-      const isSmallRoom = memberCount <= 2;
-
-      const nextName = isSmallRoom && dmNickname ? dmNickname : room.name;
+      const nextName = isDmTagged && dmNickname ? dmNickname : room.name;
       setName((prev) => (prev !== nextName ? nextName : prev));
     };
 
@@ -45,7 +45,7 @@ export const useRoomName = (room: Room): string => {
       room.removeListener(RoomEvent.Name, updateName);
       room.removeListener(RoomStateEvent.Members, updateName);
     };
-  }, [room, dmNickname]);
+  }, [room, dmNickname, isDmTagged]);
 
   return name;
 };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the room name being overridden to the other person when only 1 other person is present, the initial reason was to get around continuwuity sometimes forgetting room data, thus added a path to just override the dm name whenever it wasn't explicitly set, which also affected normal rooms for whatever reason. Now it actually checks that a room is marked a dm (which actually might reduce the effectiveness of this patch, but I digress)

Fixes #775 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
