### PR TITLE
Shield matrix to links

### DIFF
--- a/.changeset/fix-matrix-to-link-wrapping.md
+++ b/.changeset/fix-matrix-to-link-wrapping.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Matrix.to links sent without explicit markdown formatting are sent as raw links instead of html links.

--- a/src/app/plugins/markdown/markdownToHtml.ts
+++ b/src/app/plugins/markdown/markdownToHtml.ts
@@ -50,6 +50,39 @@ const decodeHtmlEntities = (text: string): string => {
   return result;
 };
 
+const MATRIX_TO_PLACEHOLDER_PREFIX = 'MATRIXTORAWLINKTOKEN';
+
+const escapeHtml = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const shieldBareMatrixToLinks = (
+  input: string
+): { shielded: string; placeholders: Map<string, string> } => {
+  const placeholders = new Map<string, string>();
+  let index = 0;
+
+  const shielded = input.replace(/(?<!\]\()https?:\/\/matrix\.to\/[^\s<)]+/gi, (url) => {
+    const key = `${MATRIX_TO_PLACEHOLDER_PREFIX}${index++}X`;
+    placeholders.set(key, url);
+    return key;
+  });
+
+  return { shielded, placeholders };
+};
+
+const unshieldBareMatrixToLinks = (html: string, placeholders: Map<string, string>): string => {
+  let result = html;
+  for (const [key, url] of placeholders.entries()) {
+    result = result.split(key).join(escapeHtml(url));
+  }
+  return result;
+};
+
 /**
  * Converts markdown string to sanitized Matrix-compatible HTML.
  * Uses marked for parsing and DOMPurify for sanitization per Matrix spec.
@@ -67,7 +100,10 @@ export function markdownToHtml(markdown: string): string {
 
   const preprocessed = preprocessEmoticon(blockquotePrefixed);
 
-  const mathInput = shieldDollarRunsForMarked(maskDollarSignsInsideMarkdownCode(preprocessed));
+  const { shielded: matrixToShielded, placeholders: matrixToPlaceholders } =
+    shieldBareMatrixToLinks(preprocessed);
+
+  const mathInput = shieldDollarRunsForMarked(maskDollarSignsInsideMarkdownCode(matrixToShielded));
 
   // Parse markdown to HTML using marked with our Matrix extensions
   const html = processor.parse(mathInput) as string;
@@ -164,5 +200,10 @@ export function markdownToHtml(markdown: string): string {
     }
   );
 
-  return restoredMxEmoticonHeight.replace(/<li>(<p><\/p>)?<\/li>/gi, '<li><br></li>');
+  const unshieldedMatrixTo = unshieldBareMatrixToLinks(
+    restoredMxEmoticonHeight,
+    matrixToPlaceholders
+  );
+
+  return unshieldedMatrixTo.replace(/<li>(<p><\/p>)?<\/li>/gi, '<li><br></li>');
 }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Matrix.to links sent directly without intentional \[markdown](overrides) will no longer be formatted as \<a> tags.
Should solve issues with OOYE and Cinny displaying full urls instead of directly linking.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
