### PR TITLE
fix(ci): use GitHub App bot identity for flake-lock-fix workflow

### DIFF
--- a/.github/workflows/flake-lock-fix.yml
+++ b/.github/workflows/flake-lock-fix.yml
@@ -1,6 +1,7 @@
 name: Fix flake hashes
 
 on:
+  workflow_dispatch:
   push:
     branches: [dev]
     paths: ['pnpm-lock.yaml']
@@ -13,11 +14,20 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - name: Generate bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout dev
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: dev
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
@@ -30,6 +40,20 @@ jobs:
         if: steps.check.outcome == 'failure'
         run: determinate-nixd fix hashes --auto-apply
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure bot git identity
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          gh auth setup-git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Commit and push if changed
         if: steps.check.outcome == 'failure'
         shell: bash
@@ -39,8 +63,6 @@ jobs:
             echo "No changes after fix hashes; nothing to commit."
             exit 0
           fi
-          git config user.name "sable-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add --update --ignore-removal .
           git commit -m "chore(nix): auto-fix nix hashes"
           git push origin HEAD:dev --force-with-lease


### PR DESCRIPTION
I've also edited the rulesets to ignore sable actions app