### PR TITLE
Fix matrix.to links with custom text being sent as escaped html

### DIFF
--- a/src/app/components/editor/output.test.ts
+++ b/src/app/components/editor/output.test.ts
@@ -28,3 +28,52 @@ describe('toMatrixCustomHTML emoticons', () => {
     expect(html).toContain('height="32"');
   });
 });
+
+describe('toMatrixCustomHTML matrix.to', () => {
+  it('serializes room mentions as raw matrix.to URL text, not an anchor', () => {
+    const html = trimCustomHtml(
+      toMatrixCustomHTML(
+        [
+          {
+            type: BlockType.Paragraph,
+            children: [
+              {
+                type: BlockType.Mention,
+                id: '!room:example.org',
+                name: 'My room',
+                children: [{ text: '' }],
+              } as never,
+            ],
+          } as never,
+        ],
+        {}
+      )
+    );
+
+    expect(html).toContain('https://matrix.to/#/!room:example.org');
+    expect(html).not.toMatch(/<a\b[^>]*matrix\.to/i);
+  });
+
+  it('serializes matrix.to links as raw URL text, not an anchor', () => {
+    const html = trimCustomHtml(
+      toMatrixCustomHTML(
+        [
+          {
+            type: BlockType.Paragraph,
+            children: [
+              {
+                type: BlockType.Link,
+                href: 'https://matrix.to/#/@alice:example.org',
+                children: [{ text: 'Alice' }],
+              } as never,
+            ],
+          } as never,
+        ],
+        {}
+      )
+    );
+
+    expect(html).toContain('https://matrix.to/#/@alice:example.org');
+    expect(html).not.toMatch(/<a\b[^>]*matrix\.to/i);
+  });
+});

--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -8,7 +8,7 @@ import { isUserId } from '$utils/matrix';
 import type { CustomElement } from './slate';
 import { BlockType } from './types';
 import { getMarkdownCodeSpanRanges, isInsideMarkdownCodeSpan } from './utils';
-import { MATRIX_TO_BASE } from '$plugins/matrix-to';
+import { MATRIX_TO_BASE, testMatrixTo } from '$plugins/matrix-to';
 
 export type OutputOptions = {
   /**
@@ -38,8 +38,8 @@ const elementToCustomHtml = (node: CustomElement, children: string): string => {
         fragment += `?${node.viaServers.map((server) => `via=${server}`).join('&')}`;
       }
 
-      const matrixTo = `https://matrix.to/#/${fragment}`;
-      return `<a href="${encodeURI(matrixTo)}" target="_blank" rel="noreferrer noopener">${sanitizeText(node.name)}</a>`;
+      const matrixTo = `${MATRIX_TO_BASE}#/${fragment}`;
+      return sanitizeText(matrixTo);
     }
     case BlockType.Emoticon:
       return node.key.startsWith('mxc://')
@@ -48,7 +48,9 @@ const elementToCustomHtml = (node: CustomElement, children: string): string => {
           )}" title="${sanitizeText(node.shortcode)}" height="32" />`
         : sanitizeText(node.key);
     case BlockType.Link:
-      return `<a href="${encodeURI(node.href)}" target="_blank" rel="noreferrer noopener">${children}</a>`;
+      return testMatrixTo(node.href)
+        ? sanitizeText(node.href)
+        : `<a href="${encodeURI(node.href)}" target="_blank" rel="noreferrer noopener">${children}</a>`;
     case BlockType.Command:
       return `/${sanitizeText(node.command)}`;
     default:

--- a/src/app/plugins/markdown/markdownToHtml.test.ts
+++ b/src/app/plugins/markdown/markdownToHtml.test.ts
@@ -223,4 +223,21 @@ describe('markdownToHtml', () => {
     const result = markdownToHtml(html);
     expect(result).not.toContain('?');
   });
+
+  it('keeps normal markdown links valid when many bare matrix.to URLs are shielded', () => {
+    const matrixLines = Array.from(
+      { length: 12 },
+      (_, i) => `https://matrix.to/#/@u${i}:example.org`
+    ).join('\n');
+    const md = `${matrixLines}\n[docs](https://example.com/doc)`;
+    const result = markdownToHtml(md);
+    expect(result).toContain('<a href="https://example.com/doc"');
+    expect(result).not.toContain('&lt;a href=');
+  });
+
+  it('emits bare matrix.to text for unformatted URLs, not anchor tags', () => {
+    const result = markdownToHtml('join https://matrix.to/#/#room:example.org please');
+    expect(result).toContain('https://matrix.to/#/#room:example.org');
+    expect(result).not.toMatch(/<a[^>]*matrix\.to/);
+  });
 });

--- a/src/app/plugins/markdown/markdownToHtml.ts
+++ b/src/app/plugins/markdown/markdownToHtml.ts
@@ -66,19 +66,24 @@ const shieldBareMatrixToLinks = (
   const placeholders = new Map<string, string>();
   let index = 0;
 
-  const shielded = input.replace(/(?<!\]\()https?:\/\/matrix\.to\/[^\s<)]+/gi, (url) => {
-    const key = `${MATRIX_TO_PLACEHOLDER_PREFIX}${index++}X`;
-    placeholders.set(key, url);
-    return key;
-  });
+  const shielded = input.replace(
+    /(?<!\]\()https?:\/\/matrix\.to\/[^\s<)]+/gi,
+    (url) => {
+      const key = `${MATRIX_TO_PLACEHOLDER_PREFIX}${index++}X`;
+      placeholders.set(key, url);
+      return key;
+    }
+  );
 
   return { shielded, placeholders };
 };
 
 const unshieldBareMatrixToLinks = (html: string, placeholders: Map<string, string>): string => {
   let result = html;
-  for (const [key, url] of placeholders.entries()) {
-    result = result.split(key).join(escapeHtml(url));
+  const keys = [...placeholders.keys()].sort((a, b) => b.length - a.length);
+  for (const key of keys) {
+    const url = placeholders.get(key);
+    if (url) result = result.split(key).join(escapeHtml(url));
   }
   return result;
 };

--- a/src/app/plugins/markdown/markdownToHtml.ts
+++ b/src/app/plugins/markdown/markdownToHtml.ts
@@ -66,14 +66,11 @@ const shieldBareMatrixToLinks = (
   const placeholders = new Map<string, string>();
   let index = 0;
 
-  const shielded = input.replace(
-    /(?<!\]\()https?:\/\/matrix\.to\/[^\s<)]+/gi,
-    (url) => {
-      const key = `${MATRIX_TO_PLACEHOLDER_PREFIX}${index++}X`;
-      placeholders.set(key, url);
-      return key;
-    }
-  );
+  const shielded = input.replace(/(?<!\]\()https?:\/\/matrix\.to\/[^\s<)]+/gi, (url) => {
+    const key = `${MATRIX_TO_PLACEHOLDER_PREFIX}${index++}X`;
+    placeholders.set(key, url);
+    return key;
+  });
 
   return { shielded, placeholders };
 };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes matrix.to links with custom text, like links to rooms, being sent as escaped html. Internal because it has yet to escape dev.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

Tests were  AI generated.