### PR TITLE
Improve caption behavior

### DIFF
--- a/.changeset/fix-alt-text-behavior.md
+++ b/.changeset/fix-alt-text-behavior.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Adjusted captions so the alt text on an image is set when captions are hidden, and is otherwise blank, to improve screen reader behavior.

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -350,6 +350,7 @@ function RenderMessageContentInternal({
     return renderCaptionedAttachment(
       <MImage
         content={content as Record<string, never> & { msgtype: MsgType.Image }}
+        suppressInlineImageAlt={captionPosition !== CaptionPosition.Hidden}
         renderImageContent={(imageProps) => (
           <ImageContent
             {...imageProps}

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -384,6 +384,7 @@ export function MNotice({
 
 type RenderImageContentProps = {
   body: string;
+  imageAlt?: string;
   filename?: string;
   info?: IImageInfo & IThumbnailContent;
   mimeType?: string;
@@ -396,13 +397,21 @@ type MImageProps = {
   content: IImageContent;
   renderImageContent: (props: RenderImageContentProps) => ReactNode;
   outlined?: boolean;
+  suppressInlineImageAlt?: boolean;
 };
-export function MImage({ content, renderImageContent, outlined }: MImageProps) {
+export function MImage({
+  content,
+  renderImageContent,
+  outlined,
+  suppressInlineImageAlt,
+}: MImageProps) {
   const imgInfo = content?.info;
   const mxcUrl = content.file?.url ?? content.url;
   if (typeof mxcUrl !== 'string') {
     return <BrokenContent body={content.body ?? content.filename} />;
   }
+  const description =
+    (typeof content.body === 'string' && content.body.trim()) || content.filename || 'Image';
   const MAX_SIZE = 400;
   const imgW = imgInfo?.w ?? MAX_SIZE;
   const imgH = imgInfo?.h ?? MAX_SIZE;
@@ -426,7 +435,8 @@ export function MImage({ content, renderImageContent, outlined }: MImageProps) {
         }}
       >
         {renderImageContent({
-          body: content.filename || 'Image',
+          body: description,
+          ...(suppressInlineImageAlt ? { imageAlt: '' } : {}),
           info: imgInfo,
           mimeType: imgInfo?.mimetype,
           url: mxcUrl,

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -71,6 +71,7 @@ type RenderImageProps = {
 };
 export type ImageContentProps = {
   body: string;
+  imageAlt?: string;
   mimeType?: string;
   url: string;
   info?: IImageInfo;
@@ -91,6 +92,7 @@ export const ImageContent = as<'div', ImageContentProps>(
       className,
       style,
       body,
+      imageAlt,
       mimeType,
       url,
       info,
@@ -283,7 +285,7 @@ export const ImageContent = as<'div', ImageContentProps>(
             style={{ width: '100%' }}
           >
             {renderImage({
-              alt: body,
+              alt: imageAlt !== undefined ? imageAlt : body,
               title: body,
               src: srcState.data,
               onLoad: handleLoad,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Still need to figure out what behaviors are the best for this.

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adjusted captions so the alt text on an image is set when captions are hidden, and is otherwise blank, to improve screen reader behavior.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
