### PR TITLE
Create trademark policy for Sable project

### DIFF
--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -41,6 +41,7 @@ You may:
 - Use the Sable name, logo, or branding in your project’s name or identity (e.g., "Sable-Enterprise", "Sable for Android", "Sable-Lite").
 - Create derivative, similar, or completely wild new logos based on ours.
 - Distribute or package the software for platforms not officially supported by us using the Sable name.
+- Take this trademark document and derive your own version of it, provided it's for your branding, rather than Sable
 
 You must not:
 - Feel bad about forking our project. Forks are healthy for FOSS!

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -9,6 +9,7 @@ While our source code is governed by the GNU Affero General Public License (AGPL
 The Sable logo is dedicated to the public domain under the CC0 1.0 Universal (Public Domain Dedication). All rights waived.
 
 The logo may absolutely be:
+
 - Modified, distorted, or recolored
 - Used as part of another logo or mark
 - Given a tiny top hat, sunglasses, or a cool jacket
@@ -17,6 +18,7 @@ The logo may absolutely be:
 ### Permitted Uses
 
 You are highly encouraged to:
+
 - Use the name “Sable” in text anywhere you like
 - Link to the official repository or documentation
 - State in plain text that your project is “based on Sable”, “a fork of Sable”, or “better than Sable”
@@ -26,28 +28,35 @@ You are highly encouraged to:
 ### Restricted Uses
 
 We only have two rules to protect the community. You may not:
+
 - Impersonate the core Sable maintainers or use the Sable name/logo to distribute malware or malicious software.
 - Use the Sable name or logo to falsely claim that the core maintainers officially legally endorse your specific corporate product.
 
 That's literally it.
 
 ## Requirements for Forks and Modifications
+
 If you modify or build upon the Sable source code:
 
 You must:
+
 - Comply with the AGPLv3 license terms (keep open source open!).
 
 You may:
+
 - Use the Sable name, logo, or branding in your project’s name or identity (e.g., "Sable-Enterprise", "Sable for Android", "Sable-Lite").
 - Create derivative, similar, or completely wild new logos based on ours.
 - Distribute or package the software for platforms not officially supported by us using the Sable name.
 - Take this trademark document and derive your own version of it, provided it's for your branding, rather than Sable
 
 You must not:
+
 - Feel bad about forking our project. Forks are healthy for FOSS!
 
 ## Community and Social Use
+
 Community pages, groups, or accounts:
+
 - Are awesome.
 - Can absolutely use the name Sable.
 - Can freely use the Sable logo.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,53 @@
+# Trademarks
+
+The Sable name and the Sable logo belong to the FOSS community.
+
+While our source code is governed by the GNU Affero General Public License (AGPLv3), we believe the Free and Open Source ethos shouldn't stop there. We actually like it when people use, share, and build upon our work.
+
+## Logo
+
+The Sable logo is dedicated to the public domain under the CC0 1.0 Universal (Public Domain Dedication). All rights waived.
+
+The logo may absolutely be:
+- Modified, distorted, or recolored
+- Used as part of another logo or mark
+- Given a tiny top hat, sunglasses, or a cool jacket
+- Used more prominently than your own branding, if you really want to for some reason
+
+### Permitted Uses
+
+You are highly encouraged to:
+- Use the name “Sable” in text anywhere you like
+- Link to the official repository or documentation
+- State in plain text that your project is “based on Sable”, “a fork of Sable”, or “better than Sable”
+- Use the name and logo when self-hosting, whether you modified the software or not
+- Strip out our branding entirely and replace it with your own. If you’re hosting, you can do whatever you want!
+
+### Restricted Uses
+
+We only have two rules to protect the community. You may not:
+- Impersonate the core Sable maintainers or use the Sable name/logo to distribute malware or malicious software.
+- Use the Sable name or logo to falsely claim that the core maintainers officially legally endorse your specific corporate product.
+
+That's literally it.
+
+## Requirements for Forks and Modifications
+If you modify or build upon the Sable source code:
+
+You must:
+- Comply with the AGPLv3 license terms (keep open source open!).
+
+You may:
+- Use the Sable name, logo, or branding in your project’s name or identity (e.g., "Sable-Enterprise", "Sable for Android", "Sable-Lite").
+- Create derivative, similar, or completely wild new logos based on ours.
+- Distribute or package the software for platforms not officially supported by us using the Sable name.
+
+You must not:
+- Feel bad about forking our project. Forks are healthy for FOSS!
+
+## Community and Social Use
+Community pages, groups, or accounts:
+- Are awesome.
+- Can absolutely use the name Sable.
+- Can freely use the Sable logo.
+- Please just add a tiny disclaimer somewhere that it's a community-run space so people don't yell at us when your server goes down for maintenance.


### PR DESCRIPTION
Added a trademark policy outlining permitted and restricted uses of the Sable name and logo.