### PR TITLE
Add Space Banner Support per MSC4221

### DIFF
--- a/.changeset/add-room-banner-support.md
+++ b/.changeset/add-room-banner-support.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add Space banner support per MSC4221. You can now set it from the space settings.

--- a/src/app/components/page/Page.tsx
+++ b/src/app/components/page/Page.tsx
@@ -49,7 +49,6 @@ export const PageNavHeader = as<'header', css.PageNavHeaderVariants>(
     <Header
       className={classNames(css.PageNavHeader({ outlined }), className)}
       variant="Background"
-      size="600"
       {...props}
       ref={ref}
     />

--- a/src/app/features/common-settings/general/RoomProfile.tsx
+++ b/src/app/features/common-settings/general/RoomProfile.tsx
@@ -40,6 +40,9 @@ import { useAlive } from '$hooks/useAlive';
 import type { RoomPermissionsAPI } from '$hooks/useRoomPermissions';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
+import { useStateEvent } from '$hooks/useStateEvent';
+import type { RoomBannerContent } from '$types/matrix-sdk-events';
+import { CustomStateEvent } from '$types/matrix/room';
 
 type RoomProfileEditProps = {
   canEditAvatar: boolean;
@@ -325,6 +328,10 @@ export function RoomProfile({ permissions }: RoomProfileProps) {
 
   const handleCloseEdit = useCallback(() => setEdit(false), []);
 
+  const bannerState = useStateEvent(room, CustomStateEvent.RoomBanner);
+  const bannerMXC = bannerState?.getContent<RoomBannerContent>()?.url;
+  const bannerURI = mxcUrlToHttp(mx, bannerMXC ?? '', true);
+
   return (
     <Box direction="Column" gap="100">
       <Text size="L400">Profile</Text>
@@ -393,6 +400,18 @@ export function RoomProfile({ permissions }: RoomProfileProps) {
           </Box>
         )}
       </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400">
+
+            <img
+              src={bannerURI ?? ''}
+              alt={`${name}'s banner`}
+              draggable="false"
+            />
+        </SequenceCard>
     </Box>
   );
 }

--- a/src/app/features/common-settings/general/RoomProfile.tsx
+++ b/src/app/features/common-settings/general/RoomProfile.tsx
@@ -4,15 +4,22 @@ import {
   Button,
   Chip,
   color,
+  config,
+  Dialog,
+  Header,
   Icon,
+  IconButton,
   Icons,
   Input,
+  Overlay,
+  OverlayBackdrop,
+  OverlayCenter,
   Spinner,
   Text,
   TextArea,
 } from 'folds';
 import type { FormEventHandler } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import Linkify from 'linkify-react';
 import classNames from 'classnames';
@@ -43,6 +50,9 @@ import { settingsAtom } from '$state/settings';
 import { useStateEvent } from '$hooks/useStateEvent';
 import type { RoomBannerContent } from '$types/matrix-sdk-events';
 import { CustomStateEvent } from '$types/matrix/room';
+import { SettingTile } from '$components/setting-tile';
+import { stopPropagation } from '$utils/keyboard';
+import FocusTrap from 'focus-trap-react';
 
 type RoomProfileEditProps = {
   canEditAvatar: boolean;
@@ -299,6 +309,175 @@ export function RoomProfileEdit({
   );
 }
 
+export type ProfileProps = {
+  bannerURI?: string;
+};
+function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
+  const mx = useMatrixClient();
+  const [alertRemove, setAlertRemove] = useState(false);
+  
+  const space = useRoom();
+  const [stagedUrl, setStagedUrl] = useState<string>();
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const bannerUrl = bannerURI;
+
+  useEffect(() => {
+    if (bannerUrl) {
+      setStagedUrl(undefined);
+    }
+  }, [bannerUrl]);
+
+  const [imageFile, setImageFile] = useState<File>();
+  const imageFileURL = useObjectURL(imageFile);
+
+  const uploadAtom = useMemo(() => {
+    if (imageFile) return createUploadAtom(imageFile);
+    return undefined;
+  }, [imageFile]);
+
+  const pickFile = useFilePicker(setImageFile, false);
+
+  const handlePick = useCallback(() => {
+    setIsRemoving(false);
+    setStagedUrl(undefined);
+    pickFile('image/*');
+  }, [pickFile]);
+
+  const handleRemoveUpload = useCallback(() => {
+    setImageFile(undefined);
+  }, []);
+
+  const handleUploaded = useCallback(
+    (upload: UploadSuccess) => {
+      const { mxc } = upload;
+
+      if (imageFileURL) setStagedUrl(imageFileURL);
+      mx.sendStateEvent(space.roomId, CustomStateEvent.RoomBanner, {url: mxc}, '');
+      setImageFile(undefined);
+    },
+    [mx, imageFileURL, space]
+  );
+
+  const handleRemoveBanner = async () => {
+    setIsRemoving(true);
+    setStagedUrl(undefined);
+    setImageFile(undefined);
+
+      mx.sendStateEvent(space.roomId, CustomStateEvent.RoomBanner, {url: ''}, '');
+
+    setAlertRemove(false);
+  };
+
+  const previewUrl = isRemoving ? undefined : imageFileURL || stagedUrl || bannerUrl;
+
+  return (
+    <SettingTile title="Banner" focusId="banner">
+      <Box direction="Column" gap="300" grow="Yes">
+        <Box
+          style={{
+            height: '100px',
+            width: '100%',
+            borderRadius: config.radii.R400,
+            overflow: 'hidden',
+            backgroundColor: 'var(--sable-surface-container)',
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {previewUrl ? (
+            <img
+              src={previewUrl}
+              key={previewUrl}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              alt="Banner Preview"
+            />
+          ) : (
+            <Box justifyContent="Center" alignItems="Center">
+              <Text priority="300" size="T200">
+                No Banner Set
+              </Text>
+            </Box>
+          )}
+        </Box>
+
+        {uploadAtom ? (
+          <Box gap="200" direction="Column">
+            <CompactUploadCardRenderer
+              uploadAtom={uploadAtom}
+              onRemove={handleRemoveUpload}
+              onComplete={handleUploaded}
+            />
+          </Box>
+        ) : (
+          <Box gap="200">
+            <Button
+              onClick={handlePick}
+              size="300"
+              variant="Secondary"
+              fill="Soft"
+              outlined
+              radii="300"
+            >
+              <Text size="B300">{bannerUrl ? 'Change Banner' : 'Upload Banner'}</Text>
+            </Button>
+            {bannerUrl && (
+              <Button
+                size="300"
+                variant="Critical"
+                fill="None"
+                radii="300"
+                onClick={() => setAlertRemove(true)}
+              >
+                <Text size="B300">Remove</Text>
+              </Button>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      <Overlay open={alertRemove} backdrop={<OverlayBackdrop />}>
+        <OverlayCenter>
+          <FocusTrap
+            focusTrapOptions={{
+              initialFocus: false,
+              onDeactivate: () => setAlertRemove(false),
+              clickOutsideDeactivates: true,
+              escapeDeactivates: stopPropagation,
+            }}
+          >
+            <Dialog variant="Surface">
+              <Header
+                style={{
+                  padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
+                  borderBottomWidth: config.borderWidth.B300,
+                }}
+                variant="Surface"
+                size="500"
+              >
+                <Box grow="Yes">
+                  <Text size="H4">Remove Banner</Text>
+                </Box>
+                <IconButton size="300" onClick={() => setAlertRemove(false)} radii="300">
+                  <Icon src={Icons.Cross} />
+                </IconButton>
+              </Header>
+              <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
+                <Text priority="400">Are you sure you want to remove profile banner?</Text>
+                <Button variant="Critical" onClick={handleRemoveBanner}>
+                  <Text size="B400">Remove</Text>
+                </Button>
+              </Box>
+            </Dialog>
+          </FocusTrap>
+        </OverlayCenter>
+      </Overlay>
+    </SettingTile>
+  );
+}
+
 type RoomProfileProps = {
   permissions: RoomPermissionsAPI;
 };
@@ -404,14 +583,10 @@ export function RoomProfile({ permissions }: RoomProfileProps) {
         className={SequenceCardStyle}
         variant="SurfaceVariant"
         direction="Column"
-        gap="400">
-
-            <img
-              src={bannerURI ?? ''}
-              alt={`${name}'s banner`}
-              draggable="false"
-            />
-        </SequenceCard>
+        gap="400"
+      >
+        <RoomBannerEdit bannerURI={bannerURI ?? undefined}/>
+      </SequenceCard>
     </Box>
   );
 }

--- a/src/app/features/common-settings/general/RoomProfile.tsx
+++ b/src/app/features/common-settings/general/RoomProfile.tsx
@@ -315,7 +315,7 @@ export type ProfileProps = {
 function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
   const mx = useMatrixClient();
   const [alertRemove, setAlertRemove] = useState(false);
-  
+
   const space = useRoom();
   const [stagedUrl, setStagedUrl] = useState<string>();
   const [isRemoving, setIsRemoving] = useState(false);
@@ -353,7 +353,7 @@ function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
       const { mxc } = upload;
 
       if (imageFileURL) setStagedUrl(imageFileURL);
-      mx.sendStateEvent(space.roomId, CustomStateEvent.RoomBanner, {url: mxc}, '');
+      mx.sendStateEvent(space.roomId, CustomStateEvent.RoomBanner, { url: mxc }, '');
       setImageFile(undefined);
     },
     [mx, imageFileURL, space]
@@ -364,7 +364,7 @@ function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
     setStagedUrl(undefined);
     setImageFile(undefined);
 
-      mx.sendStateEvent(space.roomId, CustomStateEvent.RoomBanner, {url: ''}, '');
+    mx.sendStateEvent(space.roomId, CustomStateEvent.RoomBanner, { url: '' }, '');
 
     setAlertRemove(false);
   };
@@ -579,14 +579,16 @@ export function RoomProfile({ permissions }: RoomProfileProps) {
           </Box>
         )}
       </SequenceCard>
-      <SequenceCard
-        className={SequenceCardStyle}
-        variant="SurfaceVariant"
-        direction="Column"
-        gap="400"
-      >
-        <RoomBannerEdit bannerURI={bannerURI ?? undefined}/>
-      </SequenceCard>
+      {room.isSpaceRoom() && (
+        <SequenceCard
+          className={SequenceCardStyle}
+          variant="SurfaceVariant"
+          direction="Column"
+          gap="400"
+        >
+          <RoomBannerEdit bannerURI={bannerURI ?? undefined} />
+        </SequenceCard>
+      )}
     </Box>
   );
 }

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -237,7 +237,7 @@ function ThemeVisualPreferences() {
   const [linkPreviewMaxHeightInput, setLinkPreviewMaxHeightInput] = useState(
     linkPreviewImageMaxHeight.toString()
   );
-  const [showRoomBanners,setShowRoomBanners] = useSetting(settingsAtom, 'showRoomBanners');
+  const [showRoomBanners, setShowRoomBanners] = useSetting(settingsAtom, 'showRoomBanners');
 
   const handleIncomingDefaultHeightChange: ChangeEventHandler<HTMLInputElement> = (evt) => {
     const val = evt.target.value;
@@ -627,10 +627,7 @@ function SidebarWidth({ sidebarSelector }: { sidebarSelector: string }) {
     settingsAtom,
     'widgetSidebarWidth'
   );
-  const [roomBannerHeight, setRoomBannerHeight] = useSetting(
-    settingsAtom,
-    'roomBannerHeight'
-  );
+  const [roomBannerHeight, setRoomBannerHeight] = useSetting(settingsAtom, 'roomBannerHeight');
 
   // Yandere style code but it works  and is as straight forward as can be :shrug:
   const getCurValue = useMemo(() => {
@@ -650,7 +647,7 @@ function SidebarWidth({ sidebarSelector }: { sidebarSelector: string }) {
     threadRootHeight,
     vcmsgSidebarWidth,
     widgetSidebarWidth,
-    roomBannerHeight
+    roomBannerHeight,
   ]);
   const [curValue, setCurValue] = useState(getCurValue);
   const setValue = (value: number) => {

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -237,6 +237,7 @@ function ThemeVisualPreferences() {
   const [linkPreviewMaxHeightInput, setLinkPreviewMaxHeightInput] = useState(
     linkPreviewImageMaxHeight.toString()
   );
+  const [showRoomBanners,setShowRoomBanners] = useSetting(settingsAtom, 'showRoomBanners');
 
   const handleIncomingDefaultHeightChange: ChangeEventHandler<HTMLInputElement> = (evt) => {
     const val = evt.target.value;
@@ -342,6 +343,14 @@ function ThemeVisualPreferences() {
           focusId="autoplay-emojis"
           description="Automatically play animated custom emojis."
           after={<Switch variant="Primary" value={autoplayEmojis} onChange={setAutoplayEmojis} />}
+        />
+      </SequenceCard>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Display Room banners"
+          focusId="display-room-banners"
+          after={<Switch variant="Primary" value={showRoomBanners} onChange={setShowRoomBanners} />}
         />
       </SequenceCard>
 
@@ -618,6 +627,10 @@ function SidebarWidth({ sidebarSelector }: { sidebarSelector: string }) {
     settingsAtom,
     'widgetSidebarWidth'
   );
+  const [roomBannerHeight, setRoomBannerHeight] = useSetting(
+    settingsAtom,
+    'roomBannerHeight'
+  );
 
   // Yandere style code but it works  and is as straight forward as can be :shrug:
   const getCurValue = useMemo(() => {
@@ -627,6 +640,7 @@ function SidebarWidth({ sidebarSelector }: { sidebarSelector: string }) {
     if (sidebarSelector === 'threadRootHeight') return threadRootHeight;
     if (sidebarSelector === 'vcmsgSidebarWidth') return vcmsgSidebarWidth;
     if (sidebarSelector === 'widgetSidebarWidth') return widgetSidebarWidth;
+    if (sidebarSelector === 'roomBannerHeight') return roomBannerHeight;
     return undefined;
   }, [
     sidebarSelector,
@@ -636,6 +650,7 @@ function SidebarWidth({ sidebarSelector }: { sidebarSelector: string }) {
     threadRootHeight,
     vcmsgSidebarWidth,
     widgetSidebarWidth,
+    roomBannerHeight
   ]);
   const [curValue, setCurValue] = useState(getCurValue);
   const setValue = (value: number) => {
@@ -645,6 +660,7 @@ function SidebarWidth({ sidebarSelector }: { sidebarSelector: string }) {
     if (sidebarSelector === 'threadRootHeight') setThreadRootHeight(value);
     if (sidebarSelector === 'vcmsgSidebarWidth') setvcmsgSidebarWidth(value);
     if (sidebarSelector === 'widgetSidebarWidth') setWidgetSidebarWidth(value);
+    if (sidebarSelector === 'roomBannerHeight') setRoomBannerHeight(value);
   };
 
   useEffect(() => {

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -93,6 +93,7 @@ const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly string[]
     'customize-dm-cards',
     'custom-profile-cards',
     'dark-theme',
+    'display-room-banners',
     'jumbo-emoji-size',
     'light-theme',
     'manual-theme',

--- a/src/app/hooks/usePanelSizes.ts
+++ b/src/app/hooks/usePanelSizes.ts
@@ -32,6 +32,10 @@ export const usePanelSizeItems = (): PanelSizetItem[] =>
         layout: 'widgetSidebarWidth',
         name: 'Widget Panel Width',
       },
+      {
+        layout: 'roomBannerHeight',
+        name: 'Room Banner Height',
+      },
     ],
     []
   );

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -271,15 +271,25 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
       return cords;
     });
   };
+  const [roomBannerHeight, setRoomBannerHeight] = useSetting(settingsAtom, 'roomBannerHeight');
+  const [curHeight, setCurHeight] = useState(roomBannerHeight);
+  useEffect(() => {
+    setCurHeight(roomBannerHeight);
+  }, [roomBannerHeight]);
 
   const bannerState = useStateEvent(space, CustomStateEvent.RoomBanner);
   const bannerMXC = bannerState?.getContent<RoomBannerContent>()?.url;
   const bannerURI = mxcUrlToHttp(mx, bannerMXC ?? '', true);
   const hasBanner = bannerURI && !hideText;
+
   return (
     <>
       <div className={hasBanner ? css.RoomCoverHeaderContainer : ''}>
-        <div className={hasBanner ? css.RoomCoverNavContainer : css.RoomCoverlessNavContainer}>
+        <div
+          className={
+            hasBanner ? css.RoomCoverNavContainer : css.RoomCoverlessNavContainer({ hideText })
+          }
+        >
           <PageNavHeader outlined={false}>
             <Box alignItems="Center" grow="Yes" gap="300" justifyContent="Center">
               {hideText ? (
@@ -346,7 +356,8 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
         </div>
       </div>
       {bannerURI && !hideText && (
-        <div className={css.RoomCoverContainer}>
+        <>
+        <div className={css.RoomCoverContainer} style={{height:toRem(curHeight)}}>
           <ClientSideHoverFreeze src={bannerURI} className={css.RoomCover}>
             <img
               className={css.RoomCoverImage}
@@ -356,7 +367,19 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
             />
           </ClientSideHoverFreeze>
         </div>
+        <SidebarResizer
+          setCurWidth={setCurHeight}
+          sidebarWidth={roomBannerHeight}
+          setSidebarWidth={setRoomBannerHeight}
+          instep={50}
+          outstep={60}
+          minValue={50}
+          maxValue={500}
+          topSided
+        />
+        </>
       )}
+
     </>
   );
 }

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -281,7 +281,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
   const bannerState = useStateEvent(space, CustomStateEvent.RoomBanner);
   const bannerMXC = bannerState?.getContent<RoomBannerContent>()?.url;
   const bannerURI = mxcUrlToHttp(mx, bannerMXC ?? '', true);
-  const hasBanner = bannerURI && !hideText && showBanners;
+  const hasBanner = !!(bannerURI && !hideText && showBanners);
 
   return (
     <>

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -86,6 +86,8 @@ import { RoomAvatar } from '$components/room-avatar';
 import { getRoomAvatarUrl } from '$utils/room';
 import { nameInitials } from '$utils/common';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import { CustomStateEvent } from '$types/matrix/room';
+import type { RoomBannerContent } from '$types/matrix-sdk-events';
 
 const debugLog = createDebugLogger('Space');
 
@@ -268,6 +270,8 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
     });
   };
 
+  const bannerState = useStateEvent(space, CustomStateEvent.RoomBanner);
+  const bannerURI = bannerState?.getContent<RoomBannerContent>()?.url;
   return (
     <>
       <PageNavHeader>
@@ -303,6 +307,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
                   <Icon src={Icons.VerticalDots} size="200" />
                 </IconButton>
               </Box>
+              <Text>{bannerURI}</Text>
             </>
           )}
         </Box>

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -29,7 +29,7 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { mDirectAtom } from '$state/mDirectList';
 import { NavCategory, NavCategoryHeader, NavItem, NavItemContent, NavLink } from '$components/nav';
 import { getSpaceLobbyPath, getSpaceRoomPath, getSpaceSearchPath } from '$pages/pathUtils';
-import { getCanonicalAliasOrRoomId, isRoomAlias } from '$utils/matrix';
+import { getCanonicalAliasOrRoomId, isRoomAlias, mxcUrlToHttp } from '$utils/matrix';
 import { useSelectedRoom } from '$hooks/router/useSelectedRoom';
 import { useSpaceLobbySelected, useSpaceSearchSelected } from '$hooks/router/useSelectedSpace';
 import { useSpace } from '$hooks/useSpace';
@@ -88,6 +88,8 @@ import { nameInitials } from '$utils/common';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { CustomStateEvent } from '$types/matrix/room';
 import type { RoomBannerContent } from '$types/matrix-sdk-events';
+import * as css from './styles.css';
+import { ClientSideHoverFreeze } from '$components/ClientSideHoverFreeze';
 
 const debugLog = createDebugLogger('Space');
 
@@ -271,69 +273,89 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
   };
 
   const bannerState = useStateEvent(space, CustomStateEvent.RoomBanner);
-  const bannerURI = bannerState?.getContent<RoomBannerContent>()?.url;
+  const bannerMXC = bannerState?.getContent<RoomBannerContent>()?.url;
+  const bannerURI = mxcUrlToHttp(mx, bannerMXC ?? '', true);
+  const hasBanner = bannerURI && !hideText;
   return (
     <>
-      <PageNavHeader>
-        <Box alignItems="Center" grow="Yes" gap="300" justifyContent="Center">
-          {hideText ? (
-            <Avatar size={hideText ? undefined : '200'} radii="400" onClick={handleOpenMenu}>
-              <RoomAvatar
-                roomId={space.roomId}
-                src={getRoomAvatarUrl(mx, space, 96, useAuthentication)}
-                uniformIcons
-                alt={spaceName}
-                renderFallback={() => (
-                  <Text as="span" size="H6">
-                    {nameInitials(spaceName)}
-                  </Text>
-                )}
-              />
-            </Avatar>
-          ) : (
-            <>
-              <Box grow="Yes" alignItems="Center" gap="100">
-                <Text size="H4" truncate>
-                  {spaceName}
-                </Text>
-                {joinRules?.join_rule !== JoinRule.Public && <Icon src={Icons.Lock} size="50" />}
-              </Box>
-              <Box shrink="No">
-                <IconButton
-                  aria-pressed={!!menuAnchor}
-                  variant="Background"
-                  onClick={handleOpenMenu}
+      <div className={hasBanner ? css.RoomCoverHeaderContainer : ''}>
+        <div className={hasBanner ? css.RoomCoverNavContainer : css.RoomCoverlessNavContainer}>
+          <PageNavHeader outlined={false}>
+            <Box alignItems="Center" grow="Yes" gap="300" justifyContent="Center">
+              {hideText ? (
+                <Avatar size={hideText ? undefined : '200'} radii="400" onClick={handleOpenMenu}>
+                  <RoomAvatar
+                    roomId={space.roomId}
+                    src={getRoomAvatarUrl(mx, space, 96, useAuthentication)}
+                    uniformIcons
+                    alt={spaceName}
+                    renderFallback={() => (
+                      <Text as="span" size="H6">
+                        {nameInitials(spaceName)}
+                      </Text>
+                    )}
+                  />
+                </Avatar>
+              ) : (
+                <>
+                  <Box grow="Yes" alignItems="Center" gap="100">
+                    <Text size="H4" truncate>
+                      {spaceName}
+                    </Text>
+                    {joinRules?.join_rule !== JoinRule.Public && (
+                      <Icon src={Icons.Lock} size="50" />
+                    )}
+                  </Box>
+                  <Box shrink="No">
+                    <IconButton
+                      aria-pressed={!!menuAnchor}
+                      variant="Background"
+                      style={hasBanner ? { backgroundColor: '#0000' } : {}}
+                      onClick={handleOpenMenu}
+                    >
+                      <Icon src={Icons.VerticalDots} size="200" />
+                    </IconButton>
+                  </Box>
+                </>
+              )}
+            </Box>
+          </PageNavHeader>
+          {menuAnchor && (
+            <PopOut
+              anchor={menuAnchor}
+              position="Bottom"
+              align="End"
+              offset={6}
+              content={
+                <FocusTrap
+                  focusTrapOptions={{
+                    initialFocus: false,
+                    returnFocusOnDeactivate: false,
+                    onDeactivate: () => setMenuAnchor(undefined),
+                    clickOutsideDeactivates: true,
+                    isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
+                    isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
+                    escapeDeactivates: stopPropagation,
+                  }}
                 >
-                  <Icon src={Icons.VerticalDots} size="200" />
-                </IconButton>
-              </Box>
-              <Text>{bannerURI}</Text>
-            </>
+                  <SpaceMenu room={space} requestClose={() => setMenuAnchor(undefined)} />
+                </FocusTrap>
+              }
+            />
           )}
-        </Box>
-      </PageNavHeader>
-      {menuAnchor && (
-        <PopOut
-          anchor={menuAnchor}
-          position="Bottom"
-          align="End"
-          offset={6}
-          content={
-            <FocusTrap
-              focusTrapOptions={{
-                initialFocus: false,
-                returnFocusOnDeactivate: false,
-                onDeactivate: () => setMenuAnchor(undefined),
-                clickOutsideDeactivates: true,
-                isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
-                isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
-                escapeDeactivates: stopPropagation,
-              }}
-            >
-              <SpaceMenu room={space} requestClose={() => setMenuAnchor(undefined)} />
-            </FocusTrap>
-          }
-        />
+        </div>
+      </div>
+      {bannerURI && !hideText && (
+        <div className={css.RoomCoverContainer}>
+          <ClientSideHoverFreeze src={bannerURI} className={css.RoomCover}>
+            <img
+              className={css.RoomCoverImage}
+              src={bannerURI}
+              alt={`${spaceName}'s banner`}
+              draggable="false"
+            />
+          </ClientSideHoverFreeze>
+        </div>
       )}
     </>
   );

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -271,6 +271,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
       return cords;
     });
   };
+  const [showBanners] = useSetting(settingsAtom, 'showRoomBanners');
   const [roomBannerHeight, setRoomBannerHeight] = useSetting(settingsAtom, 'roomBannerHeight');
   const [curHeight, setCurHeight] = useState(roomBannerHeight);
   useEffect(() => {
@@ -280,7 +281,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
   const bannerState = useStateEvent(space, CustomStateEvent.RoomBanner);
   const bannerMXC = bannerState?.getContent<RoomBannerContent>()?.url;
   const bannerURI = mxcUrlToHttp(mx, bannerMXC ?? '', true);
-  const hasBanner = bannerURI && !hideText;
+  const hasBanner = bannerURI && !hideText && showBanners;
 
   return (
     <>
@@ -355,31 +356,30 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
           )}
         </div>
       </div>
-      {bannerURI && !hideText && (
+      {hasBanner && (
         <>
-        <div className={css.RoomCoverContainer} style={{height:toRem(curHeight)}}>
-          <ClientSideHoverFreeze src={bannerURI} className={css.RoomCover}>
-            <img
-              className={css.RoomCoverImage}
-              src={bannerURI}
-              alt={`${spaceName}'s banner`}
-              draggable="false"
-            />
-          </ClientSideHoverFreeze>
-        </div>
-        <SidebarResizer
-          setCurWidth={setCurHeight}
-          sidebarWidth={roomBannerHeight}
-          setSidebarWidth={setRoomBannerHeight}
-          instep={50}
-          outstep={60}
-          minValue={50}
-          maxValue={500}
-          topSided
-        />
+          <div className={css.RoomCoverContainer} style={{ height: toRem(curHeight) }}>
+            <ClientSideHoverFreeze src={bannerURI} className={css.RoomCover}>
+              <img
+                className={css.RoomCoverImage}
+                src={bannerURI}
+                alt={`${spaceName}'s banner`}
+                draggable="false"
+              />
+            </ClientSideHoverFreeze>
+          </div>
+          <SidebarResizer
+            setCurWidth={setCurHeight}
+            sidebarWidth={roomBannerHeight}
+            setSidebarWidth={setRoomBannerHeight}
+            instep={50}
+            outstep={60}
+            minValue={50}
+            maxValue={500}
+            topSided
+          />
         </>
       )}
-
     </>
   );
 }

--- a/src/app/pages/client/space/styles.css.ts
+++ b/src/app/pages/client/space/styles.css.ts
@@ -1,0 +1,40 @@
+import { style } from '@vanilla-extract/css';
+import { color, config, toRem } from 'folds';
+
+export const RoomCoverHeaderContainer = style({ width: '100%', position: 'relative' });
+export const RoomCoverNavContainer = style({
+  position: 'absolute',
+  width: '100%',
+  zIndex: '10000',
+  top: '0',
+  background: 'linear-gradient(0deg,#0000 0%, rgb(0, 0, 0) 120%)',
+});
+export const RoomCoverlessNavContainer = style({
+  flexShrink: 0,
+  padding: `${config.space.S100} ${config.space.S200} ${config.space.S200} ${config.space.S400}`,
+  borderBottom: `1px solid ${color.Background.ContainerLine}`,
+  minHeight: '100%',
+  paddingRight: 0,
+});
+
+export const RoomCoverContainer = style({
+  height: toRem(190),
+  overflow: 'hidden',
+});
+
+export const RoomCover = style({
+  height: '100%',
+  width: '100%',
+  objectFit: 'cover',
+  objectPosition: 'center',
+});
+
+export const RoomCoverFallback = style({
+  filter: 'blur(16px) brightness(50%)',
+  transform: 'scale(2)',
+});
+
+export const RoomCoverImage = style({
+  objectFit: 'cover',
+  width: '100%',
+});

--- a/src/app/pages/client/space/styles.css.ts
+++ b/src/app/pages/client/space/styles.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
-import { color, config, toRem } from 'folds';
+import { recipe } from '@vanilla-extract/recipes';
+import { color, config } from 'folds';
 
 export const RoomCoverHeaderContainer = style({ width: '100%', position: 'relative' });
 export const RoomCoverNavContainer = style({
@@ -9,16 +10,26 @@ export const RoomCoverNavContainer = style({
   top: '0',
   background: 'linear-gradient(0deg,#0000 0%, rgb(0, 0, 0) 120%)',
 });
-export const RoomCoverlessNavContainer = style({
-  flexShrink: 0,
-  padding: `${config.space.S100} ${config.space.S200} ${config.space.S200} ${config.space.S400}`,
-  borderBottom: `1px solid ${color.Background.ContainerLine}`,
-  minHeight: '100%',
-  paddingRight: 0,
+export const RoomCoverlessNavContainer = recipe({
+  base: {
+    flexShrink: 0,
+    borderBottom: `1px solid ${color.Background.ContainerLine}`,
+    minHeight: '100%',
+    paddingRight: 0,
+  },
+  variants: {
+    hideText: {
+      true: {
+        padding: `${config.space.S100} ${config.space.S200} ${config.space.S200}`,
+      },
+      false: {
+        padding: `${config.space.S100} ${config.space.S200} ${config.space.S200} ${config.space.S400}`,
+      },
+    },
+  },
 });
 
 export const RoomCoverContainer = style({
-  height: toRem(190),
   overflow: 'hidden',
 });
 

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -161,6 +161,7 @@ export interface Settings {
   showPersonaSetting: boolean;
   closeFoldersByDefault: boolean;
   showRoomIcon: ShowRoomIcon;
+  showRoomBanners: boolean;
   roomSidebarWidth: number;
   roomBannerHeight: number;
   memberSidebarWidth: number;
@@ -292,6 +293,7 @@ export const defaultSettings: Settings = {
   showPersonaSetting: false,
   closeFoldersByDefault: false,
   showRoomIcon: ShowRoomIcon.Smart,
+  showRoomBanners: true,
   roomSidebarWidth: 256,
   roomBannerHeight: 190,
   memberSidebarWidth: 262,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -162,6 +162,7 @@ export interface Settings {
   closeFoldersByDefault: boolean;
   showRoomIcon: ShowRoomIcon;
   roomSidebarWidth: number;
+  roomBannerHeight: number;
   memberSidebarWidth: number;
   threadSidebarWidth: number;
   threadRootHeight: number;
@@ -292,6 +293,7 @@ export const defaultSettings: Settings = {
   closeFoldersByDefault: false,
   showRoomIcon: ShowRoomIcon.Smart,
   roomSidebarWidth: 256,
+  roomBannerHeight: 190,
   memberSidebarWidth: 262,
   threadSidebarWidth: 440,
   threadRootHeight: 220,

--- a/src/types/matrix-sdk-events.d.ts
+++ b/src/types/matrix-sdk-events.d.ts
@@ -32,6 +32,9 @@ type RoomCosmeticsPronounsEventContent = {
   pronouns?: PronounSet[];
 };
 
+type RoomBannerContent = {
+  url?: string;
+};
 declare module 'matrix-js-sdk/lib/@types/event' {
   interface StateEvents {
     [prefix.MATRIX_UNSTABLE_STATE_ROOM_EMOTES_PROPERTY_NAME]: PackContent;
@@ -41,6 +44,7 @@ declare module 'matrix-js-sdk/lib/@types/event' {
     [prefix.MATRIX_SABLE_UNSTABLE_STATE_COSMETICS_MEMBER_FONT_PROPERTY_NAME]: RoomCosmeticsFontEventContent;
     [prefix.MATRIX_SABLE_UNSTABLE_STATE_COSMETICS_MEMBER_PRONOUNS_PROPERTY_NAME]: RoomCosmeticsPronounsEventContent;
     [prefix.MATRIX_SABLE_UNSTABLE_STATE_ROOM_ABBREVIATIONS_PROPERTY_NAME]: RoomAbbreviationsContent;
+    [prefix.MATRIX_UNSTABLE_STATE_ROOM_BANNER_PROPERTY_NAME]: RoomBannerContent;
   }
 
   interface AccountDataEvents {

--- a/src/types/matrix/room.ts
+++ b/src/types/matrix/room.ts
@@ -16,6 +16,7 @@ export const CustomStateEvent = {
   RoomCosmeticsFont: 'moe.sable.room.cosmetics.font',
   RoomCosmeticsPronouns: 'moe.sable.room.cosmetics.pronouns',
   RoomAbbreviations: 'moe.sable.room.abbreviations',
+  RoomBanner: 'page.codeberg.everypizza.room.banner',
 } as const;
 export type CustomStateEvent = (typeof CustomStateEvent)[keyof typeof CustomStateEvent];
 

--- a/src/unstable/prefixes/misc.ts
+++ b/src/unstable/prefixes/misc.ts
@@ -15,3 +15,6 @@ export const MATRIX_CINNY_UNSTABLE_STATE_ROOM_POWER_LEVELS_LABEL_PROPERTY_NAME =
 export const MATRIX_ELEMENT_UNSTABLE_ACCOUNT_RECENT_EMOJIS_PROPERTY_NAME =
   'io.element.recent_emoji';
 export const MATRIX_ELEMENT_UNSTABLE_STATE_ROOM_WIDGET_PROPERTY_NAME = 'im.vector.modular.widgets';
+
+export const MATRIX_UNSTABLE_STATE_ROOM_BANNER_PROPERTY_NAME =
+  'page.codeberg.everypizza.room.banner';


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Implements Space Banners that are resizable using the hover bar in both height and width.

Implements https://github.com/matrix-org/matrix-spec-proposals/pull/4221

(example)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c6bf0f7a-e92c-4fa3-9e0b-a5ce03645caf" />

(resizing version)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/950e06c6-a618-4be0-a819-ded01bbbd094" />

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
A nondescript bird flipped itself into providing the implementation to me