### PR TITLE
fix: show col-resize cursor on SidebarResizer

### DIFF
--- a/src/app/pages/client/sidebar/SidebarResizer.css.ts
+++ b/src/app/pages/client/sidebar/SidebarResizer.css.ts
@@ -5,6 +5,7 @@ export const SidebarResizer = style({
   width: toRem(4),
   backgroundColor: 'inherit',
   transition: '0.2s',
+  cursor: 'col-resize',
   ':hover': {},
 });
 export const SidebarResizerHover = style({


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the resize cursor not showing when trying to resize the sidebar.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

Tested, working (please excuse my weird cursor theme):
<img width="240" height="112" alt="image" src="https://github.com/user-attachments/assets/7620837b-594a-45a9-8d2a-514c7fe15d5a" />
