### PR TITLE
Allow svg images to be sent as images instead of files.

### DIFF
--- a/.changeset/fix-svg-embeds.md
+++ b/.changeset/fix-svg-embeds.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Added svgs to the allowed embeds for rendering/sending.

--- a/src/app/utils/mimeTypes.test.ts
+++ b/src/app/utils/mimeTypes.test.ts
@@ -12,6 +12,7 @@ describe('getBlobSafeMimeType', () => {
     expect(getBlobSafeMimeType('image/jpeg')).toBe('image/jpeg');
     expect(getBlobSafeMimeType('image/png')).toBe('image/png');
     expect(getBlobSafeMimeType('image/webp')).toBe('image/webp');
+    expect(getBlobSafeMimeType('image/svg+xml')).toBe('image/svg+xml');
   });
 
   it('passes through known video and audio types', () => {

--- a/src/app/utils/mimeTypes.ts
+++ b/src/app/utils/mimeTypes.ts
@@ -5,6 +5,7 @@ export const IMAGE_MIME_TYPES = [
   'image/apng',
   'image/webp',
   'image/avif',
+  'image/svg+xml',
 ];
 
 export const VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #793 

This adds svgs to the image list. SVGs are still rendered safely via \<img> tags. They only render if the other user/client also sends the svg as an image, svg file uploads do not get intercepted and rendered and are treated like normal files.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
