### PR TITLE
Fix spoilers leaking emojis and mentions

### DIFF
--- a/.changeset/fix-spoiler-hides-mentions-and-images.md
+++ b/.changeset/fix-spoiler-hides-mentions-and-images.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix spoilers not hiding nested content like mentions, emoji images, and custom-colored spans.

--- a/src/app/styles/CustomHtml.css.ts
+++ b/src/app/styles/CustomHtml.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { color, config, DefaultReset, toRem } from 'folds';
 import { ContainerColor } from './ContainerColor.css';
@@ -60,20 +60,26 @@ export const Code = style([
   },
 ]);
 
-export const Spoiler = recipe({
-  base: [
-    DefaultReset,
-    {
-      padding: `0 ${config.space.S100}`,
-      backgroundColor: color.SurfaceVariant.ContainerLine,
-      borderRadius: config.radii.R300,
-      selectors: {
-        '&[aria-pressed=true]': {
-          color: 'transparent',
-        },
+const SpoilerBase = style([
+  DefaultReset,
+  {
+    padding: `0 ${config.space.S100}`,
+    backgroundColor: color.SurfaceVariant.ContainerLine,
+    borderRadius: config.radii.R300,
+    selectors: {
+      '&[aria-pressed=true]': {
+        color: 'transparent',
       },
     },
-  ],
+  },
+]);
+
+globalStyle(`${SpoilerBase}[aria-pressed="true"] *`, {
+  visibility: 'hidden',
+});
+
+export const Spoiler = recipe({
+  base: SpoilerBase,
   variants: {
     active: {
       true: {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

At some point everything (maybe?) other than plaintext got was no longer hidden by spoilers, instead showing on top of them. This fixes that.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
