### PR TITLE
fix(emoji-board): skip displayCheck on FocusTrap activation

### DIFF
--- a/.changeset/emoji-board-focustrap.md
+++ b/.changeset/emoji-board-focustrap.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Skip displayCheck on FocusTrap activation in the emoji board to prevent focus trap errors.

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -545,6 +545,7 @@ export function EmojiBoard({
         isKeyBackward: (evt: KeyboardEvent) =>
           !editableActiveElement() && isKeyHotkey(['arrowup', 'arrowleft'], evt),
         escapeDeactivates: stopPropagation,
+        tabbableOptions: { displayCheck: 'none' },
       }}
     >
       <EmojiBoardLayout


### PR DESCRIPTION
### Description

`focus-trap` (used by the emoji board) runs a `displayCheck` by default on activation, which traverses the DOM to find tabbable elements. This can throw when elements have zero dimensions (e.g. immediately after mount before layout). Passing `displayCheck: 'none'` skips that check and lets the trap activate reliably.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The change passes a single option object to the `focus-trap` `activate()` call. Skipping the display check prevents the library from traversing the DOM for tabbable elements before the emoji board has finished layout, which was causing an activation error immediately after mount.