### PR TITLE
fix(client): show connecting banner on reconnect instead of splash screen

### DIFF
--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -175,7 +175,6 @@ type ClientRootProps = {
   children: ReactNode;
 };
 export function ClientRoot({ children }: ClientRootProps) {
-  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
   const clientConfig = useClientConfig();
   const sessions = useAtomValue(sessionsAtom);
@@ -190,6 +189,8 @@ export function ClientRoot({ children }: ClientRootProps) {
   const loadedUserIdRef = useRef<string | undefined>(undefined);
   const syncStartTimeRef = useRef(performance.now());
   const firstSyncReadyRef = useRef(false);
+
+  const [loading, setLoading] = useState(true);
 
   const [loadState, loadMatrix, setLoadState] = useAsyncCallback<MatrixClient, Error, []>(
     useCallback(async () => {
@@ -238,8 +239,8 @@ export function ClientRoot({ children }: ClientRootProps) {
       if (mx?.clientRunning) {
         stopClient(mx);
       }
-      setLoading(true);
       loadedUserIdRef.current = undefined;
+      setLoading(true);
       setLoadState({ status: AsyncStatus.Idle });
       navigate(getHomePath(), { replace: true });
     }
@@ -292,6 +293,7 @@ export function ClientRoot({ children }: ClientRootProps) {
     mx,
     useCallback((state: string) => {
       if (isClientReady(state)) {
+        setLoading(false);
         if (!firstSyncReadyRef.current) {
           firstSyncReadyRef.current = true;
           Sentry.metrics.distribution(
@@ -299,7 +301,6 @@ export function ClientRoot({ children }: ClientRootProps) {
             performance.now() - syncStartTimeRef.current
           );
         }
-        setLoading(false);
       }
     }, [])
   );
@@ -358,7 +359,7 @@ export function ClientRoot({ children }: ClientRootProps) {
     <AutoDiscovery userId={userId ?? ''} baseUrl={baseUrl ?? ''}>
       <SpecVersions baseUrl={baseUrl ?? ''}>
         {mx && <SyncStatus mx={mx} />}
-        {loading && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
+        {(loading || !mx) && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
         {(loadState.status === AsyncStatus.Error || startState.status === AsyncStatus.Error) && (
           <SplashScreen>
             <Box


### PR DESCRIPTION
Closing — consolidated into [fix/loading-ux (#829)](https://github.com/SableClient/Sable/pull/829).