### PR TITLE
fix(loading): consolidate splash-skip + connecting-banner UX fixes

### DIFF
--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -175,7 +175,6 @@ type ClientRootProps = {
   children: ReactNode;
 };
 export function ClientRoot({ children }: ClientRootProps) {
-  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
   const clientConfig = useClientConfig();
   const sessions = useAtomValue(sessionsAtom);
@@ -190,6 +189,8 @@ export function ClientRoot({ children }: ClientRootProps) {
   const loadedUserIdRef = useRef<string | undefined>(undefined);
   const syncStartTimeRef = useRef(performance.now());
   const firstSyncReadyRef = useRef(false);
+
+  const [loading, setLoading] = useState(true);
 
   const [loadState, loadMatrix, setLoadState] = useAsyncCallback<MatrixClient, Error, []>(
     useCallback(async () => {
@@ -238,8 +239,8 @@ export function ClientRoot({ children }: ClientRootProps) {
       if (mx?.clientRunning) {
         stopClient(mx);
       }
-      setLoading(true);
       loadedUserIdRef.current = undefined;
+      setLoading(true);
       setLoadState({ status: AsyncStatus.Idle });
       navigate(getHomePath(), { replace: true });
     }
@@ -303,6 +304,7 @@ export function ClientRoot({ children }: ClientRootProps) {
     mx,
     useCallback((state: string) => {
       if (isClientReady(state)) {
+        setLoading(false);
         if (!firstSyncReadyRef.current) {
           firstSyncReadyRef.current = true;
           Sentry.metrics.distribution(
@@ -310,7 +312,6 @@ export function ClientRoot({ children }: ClientRootProps) {
             performance.now() - syncStartTimeRef.current
           );
         }
-        setLoading(false);
       }
     }, [])
   );
@@ -369,7 +370,7 @@ export function ClientRoot({ children }: ClientRootProps) {
     <AutoDiscovery userId={userId ?? ''} baseUrl={baseUrl ?? ''}>
       <SpecVersions baseUrl={baseUrl ?? ''}>
         {mx && <SyncStatus mx={mx} />}
-        {loading && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
+        {(loading || !mx) && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
         {(loadState.status === AsyncStatus.Error || startState.status === AsyncStatus.Error) && (
           <SplashScreen>
             <Box

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -288,6 +288,17 @@ export function ClientRoot({ children }: ClientRootProps) {
     }
   }, [mx]);
 
+  // Once the client has started (store loaded from IndexedDB, sync loop running),
+  // hide the splash immediately if there are cached rooms — no need to wait for
+  // the first server response. The SyncStatus banner shows "Connecting..." instead.
+  useEffect(() => {
+    if (startState.status !== AsyncStatus.Success || !mx) return;
+    if (isClientReady(mx.getSyncState())) return;
+    if (mx.getRooms().length > 0) {
+      setLoading(false);
+    }
+  }, [mx, startState.status]);
+
   useSyncState(
     mx,
     useCallback((state: string) => {


### PR DESCRIPTION
Superseded by #836 — consolidated with #810, #811, #812, #813, #828 into a single mobile/iOS/iPad PR.