### PR TITLE
Perf: banners and room icons

### DIFF
--- a/.changeset/add_per_room_icon_display.md
+++ b/.changeset/add_per_room_icon_display.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add per Space setting for when to show room icons in sidebar

--- a/.changeset/fix-various-banner-fixes.md
+++ b/.changeset/fix-various-banner-fixes.md
@@ -1,0 +1,5 @@
+---
+default: fix
+---
+
+Various small banner changes

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -18,6 +18,7 @@ import {
   as,
   color,
   config,
+  toRem,
 } from 'folds';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
@@ -36,6 +37,9 @@ import { KnockRoomPrompt } from '$components/knock-room-prompt';
 import { RoomAvatar } from '$components/room-avatar';
 import { formatCompactNumber } from '$utils/formatCompactNumber';
 import * as css from './style.css';
+import type { RoomBannerContent } from '$types/matrix-sdk-events';
+import { CustomStateEvent } from '$types/matrix/room';
+import colorMXID from '$utils/colorMXID';
 
 type GridColumnCount = '1' | '2' | '3';
 const getGridColumnCount = (gridWidth: number): GridColumnCount => {
@@ -66,7 +70,6 @@ export function RoomCardGrid({ children }: { children: ReactNode }) {
 export const RoomCardBase = as<'div'>(({ className, ...props }, ref) => (
   <Box
     direction="Column"
-    gap="300"
     className={classNames(css.RoomCardBase, className)}
     {...props}
     ref={ref}
@@ -185,6 +188,11 @@ export const RoomCard = as<'div', RoomCardProps>(
       ? getRoomAvatarUrl(mx, joinedRoom, 96, useAuthentication)
       : avatarUrl && mxcUrlToHttp(mx, avatarUrl, useAuthentication, 96, 96, 'crop');
 
+    const bannerState = joinedRoom
+      ? getStateEvent(joinedRoom, CustomStateEvent.RoomBanner)
+      : undefined;
+    const bannerMXC = bannerState?.getContent<RoomBannerContent>()?.url;
+    const bannerURI = mxcUrlToHttp(mx, bannerMXC ?? '', true);
     const roomName = joinedRoom?.name || name || fallbackName;
     const roomTopic =
       (topicEvent?.getContent().topic as string) || undefined || topic || fallbackTopic;
@@ -215,11 +223,28 @@ export const RoomCard = as<'div', RoomCardProps>(
     const [viewTopic, setViewTopic] = useState(false);
     const closeTopic = () => setViewTopic(false);
     const openTopic = () => setViewTopic(true);
-
+    if (!bannerURI && !avatar)
+      // oxlint-disable-next-line no-console
+      console.log(bannerURI, avatar, roomIdOrAlias);
     return (
       <RoomCardBase {...props} ref={ref}>
-        <Box gap="200" justifyContent="SpaceBetween">
-          <Avatar size="500">
+        <Box style={{ height: toRem(120) }} direction='Column'>
+          {!bannerURI && !avatar ? (
+            <span
+              className={css.RoomCardBanner({trueBanner: false})}
+              style={{
+                backgroundColor: colorMXID(roomIdOrAlias),
+              }}
+            />
+          ) : (
+            <img
+              className={css.RoomCardBanner({trueBanner: !!bannerURI})}
+              src={bannerURI ? bannerURI : (avatar ?? undefined)}
+              alt={`${name} cover`}
+              draggable="false"
+            />
+          )}
+          <Avatar className={css.RoomCardAvatar} size="500">
             <RoomAvatar
               roomId={roomIdOrAlias}
               src={avatar ?? undefined}
@@ -231,117 +256,120 @@ export const RoomCard = as<'div', RoomCardProps>(
               )}
             />
           </Avatar>
-          {(roomType === RoomType.Space || joinedRoom?.isSpaceRoom()) && (
-            <Badge variant="Secondary" fill="Soft" outlined>
-              <Text size="L400">Space</Text>
-            </Badge>
-          )}
         </Box>
-        <Box grow="Yes" direction="Column" gap="100">
-          <RoomCardName>{roomName}</RoomCardName>
-          <RoomCardTopic onClick={openTopic} onKeyDown={onEnterOrSpace(openTopic)} tabIndex={0}>
-            {roomTopic}
-          </RoomCardTopic>
-
-          <Overlay open={viewTopic} backdrop={<OverlayBackdrop />}>
-            <OverlayCenter>
-              <FocusTrap
-                focusTrapOptions={{
-                  initialFocus: false,
-                  clickOutsideDeactivates: true,
-                  onDeactivate: closeTopic,
-                  escapeDeactivates: stopPropagation,
-                }}
-              >
-                {renderTopicViewer(roomName, roomTopic, closeTopic)}
-              </FocusTrap>
-            </OverlayCenter>
-          </Overlay>
-        </Box>
-        {typeof joinedMemberCount === 'number' && (
-          <Box gap="100">
-            <Icon size="50" src={Icons.User} />
-            <Text size="T200">{`${formatCompactNumber(joinedMemberCount)} Members`}</Text>
-          </Box>
-        )}
-        {typeof joinedRoomId === 'string' && (
-          <Button
-            onClick={onView ? () => onView(joinedRoomId) : undefined}
-            variant="Secondary"
-            fill="Soft"
-            size="300"
-          >
-            <Text size="B300" truncate>
-              View
-            </Text>
-          </Button>
-        )}
-        {typeof joinedRoomId !== 'string' &&
-          joinState.status !== AsyncStatus.Error &&
-          (joinRule === JoinRule.Knock ? (
-            <>
-              <Button onClick={() => setKnocking(true)} variant="Secondary" size="300">
-                <Text size="B300" truncate>
-                  Knock
-                </Text>
-              </Button>
-
-              {knocking && (
-                <KnockRoomPrompt
-                  roomId={roomIdOrAlias}
-                  via={viaServers}
-                  onDone={() => setKnocking(false)}
-                  onCancel={() => setKnocking(false)}
-                />
-              )}
-            </>
-          ) : (
-            <Button
-              onClick={join}
-              variant="Secondary"
-              size="300"
-              disabled={joining}
-              before={joining && <Spinner size="50" variant="Secondary" fill="Soft" />}
-            >
-              <Text size="B300" truncate>
-                {joining ? 'Joining' : 'Join'}
-              </Text>
-            </Button>
-          ))}
-        {typeof joinedRoomId !== 'string' && joinState.status === AsyncStatus.Error && (
-          <Box gap="200">
-            <Button
-              onClick={join}
-              className={css.ActionButton}
-              variant="Critical"
-              fill="Solid"
-              size="300"
-            >
-              <Text size="B300" truncate>
-                Retry
-              </Text>
-            </Button>
-            <ErrorDialog
-              title="Join Error"
-              message={joinState.error.message || 'Failed to join. Unknown Error.'}
-            >
-              {(openError) => (
-                <Button
-                  onClick={openError}
-                  className={css.ActionButton}
-                  variant="Critical"
-                  fill="Soft"
-                  outlined
-                  size="300"
+        <Box className={css.RoomCardItems} direction="Column" gap="300">
+          <Box gap="200" justifyContent="SpaceBetween">
+            <Box grow="Yes" direction="Column" gap="100">
+              <RoomCardName>{roomName}</RoomCardName>
+              <RoomCardTopic onClick={openTopic} onKeyDown={onEnterOrSpace(openTopic)} tabIndex={0}>
+                {roomTopic}
+              </RoomCardTopic>
+            </Box>
+            <Overlay open={viewTopic} backdrop={<OverlayBackdrop />}>
+              <OverlayCenter>
+                <FocusTrap
+                  focusTrapOptions={{
+                    initialFocus: false,
+                    clickOutsideDeactivates: true,
+                    onDeactivate: closeTopic,
+                    escapeDeactivates: stopPropagation,
+                  }}
                 >
+                  {renderTopicViewer(roomName, roomTopic, closeTopic)}
+                </FocusTrap>
+              </OverlayCenter>
+            </Overlay>
+            {(roomType === RoomType.Space || joinedRoom?.isSpaceRoom()) && (
+              <Badge variant="Secondary" fill="Soft" outlined>
+                <Text size="L400">Space</Text>
+              </Badge>
+            )}
+          </Box>
+          {typeof joinedMemberCount === 'number' && (
+            <Box gap="100">
+              <Icon size="50" src={Icons.User} />
+              <Text size="T200">{`${formatCompactNumber(joinedMemberCount)} Members`}</Text>
+            </Box>
+          )}
+          {typeof joinedRoomId === 'string' && (
+            <Button
+              onClick={onView ? () => onView(joinedRoomId) : undefined}
+              variant="Secondary"
+              fill="Soft"
+              size="300"
+            >
+              <Text size="B300" truncate>
+                View
+              </Text>
+            </Button>
+          )}
+          {typeof joinedRoomId !== 'string' &&
+            joinState.status !== AsyncStatus.Error &&
+            (joinRule === JoinRule.Knock ? (
+              <>
+                <Button onClick={() => setKnocking(true)} variant="Secondary" size="300">
                   <Text size="B300" truncate>
-                    View Error
+                    Knock
                   </Text>
                 </Button>
-              )}
-            </ErrorDialog>
-          </Box>
-        )}
+
+                {knocking && (
+                  <KnockRoomPrompt
+                    roomId={roomIdOrAlias}
+                    via={viaServers}
+                    onDone={() => setKnocking(false)}
+                    onCancel={() => setKnocking(false)}
+                  />
+                )}
+              </>
+            ) : (
+              <Button
+                onClick={join}
+                variant="Secondary"
+                size="300"
+                disabled={joining}
+                before={joining && <Spinner size="50" variant="Secondary" fill="Soft" />}
+              >
+                <Text size="B300" truncate>
+                  {joining ? 'Joining' : 'Join'}
+                </Text>
+              </Button>
+            ))}
+          {typeof joinedRoomId !== 'string' && joinState.status === AsyncStatus.Error && (
+            <Box gap="200">
+              <Button
+                onClick={join}
+                className={css.ActionButton}
+                variant="Critical"
+                fill="Solid"
+                size="300"
+              >
+                <Text size="B300" truncate>
+                  Retry
+                </Text>
+              </Button>
+              <ErrorDialog
+                title="Join Error"
+                message={joinState.error.message || 'Failed to join. Unknown Error.'}
+              >
+                {(openError) => (
+                  <Button
+                    onClick={openError}
+                    className={css.ActionButton}
+                    variant="Critical"
+                    fill="Soft"
+                    outlined
+                    size="300"
+                  >
+                    <Text size="B300" truncate>
+                      View Error
+                    </Text>
+                  </Button>
+                )}
+              </ErrorDialog>
+            </Box>
+          )}
+        </Box>
       </RoomCardBase>
     );
   }

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -223,22 +223,19 @@ export const RoomCard = as<'div', RoomCardProps>(
     const [viewTopic, setViewTopic] = useState(false);
     const closeTopic = () => setViewTopic(false);
     const openTopic = () => setViewTopic(true);
-    if (!bannerURI && !avatar)
-      // oxlint-disable-next-line no-console
-      console.log(bannerURI, avatar, roomIdOrAlias);
     return (
       <RoomCardBase {...props} ref={ref}>
-        <Box style={{ height: toRem(120) }} direction='Column'>
+        <Box style={{ height: toRem(120) }} direction="Column">
           {!bannerURI && !avatar ? (
             <span
-              className={css.RoomCardBanner({trueBanner: false})}
+              className={css.RoomCardBanner({ trueBanner: false })}
               style={{
                 backgroundColor: colorMXID(roomIdOrAlias),
               }}
             />
           ) : (
             <img
-              className={css.RoomCardBanner({trueBanner: !!bannerURI})}
+              className={css.RoomCardBanner({ trueBanner: !!bannerURI })}
               src={bannerURI ? bannerURI : (avatar ?? undefined)}
               alt={`${name} cover`}
               draggable="false"

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -236,7 +236,7 @@ export const RoomCard = as<'div', RoomCardProps>(
           ) : (
             <img
               className={css.RoomCardBanner({ trueBanner: !!bannerURI })}
-              src={bannerURI ? bannerURI : (avatar ?? undefined)}
+              src={bannerURI || avatar || undefined}
               alt={`${name} cover`}
               draggable="false"
             />

--- a/src/app/components/room-card/style.css.ts
+++ b/src/app/components/room-card/style.css.ts
@@ -52,7 +52,7 @@ export const RoomCardBanner = recipe({
     trueBanner: {
       true: {},
       false: {
-        filter: 'blur(40px)',
+        filter: 'blur(10px)',
       },
     },
   },

--- a/src/app/components/room-card/style.css.ts
+++ b/src/app/components/room-card/style.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css';
-import { DefaultReset, config } from 'folds';
+import { DefaultReset, color, config, toRem } from 'folds';
 import { ContainerColor } from '$styles/ContainerColor.css';
+import { recipe } from '@vanilla-extract/recipes';
 
 export const CardGrid = style({
   display: 'grid',
@@ -12,11 +13,15 @@ export const RoomCardBase = style([
   DefaultReset,
   ContainerColor({ variant: 'SurfaceVariant' }),
   {
-    padding: config.space.S500,
     borderRadius: config.radii.R500,
+    overflow: 'hidden',
   },
 ]);
 
+export const RoomCardItems = style({
+  padding: config.space.S500,
+  backgroundColor: color.SurfaceVariant.Container,
+});
 export const RoomCardTopic = style({
   minHeight: `calc(3 * ${config.lineHeight.T200})`,
   display: '-webkit-box',
@@ -33,4 +38,28 @@ export const RoomCardTopic = style({
 export const ActionButton = style({
   flex: '1 1 0',
   minWidth: 1,
+});
+
+export const RoomCardBanner = recipe({
+  base: {
+    height: toRem(96),
+    minHeight: toRem(96),
+    width: '100%',
+    objectFit: 'cover',
+    objectPosition: 'center center',
+  },
+  variants: {
+    trueBanner: {
+      true: {},
+      false: {
+        filter: 'blur(40px)',
+      },
+    },
+  },
+});
+export const RoomCardAvatar = style({
+  position: 'sticky',
+  transform: 'translateY(-50%)',
+  marginLeft: config.space.S500,
+  outline: `${config.borderWidth.B600} solid ${color.Surface.Container}`,
 });

--- a/src/app/features/common-settings/appearance/Appearance.tsx
+++ b/src/app/features/common-settings/appearance/Appearance.tsx
@@ -26,20 +26,19 @@ import { settingsAtom } from '$state/settings';
 import { stopPropagation } from '$utils/keyboard';
 import FocusTrap from 'focus-trap-react';
 
-export function SelectShowPerRoomRoomIcon({roomId}: {roomId: string}) {
+export function SelectShowPerRoomRoomIcon({ roomId }: { roomId: string }) {
   const [menuCords, setMenuCords] = useState<RectCords>();
   const showRoomIconItems = useShowPerRoomRoomIcon();
   const [showRoomIconArray, setShowRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
-  const showRoomIcon = showRoomIconArray.find(item => item.roomId === roomId )?.display;
+  const showRoomIcon = showRoomIconArray.find((item) => item.roomId === roomId)?.display;
 
   const handleMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
     setMenuCords(evt.currentTarget.getBoundingClientRect());
   };
 
   const handleSelect = (position?: ShowRoomIcon) => {
-    let newShowRoomIconArray = showRoomIconArray.filter(item => item.roomId !== roomId );
-    if(position)
-      newShowRoomIconArray = [...newShowRoomIconArray, {roomId, display: position}]
+    let newShowRoomIconArray = showRoomIconArray.filter((item) => item.roomId !== roomId);
+    if (position) newShowRoomIconArray = [...newShowRoomIconArray, { roomId, display: position }];
     setShowRoomIconArray(newShowRoomIconArray);
     setMenuCords(undefined);
   };
@@ -135,7 +134,7 @@ export function Appearance({ requestClose }: AppearanceProps) {
                   <SettingTile
                     title="Show Room Icons In Sidebar"
                     description="When do you want to show the specific room icons in the sidebar within this space?"
-                    after={<SelectShowPerRoomRoomIcon roomId={room.roomId}/>}
+                    after={<SelectShowPerRoomRoomIcon roomId={room.roomId} />}
                   />
                 </SequenceCard>
               </Box>

--- a/src/app/features/common-settings/appearance/Appearance.tsx
+++ b/src/app/features/common-settings/appearance/Appearance.tsx
@@ -30,7 +30,7 @@ export function SelectShowPerRoomRoomIcon({ roomId }: { roomId: string }) {
   const [menuCords, setMenuCords] = useState<RectCords>();
   const showRoomIconItems = useShowPerRoomRoomIcon();
   const [showRoomIconArray, setShowRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
-  const showRoomIcon = showRoomIconArray.find((item) => item.roomId === roomId)?.display;
+  const showRoomIcon = showRoomIconArray?.find((item) => item.roomId === roomId)?.display;
 
   const handleMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
     setMenuCords(evt.currentTarget.getBoundingClientRect());

--- a/src/app/features/common-settings/appearance/Appearance.tsx
+++ b/src/app/features/common-settings/appearance/Appearance.tsx
@@ -1,0 +1,147 @@
+import { useState, type MouseEventHandler } from 'react';
+import {
+  Box,
+  Text,
+  IconButton,
+  Icon,
+  Icons,
+  Scroll,
+  Button,
+  config,
+  Menu,
+  MenuItem,
+  PopOut,
+  type RectCords,
+} from 'folds';
+import { Page, PageContent, PageHeader } from '$components/page';
+import { SequenceCard } from '$components/sequence-card';
+import { SettingTile } from '$components/setting-tile';
+import { useRoom } from '$hooks/useRoom';
+
+import { SequenceCardStyle } from '$features/common-settings/styles.css';
+import { useShowRoomIcon } from '$hooks/useShowRoomIcon';
+import { useSetting } from '$state/hooks/settings';
+import type { ShowRoomIcon } from '$state/settings';
+import { settingsAtom } from '$state/settings';
+import { stopPropagation } from '$utils/keyboard';
+import FocusTrap from 'focus-trap-react';
+
+function SelectShowRoomIcon({roomId}: {roomId: string}) {
+  const [menuCords, setMenuCords] = useState<RectCords>();
+  const showRoomIconItems = useShowRoomIcon();
+  const [showRoomIconArray, setShowRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
+  const showRoomIcon = showRoomIconArray.find(item => item.roomId === roomId )?.display;
+  
+  const handleMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    setMenuCords(evt.currentTarget.getBoundingClientRect());
+  };
+
+  const handleSelect = (position: ShowRoomIcon) => {
+    const CleanedShowRoomIconArray = showRoomIconArray.filter(item => item.roomId !== roomId );
+    const newShowRoomIconArray = [...CleanedShowRoomIconArray, {roomId, display: position}]
+    setShowRoomIconArray(newShowRoomIconArray);
+    setMenuCords(undefined);
+  };
+
+  return (
+    <>
+      <Button
+        size="300"
+        variant="Secondary"
+        outlined
+        fill="Soft"
+        radii="300"
+        after={<Icon size="300" src={Icons.ChevronBottom} />}
+        onClick={handleMenu}
+      >
+        <Text size="T300">
+          {showRoomIconItems.find((i) => i.layout === showRoomIcon)?.name ?? showRoomIcon}
+        </Text>
+      </Button>
+      <PopOut
+        anchor={menuCords}
+        offset={5}
+        position="Bottom"
+        align="End"
+        content={
+          <FocusTrap
+            focusTrapOptions={{
+              initialFocus: false,
+              onDeactivate: () => setMenuCords(undefined),
+              clickOutsideDeactivates: true,
+              isKeyForward: (evt: KeyboardEvent) =>
+                evt.key === 'ArrowDown' || evt.key === 'ArrowRight',
+              isKeyBackward: (evt: KeyboardEvent) =>
+                evt.key === 'ArrowUp' || evt.key === 'ArrowLeft',
+              escapeDeactivates: stopPropagation,
+            }}
+          >
+            <Menu>
+              <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                {showRoomIconItems.map((item) => (
+                  <MenuItem
+                    key={item.layout}
+                    size="300"
+                    variant={showRoomIcon === item.layout ? 'Primary' : 'Surface'}
+                    radii="300"
+                    onClick={() => handleSelect(item.layout)}
+                  >
+                    <Text size="T300">{item.name}</Text>
+                  </MenuItem>
+                ))}
+              </Box>
+            </Menu>
+          </FocusTrap>
+        }
+      />
+    </>
+  );
+}
+
+type AppearanceProps = {
+  requestClose: () => void;
+};
+export function Appearance({ requestClose }: AppearanceProps) {
+  const room = useRoom();
+
+  return (
+    <Page>
+      <PageHeader outlined={false}>
+        <Box grow="Yes" gap="200">
+          <Box grow="Yes" alignItems="Center" gap="200">
+            <Text size="H3" truncate>
+              Appearance
+            </Text>
+          </Box>
+          <Box shrink="No">
+            <IconButton onClick={requestClose} variant="Surface">
+              <Icon src={Icons.Cross} />
+            </IconButton>
+          </Box>
+        </Box>
+      </PageHeader>
+      <Box grow="Yes">
+        <Scroll hideTrack visibility="Hover">
+          <PageContent>
+            <Box direction="Column" gap="700">
+              <Box direction="Column" gap="100">
+                <Text size="L400">Visual Tweaks</Text>
+                <SequenceCard
+                  className={SequenceCardStyle}
+                  variant="SurfaceVariant"
+                  direction="Column"
+                >
+                  <SettingTile
+                    title="Show Room Icons In Sidebar"
+                    description="When do you want to show the specific room icons in the sidebar within this space?"
+                    after={<SelectShowRoomIcon roomId={room.roomId}/>}
+                  />
+                </SequenceCard>
+              </Box>
+            </Box>
+          </PageContent>
+        </Scroll>
+      </Box>
+    </Page>
+  );
+}

--- a/src/app/features/common-settings/appearance/Appearance.tsx
+++ b/src/app/features/common-settings/appearance/Appearance.tsx
@@ -19,26 +19,27 @@ import { SettingTile } from '$components/setting-tile';
 import { useRoom } from '$hooks/useRoom';
 
 import { SequenceCardStyle } from '$features/common-settings/styles.css';
-import { useShowRoomIcon } from '$hooks/useShowRoomIcon';
+import { useShowPerRoomRoomIcon } from '$hooks/useShowRoomIcon';
 import { useSetting } from '$state/hooks/settings';
 import type { ShowRoomIcon } from '$state/settings';
 import { settingsAtom } from '$state/settings';
 import { stopPropagation } from '$utils/keyboard';
 import FocusTrap from 'focus-trap-react';
 
-function SelectShowRoomIcon({roomId}: {roomId: string}) {
+export function SelectShowPerRoomRoomIcon({roomId}: {roomId: string}) {
   const [menuCords, setMenuCords] = useState<RectCords>();
-  const showRoomIconItems = useShowRoomIcon();
+  const showRoomIconItems = useShowPerRoomRoomIcon();
   const [showRoomIconArray, setShowRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
   const showRoomIcon = showRoomIconArray.find(item => item.roomId === roomId )?.display;
-  
+
   const handleMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
     setMenuCords(evt.currentTarget.getBoundingClientRect());
   };
 
-  const handleSelect = (position: ShowRoomIcon) => {
-    const CleanedShowRoomIconArray = showRoomIconArray.filter(item => item.roomId !== roomId );
-    const newShowRoomIconArray = [...CleanedShowRoomIconArray, {roomId, display: position}]
+  const handleSelect = (position?: ShowRoomIcon) => {
+    let newShowRoomIconArray = showRoomIconArray.filter(item => item.roomId !== roomId );
+    if(position)
+      newShowRoomIconArray = [...newShowRoomIconArray, {roomId, display: position}]
     setShowRoomIconArray(newShowRoomIconArray);
     setMenuCords(undefined);
   };
@@ -134,7 +135,7 @@ export function Appearance({ requestClose }: AppearanceProps) {
                   <SettingTile
                     title="Show Room Icons In Sidebar"
                     description="When do you want to show the specific room icons in the sidebar within this space?"
-                    after={<SelectShowRoomIcon roomId={room.roomId}/>}
+                    after={<SelectShowPerRoomRoomIcon roomId={room.roomId}/>}
                   />
                 </SequenceCard>
               </Box>

--- a/src/app/features/common-settings/general/RoomProfile.tsx
+++ b/src/app/features/common-settings/general/RoomProfile.tsx
@@ -44,7 +44,7 @@ import { createUploadAtom } from '$state/upload';
 import { useFilePicker } from '$hooks/useFilePicker';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { useAlive } from '$hooks/useAlive';
-import type { RoomPermissionsAPI } from '$hooks/useRoomPermissions';
+import { type RoomPermissionsAPI } from '$hooks/useRoomPermissions';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { useStateEvent } from '$hooks/useStateEvent';
@@ -310,13 +310,18 @@ export function RoomProfileEdit({
 }
 
 export type ProfileProps = {
+  permissions: RoomPermissionsAPI;
   bannerURI?: string;
 };
-function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
+function RoomBannerEdit({ bannerURI, permissions }: Readonly<ProfileProps>) {
   const mx = useMatrixClient();
   const [alertRemove, setAlertRemove] = useState(false);
 
   const space = useRoom();
+
+  const userId = mx.getUserId() ?? '';
+  const canEdit = permissions.stateEvent(CustomStateEvent.RoomAbbreviations, userId);
+
   const [stagedUrl, setStagedUrl] = useState<string>();
   const [isRemoving, setIsRemoving] = useState(false);
 
@@ -420,6 +425,7 @@ function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
               fill="Soft"
               outlined
               radii="300"
+              disabled={!canEdit}
             >
               <Text size="B300">{bannerUrl ? 'Change Banner' : 'Upload Banner'}</Text>
             </Button>
@@ -430,6 +436,7 @@ function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
                 fill="None"
                 radii="300"
                 onClick={() => setAlertRemove(true)}
+                disabled={!canEdit}
               >
                 <Text size="B300">Remove</Text>
               </Button>
@@ -466,7 +473,7 @@ function RoomBannerEdit({ bannerURI }: Readonly<ProfileProps>) {
               </Header>
               <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
                 <Text priority="400">Are you sure you want to remove profile banner?</Text>
-                <Button variant="Critical" onClick={handleRemoveBanner}>
+                <Button variant="Critical" onClick={handleRemoveBanner} disabled={!canEdit}>
                   <Text size="B400">Remove</Text>
                 </Button>
               </Box>
@@ -585,8 +592,9 @@ export function RoomProfile({ permissions }: RoomProfileProps) {
           variant="SurfaceVariant"
           direction="Column"
           gap="400"
+          disabled={!canEdit}
         >
-          <RoomBannerEdit bannerURI={bannerURI ?? undefined} />
+          <RoomBannerEdit permissions={permissions} bannerURI={bannerURI ?? undefined} />
         </SequenceCard>
       )}
     </Box>

--- a/src/app/features/common-settings/general/RoomProfile.tsx
+++ b/src/app/features/common-settings/general/RoomProfile.tsx
@@ -320,7 +320,7 @@ function RoomBannerEdit({ bannerURI, permissions }: Readonly<ProfileProps>) {
   const space = useRoom();
 
   const userId = mx.getUserId() ?? '';
-  const canEdit = permissions.stateEvent(CustomStateEvent.RoomAbbreviations, userId);
+  const canEdit = permissions.stateEvent(CustomStateEvent.RoomBanner, userId);
 
   const [stagedUrl, setStagedUrl] = useState<string>();
   const [isRemoving, setIsRemoving] = useState(false);

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -296,8 +296,6 @@ export function MembersDrawer({ room, members }: MembersDrawerProps) {
   );
 
   const handleMemberClick: MouseEventHandler<HTMLButtonElement> = (evt) => {
-    // oxlint-disable-next-line no-console
-    console.log(evt);
     const btn = evt.currentTarget as HTMLButtonElement;
     const userId = btn.getAttribute('data-user-id');
     if (!userId) return;

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -868,7 +868,7 @@ export function Appearance({
 
             <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
               <SettingTile
-                title="Show Room Icons"
+                title="Show Room Icons In Sidebars"
                 focusId="show-room-icons"
                 description="When do you want to show the specific room icons in the sidebar as opposed to the default room icons?"
                 after={<SelectShowRoomIcon />}

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -38,6 +38,7 @@ import FocusTrap from 'focus-trap-react';
 import { useShowRoomIcon } from '$hooks/useShowRoomIcon';
 import type { PanelSizetItem } from '$hooks/usePanelSizes';
 import { usePanelSizeItems } from '$hooks/usePanelSizes';
+import { SelectShowPerRoomRoomIcon } from '$features/common-settings/appearance/Appearance';
 
 const clampIncomingInlineImageHeight = (n: number) => Math.max(1, Math.min(4096, n));
 
@@ -717,7 +718,8 @@ function SelectShowRoomIcon() {
     setMenuCords(evt.currentTarget.getBoundingClientRect());
   };
 
-  const handleSelect = (position: ShowRoomIcon) => {
+  const handleSelect = (position?: ShowRoomIcon) => {
+    if(!position) return;
     setShowRoomIcon(position);
     setMenuCords(undefined);
   };
@@ -872,6 +874,16 @@ export function Appearance({
                 focusId="show-room-icons"
                 description="When do you want to show the specific room icons in the sidebar as opposed to the default room icons?"
                 after={<SelectShowRoomIcon />}
+              />
+            </SequenceCard>
+            {/*THIS SHOULD BE MOVED TO A NEW SETTINGS MENU INSIDE OF THE HOME SETTINGS AS SOON AS THERE IS A REASON TO CREATE A HOME MENU SETTINGS PANEL
+              it is currently here because it would be eerie to have an entire home settings menu for just one single setting*/}
+            <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+              <SettingTile
+                title="Show Room Icons In Home menu sidebar"
+                focusId="show-room-home-icons"
+                description="Show Room icons in the home menu? (overrides setting above if set)"
+                after={<SelectShowPerRoomRoomIcon roomId={'Home'} />}
               />
             </SequenceCard>
 

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -719,7 +719,7 @@ function SelectShowRoomIcon() {
   };
 
   const handleSelect = (position?: ShowRoomIcon) => {
-    if(!position) return;
+    if (!position) return;
     setShowRoomIcon(position);
     setMenuCords(undefined);
   };

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -123,6 +123,7 @@ const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly string[]
     'twitter-emoji',
     'underline-links',
     'show-room-icons',
+    'show-room-home-icons',
     'sidebar-size',
     'incoming-inline-images-default-height',
     'incoming-inline-images-max-height',

--- a/src/app/features/space-settings/SpaceSettings.tsx
+++ b/src/app/features/space-settings/SpaceSettings.tsx
@@ -17,6 +17,7 @@ import { EmojisStickers } from '$features/common-settings/emojis-stickers';
 import { Members } from '$features/common-settings/members';
 import { DeveloperTools } from '$features/common-settings/developer-tools';
 import { Cosmetics } from '$features/common-settings/cosmetics/Cosmetics';
+import { Appearance } from '$features/common-settings/appearance/Appearance';
 import { RoomAbbreviations } from '$features/room-settings/abbreviations/RoomAbbreviations';
 import { General } from './general';
 import { Permissions } from './permissions';
@@ -66,6 +67,12 @@ const useSpaceSettingsMenuItems = (): SpaceSettingsMenuItem[] =>
         page: SpaceSettingsPage.DeveloperToolsPage,
         name: 'Developer Tools',
         icon: Icons.Terminal,
+      },
+      {
+        page: SpaceSettingsPage.AppearancePage,
+        name: 'Appearance',
+        icon: Icons.Alphabet,
+        activeIcon: Icons.AlphabetUnderline,
       },
     ],
     []
@@ -196,6 +203,9 @@ export function SpaceSettings({ initialPage, requestClose }: SpaceSettingsProps)
       )}
       {activePage === SpaceSettingsPage.AbbreviationsPage && (
         <RoomAbbreviations isSpace requestClose={handlePageRequestClose} />
+      )}
+      {activePage === SpaceSettingsPage.AppearancePage && (
+        <Appearance requestClose={handlePageRequestClose} />
       )}
     </PageRoot>
   );

--- a/src/app/hooks/useShowRoomIcon.ts
+++ b/src/app/hooks/useShowRoomIcon.ts
@@ -2,13 +2,36 @@ import { useMemo } from 'react';
 import { ShowRoomIcon } from '$state/settings';
 
 export type MessageLayoutItem = {
+  layout?: ShowRoomIcon;
   name: string;
-  layout: ShowRoomIcon;
 };
 
 export const useShowRoomIcon = (): MessageLayoutItem[] =>
   useMemo(
     () => [
+      {
+        layout: ShowRoomIcon.Always,
+        name: 'Always',
+      },
+      {
+        layout: ShowRoomIcon.Smart,
+        name: 'Smart',
+      },
+      {
+        layout: ShowRoomIcon.Never,
+        name: 'Never',
+      },
+    ],
+    []
+  );
+
+export const useShowPerRoomRoomIcon = (): MessageLayoutItem[] =>
+  useMemo(
+    () => [
+      {
+        layout: undefined,
+        name: 'Default',
+      },
       {
         layout: ShowRoomIcon.Always,
         name: 'Always',

--- a/src/app/pages/client/direct/Direct.tsx
+++ b/src/app/pages/client/direct/Direct.tsx
@@ -338,6 +338,7 @@ export function Direct() {
                                   width: '100%',
                                   aspectRatio: 1,
                                   display: 'flex',
+                                  flexDirection: 'column',
                                 }
                               : {}
                           }

--- a/src/app/pages/client/home/Home.tsx
+++ b/src/app/pages/client/home/Home.tsx
@@ -427,6 +427,7 @@ export function Home() {
                                   width: '100%',
                                   aspectRatio: 1,
                                   display: 'flex',
+                                  flexDirection: 'column',
                                 }
                               : {}
                           }

--- a/src/app/pages/client/home/Home.tsx
+++ b/src/app/pages/client/home/Home.tsx
@@ -213,16 +213,20 @@ export function Home() {
 
   const [roomSidebarWidth, setRoomSidebarWidth] = useSetting(settingsAtom, 'roomSidebarWidth');
   const [curWidth, setCurWidth] = useState(roomSidebarWidth);
-
-  const [showRoomIcon] = useSetting(settingsAtom, 'showRoomIcon');
-  const showIcons = () => {
-    if (showRoomIcon === ShowRoomIcon.Always) return true;
-    if (showRoomIcon === ShowRoomIcon.Never) return false;
-    return curWidth < 96;
-  };
   useEffect(() => {
     setCurWidth(roomSidebarWidth);
   }, [roomSidebarWidth]);
+
+  const [showRoomIconGeneral] = useSetting(settingsAtom, 'showRoomIcon');
+  const [showRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
+  const showRoomIcon =
+    showRoomIconArray.find((item) => item.roomId === 'Home')?.display ?? showRoomIconGeneral;
+  const showIcons = () => {
+    if (showRoomIcon === ShowRoomIcon.Always) return true;
+    if (showRoomIcon === ShowRoomIcon.Never) return false;
+    return curWidth < 144;
+  };
+
   const [joinCallOnSingleClick] = useSetting(settingsAtom, 'joinCallOnSingleClick');
 
   const selectedRoomId = useSelectedRoom();

--- a/src/app/pages/client/sidebar/SidebarResizer.css.ts
+++ b/src/app/pages/client/sidebar/SidebarResizer.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
-import { color } from 'folds';
+import { recipe } from '@vanilla-extract/recipes';
+import { color, toRem } from 'folds';
 
 /** Out-of-flow so flex siblings (e.g. PageRoot vertical Line) stay flush with the panel edge. */
 export const SidebarResizerDockRight = style({
@@ -29,17 +30,33 @@ export const SidebarResizerDockTop = style({
   cursor: 'ns-resize',
 });
 
-export const SidebarResizer = style({
-  backgroundColor: 'inherit',
-  transition: '0.2s',
-  ':hover': {},
+export const SidebarResizer = recipe({
+  base: {
+    backgroundColor: 'inherit',
+    transition: '0.2s',
+    ':hover': {},
+    touchAction: 'none',
+  },
+  variants: {
+    topSided: {
+      true: {
+        width: '100%',
+        height: toRem(8),
+      },
+      false: {
+        width: toRem(4),
+        height: '100%',
+      },
+    },
+  },
 });
 export const SidebarResizerHover = style({
-  zIndex: 100,
+  zIndex: 110,
 });
 export const SideBarResizerAnimation = style({
   width: '100%',
   height: '100%',
   backgroundColor: color.Surface.ContainerLine,
   transition: '0.5s',
+  touchAction: 'none',
 });

--- a/src/app/pages/client/sidebar/SidebarResizer.tsx
+++ b/src/app/pages/client/sidebar/SidebarResizer.tsx
@@ -1,6 +1,6 @@
 // The disable is because the position should only update whenever the new one is updated
 // oxlint-disable eslint-plugin-react-hooks/exhaustive-deps
-import { Box, toRem } from 'folds';
+import { Box } from 'folds';
 import * as css from '$pages/client/sidebar/SidebarResizer.css';
 import type { Dispatch, SetStateAction } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -64,6 +64,7 @@ export function SidebarResizer({
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
       e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
       setOldPos(topSided ? e.clientY : e.clientX);
       setIsPointerDown(true);
       window.addEventListener('pointerup', onPointerUp);
@@ -80,14 +81,10 @@ export function SidebarResizer({
 
   return (
     <Box
-      className={`${css.SidebarResizer} ${dockClass} ${isPointerOver || isPointerDown ? css.SidebarResizerHover : ''}`}
+      className={`${css.SidebarResizer({ topSided: !!topSided })} ${dockClass} ${isPointerOver || isPointerDown ? css.SidebarResizerHover : ''}`}
       onPointerEnter={() => setIsPointerOver(true)}
       onPointerLeave={() => setIsPointerOver(false)}
       onPointerDown={onPointerDown}
-      style={{
-        width: topSided ? '100%' : toRem(4),
-        height: topSided ? toRem(4) : '100%',
-      }}
       shrink="No"
     >
       <Box

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -527,6 +527,8 @@ export function Space() {
   const [showRoomIconGeneral] = useSetting(settingsAtom, 'showRoomIcon');
   const [showRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
   const showRoomIcon = showRoomIconArray.find(item => item.roomId === space.roomId )?.display ?? showRoomIconGeneral;
+  // oxlint-disable-next-line no-console
+  console.log(showRoomIconArray, space.roomId);
   const showIcons = () => {
     if (showRoomIcon === ShowRoomIcon.Always) return true;
     if (showRoomIcon === ShowRoomIcon.Never) return false;

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -526,9 +526,8 @@ export function Space() {
 
   const [showRoomIconGeneral] = useSetting(settingsAtom, 'showRoomIcon');
   const [showRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
-  const showRoomIcon = showRoomIconArray.find(item => item.roomId === space.roomId )?.display ?? showRoomIconGeneral;
-  // oxlint-disable-next-line no-console
-  console.log(showRoomIconArray, space.roomId);
+  const showRoomIcon =
+    showRoomIconArray.find((item) => item.roomId === space.roomId)?.display ?? showRoomIconGeneral;
   const showIcons = () => {
     if (showRoomIcon === ShowRoomIcon.Always) return true;
     if (showRoomIcon === ShowRoomIcon.Never) return false;

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -372,7 +372,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
       </div>
       {hasBanner && (
         <>
-          <div className={css.RoomCoverContainer} style={{ height: toRem(curHeight) }}>
+          <Box shrink="No" className={css.RoomCoverContainer} style={{ height: toRem(curHeight) }}>
             <ClientSideHoverFreeze src={bannerURI} className={css.RoomCover}>
               <img
                 className={css.RoomCoverImage}
@@ -401,7 +401,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
                 topSided
               />
             </ClientSideHoverFreeze>
-          </div>
+          </Box>
         </>
       )}
       {hasBanner && bannerViewerOpen && (
@@ -521,10 +521,15 @@ export function Space() {
   const [roomSidebarWidth, setRoomSidebarWidth] = useSetting(settingsAtom, 'roomSidebarWidth');
   const [curWidth, setCurWidth] = useState(roomSidebarWidth);
 
-  const [showRoomIcon] = useSetting(settingsAtom, 'showRoomIcon');
+  const [showRoomIconGeneral] = useSetting(settingsAtom, 'showRoomIcon');
+
+  const [showRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
+  // oxlint-disable-next-line no-console
+  console.log(showRoomIconArray, space.roomId);
+
   const showIcons = () => {
-    if (showRoomIcon === ShowRoomIcon.Always) return true;
-    if (showRoomIcon === ShowRoomIcon.Never) return false;
+    if (showRoomIconGeneral === ShowRoomIcon.Always) return true;
+    if (showRoomIconGeneral === ShowRoomIcon.Never) return false;
     return curWidth < 144;
   };
   useEffect(() => {

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -520,21 +520,18 @@ export function Space() {
 
   const [roomSidebarWidth, setRoomSidebarWidth] = useSetting(settingsAtom, 'roomSidebarWidth');
   const [curWidth, setCurWidth] = useState(roomSidebarWidth);
-
-  const [showRoomIconGeneral] = useSetting(settingsAtom, 'showRoomIcon');
-
-  const [showRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
-  // oxlint-disable-next-line no-console
-  console.log(showRoomIconArray, space.roomId);
-
-  const showIcons = () => {
-    if (showRoomIconGeneral === ShowRoomIcon.Always) return true;
-    if (showRoomIconGeneral === ShowRoomIcon.Never) return false;
-    return curWidth < 144;
-  };
   useEffect(() => {
     setCurWidth(roomSidebarWidth);
   }, [roomSidebarWidth]);
+
+  const [showRoomIconGeneral] = useSetting(settingsAtom, 'showRoomIcon');
+  const [showRoomIconArray] = useSetting(settingsAtom, 'perRoomShowRoomIcon');
+  const showRoomIcon = showRoomIconArray.find(item => item.roomId === space.roomId )?.display ?? showRoomIconGeneral;
+  const showIcons = () => {
+    if (showRoomIcon === ShowRoomIcon.Always) return true;
+    if (showRoomIcon === ShowRoomIcon.Never) return false;
+    return curWidth < 144;
+  };
   const [joinCallOnSingleClick] = useSetting(settingsAtom, 'joinCallOnSingleClick');
 
   const tombstoneEvent = useStateEvent(space, EventType.RoomTombstone);

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -1020,6 +1020,7 @@ export function Space() {
                                 width: '100%',
                                 aspectRatio: 1,
                                 display: 'flex',
+                                flexDirection: 'column',
                               }
                             : { paddingLeft }
                         }

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -28,6 +28,11 @@ export enum ShowRoomIcon {
   Smart = 'smart',
   Never = 'never',
 }
+export type PerRoomShowRoomIcon = {
+  roomId: string;
+  display: ShowRoomIcon;
+};
+
 export type JumboEmojiSize = 'none' | 'extraSmall' | 'small' | 'normal' | 'large' | 'extraLarge';
 
 export type ThemeRemoteFavorite = {
@@ -160,6 +165,7 @@ export interface Settings {
   mentionInReplies: boolean;
   showPersonaSetting: boolean;
   closeFoldersByDefault: boolean;
+  perRoomShowRoomIcon: PerRoomShowRoomIcon[];
   showRoomIcon: ShowRoomIcon;
   showRoomBanners: boolean;
   roomSidebarWidth: number;
@@ -292,6 +298,7 @@ export const defaultSettings: Settings = {
   mentionInReplies: true,
   showPersonaSetting: false,
   closeFoldersByDefault: false,
+  perRoomShowRoomIcon: [],
   showRoomIcon: ShowRoomIcon.Smart,
   showRoomBanners: true,
   roomSidebarWidth: 256,

--- a/src/app/state/spaceSettings.ts
+++ b/src/app/state/spaceSettings.ts
@@ -9,6 +9,7 @@ export enum SpaceSettingsPage {
   // Sable pages
   CosmeticsPage,
   AbbreviationsPage,
+  AppearancePage,
 }
 
 export type SpaceSettingsState = {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Add settings for rooms icons showing for every space with the default leaving it up to the general setting for icons showing, and the rest overriding it:
<img width="823" height="697" alt="image" src="https://github.com/user-attachments/assets/7dd3255d-e483-4545-99fc-e14066a867a5" />

For the Room currently it will be present inside of the 
<img width="810" height="695" alt="image" src="https://github.com/user-attachments/assets/061d1c84-a1f6-4e3e-a216-77db96ef4063" />

It also adds styling to the RoomCard using the banner in preparation of maybe when it might happen that the associated MSC gets merged into the spec (as it stands it only works with rooms you are already a member of as it is stored as a regular state event)
<img width="993" height="1064" alt="image" src="https://github.com/user-attachments/assets/ed6ac35d-fa28-4292-a1bb-f4fd883a2035" />

And it also increases the size of the Vertical resizer bar as they are the ones that are possible to be seen on mobile and it helps with gripping them, and separated them into classes better so it might be more easily changeable with a tweak if so desired.
<img width="536" height="535" alt="image" src="https://github.com/user-attachments/assets/69661a59-9727-4ced-b165-27afb29c751a" />

Lastly it fixes the banner buttons previously being enabled when the user is missing the permissions to edit the room banner

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Caine (the AI from TADC) gave me swappable parts and trapped me into a circus if that counts as assistance!