### PR TITLE
feat(keyboard): Ctrl+Alt+Up/Down to cycle editable messages

### DIFF
--- a/.changeset/edit-message-keybind.md
+++ b/.changeset/edit-message-keybind.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add Ctrl+Alt+Up/Down keyboard shortcuts to cycle through editable messages.

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -61,9 +61,7 @@ export function GlobalKeyboardShortcuts() {
   const setReplyDraft = useSetAtom(replyDraftAtomFamily);
 
   const setEditNavRequest = useSetAtom(
-    currentRoom?.roomId
-      ? roomIdToEditNavRequestAtomFamily(currentRoom.roomId)
-      : _noopEditNavAtom
+    currentRoom?.roomId ? roomIdToEditNavRequestAtomFamily(currentRoom.roomId) : _noopEditNavAtom
   );
   const editNavNonceRef = useRef(0);
 

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -2,10 +2,10 @@
  * Global keyboard shortcuts for navigation and accessibility.
  *
  * Shortcuts provided:
- *   Alt+N              — jump to the highest-priority unread room
- *   Alt+Shift+Down     — cycle forward through unread rooms
- *   Alt+Shift+Up       — cycle backward through unread rooms
- *   Ctrl+Down / Ctrl+Up: cycle through messages to reply to
+ *   Alt+N                  — jump to the highest-priority unread room
+ *   Alt+Shift+Down/Up      — cycle forward/backward through unread rooms
+ *   Ctrl+Down / Ctrl+Up    — cycle through messages to reply to
+ *   Ctrl+Alt+Down/Up       — cycle through your own messages to edit
  */
 import { useCallback, useRef } from 'react';
 import { useNavigate, useLocation, matchPath } from 'react-router-dom';
@@ -20,7 +20,10 @@ import { getDirectRoomPath, getHomeRoomPath, getSpaceRoomPath } from '$pages/pat
 import { HOME_ROOM_PATH, DIRECT_ROOM_PATH, SPACE_ROOM_PATH } from '$pages/paths';
 import { getCanonicalAliasOrRoomId } from '$utils/matrix';
 import { announce } from '$utils/announce';
-import { roomIdToReplyDraftAtomFamily } from '$state/room/roomInputDrafts';
+import {
+  roomIdToReplyDraftAtomFamily,
+  roomIdToEditNavRequestAtomFamily,
+} from '$state/room/roomInputDrafts';
 import type { Room } from '$types/matrix-sdk';
 
 export function GlobalKeyboardShortcuts() {
@@ -51,6 +54,9 @@ export function GlobalKeyboardShortcuts() {
   const replyDraftAtomFamily = roomIdToReplyDraftAtomFamily(currentRoom?.roomId ?? '');
   const replyDraft = useAtomValue(replyDraftAtomFamily);
   const setReplyDraft = useSetAtom(replyDraftAtomFamily);
+
+  const setEditNavRequest = useSetAtom(roomIdToEditNavRequestAtomFamily(currentRoom?.roomId ?? ''));
+  const editNavNonceRef = useRef(0);
 
   /** Navigate to a room by ID and announce it to screen readers. */
   const navigateToRoom = useCallback(
@@ -151,9 +157,24 @@ export function GlobalKeyboardShortcuts() {
     [currentRoom, replyDraft, setReplyDraft]
   );
 
+  /** Ctrl+Alt+Down / Ctrl+Alt+Up: cycle through the current user's editable messages. */
+  const handleEditKeyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      const isDown = isKeyHotkey('mod+alt+down', evt);
+      const isUp = isKeyHotkey('mod+alt+up', evt);
+      if (!isDown && !isUp) return;
+      if (currentRoom === null) return;
+      evt.preventDefault();
+      editNavNonceRef.current += 1;
+      setEditNavRequest({ dir: isDown ? 'next' : 'prev', nonce: editNavNonceRef.current });
+    },
+    [currentRoom, setEditNavRequest]
+  );
+
   useKeyDown(window, handleNextUnreadKeyDown);
   useKeyDown(window, handleUnreadNavKeyDown);
   useKeyDown(window, handleReplyKeyDown);
+  useKeyDown(window, handleEditKeyDown);
 
   return null;
 }

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -9,7 +9,7 @@
  */
 import { useCallback, useRef } from 'react';
 import { useNavigate, useLocation, matchPath } from 'react-router-dom';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom, atom } from 'jotai';
 import { isKeyHotkey } from 'is-hotkey';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { roomToParentsAtom } from '$state/room/roomToParents';
@@ -23,8 +23,13 @@ import { announce } from '$utils/announce';
 import {
   roomIdToReplyDraftAtomFamily,
   roomIdToEditNavRequestAtomFamily,
+  type IEditNavRequest,
 } from '$state/room/roomInputDrafts';
 import type { Room } from '$types/matrix-sdk';
+
+// Stable fallback atom used when no room is active — prevents atomFamily from
+// creating a spurious entry under the empty-string key ''.
+const _noopEditNavAtom = atom<IEditNavRequest | undefined>(undefined);
 
 export function GlobalKeyboardShortcuts() {
   const navigate = useNavigate();
@@ -55,7 +60,11 @@ export function GlobalKeyboardShortcuts() {
   const replyDraft = useAtomValue(replyDraftAtomFamily);
   const setReplyDraft = useSetAtom(replyDraftAtomFamily);
 
-  const setEditNavRequest = useSetAtom(roomIdToEditNavRequestAtomFamily(currentRoom?.roomId ?? ''));
+  const setEditNavRequest = useSetAtom(
+    currentRoom?.roomId
+      ? roomIdToEditNavRequestAtomFamily(currentRoom.roomId)
+      : _noopEditNavAtom
+  );
   const editNavNonceRef = useRef(0);
 
   /** Navigate to a room by ID and announce it to screen readers. */

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'react';
 import type { Editor } from 'slate';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useAtom, useSetAtom } from 'jotai';
 import type { Room } from '$types/matrix-sdk';
 import { PushProcessor, Direction } from '$types/matrix-sdk';
 import classNames from 'classnames';
@@ -45,7 +45,7 @@ import {
   factoryRenderLinkifyWithMention,
 } from '$plugins/react-custom-html-parser';
 import { today, yesterday, timeDayMonthYear } from '$utils/time';
-import { unwrapRelationJumpTarget } from '$utils/room';
+import { unwrapRelationJumpTarget, canEditEvent } from '$utils/room';
 import { useMemberEventParser } from '$hooks/useMemberEventParser';
 import { usePowerLevelsContext } from '$hooks/usePowerLevels';
 import { useRoomCreators } from '$hooks/useRoomCreators';
@@ -825,18 +825,17 @@ export function RoomTimeline({
   const handleEditRef = useRef(handleEdit);
   handleEditRef.current = handleEdit;
 
-  const editNavRequest = useAtomValue(roomIdToEditNavRequestAtomFamily(room.roomId));
+  const [editNavRequest, setEditNavRequest] = useAtom(roomIdToEditNavRequestAtomFamily(room.roomId));
 
   useEffect(() => {
     if (!editNavRequest) return;
-    const myUserId = mx.getUserId();
     const editableEvents = processedEventsRef.current.filter(
-      (e) =>
-        e.mEvent.getSender() === myUserId &&
-        e.mEvent.getType() === 'm.room.message' &&
-        !e.mEvent.isRedacted()
+      (e) => !e.mEvent.isRedacted() && canEditEvent(mx, e.mEvent)
     );
-    if (editableEvents.length === 0) return;
+    if (editableEvents.length === 0) {
+      setEditNavRequest(undefined);
+      return;
+    }
 
     const currentEditId = editIdRef.current;
     const doHandleEdit = handleEditRef.current;
@@ -846,6 +845,7 @@ export function RoomTimeline({
       const latest = editableEvents.at(-1)!;
       const id = latest.mEvent.getId();
       if (id) doHandleEdit(id);
+      setEditNavRequest(undefined);
       return;
     }
 
@@ -854,10 +854,11 @@ export function RoomTimeline({
       editNavRequest.dir === 'prev'
         ? editableEvents[currentIdx - 1]
         : editableEvents[currentIdx + 1];
+    setEditNavRequest(undefined);
     if (!next) return;
     const id = next.mEvent.getId();
     if (id) doHandleEdit(id);
-  }, [editNavRequest, mx]);
+  }, [editNavRequest, mx, setEditNavRequest]);
 
   useEffect(() => {
     const v = vListRef.current;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -67,7 +67,10 @@ import { useRoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
 import { buildAbbrReplaceTextNode } from '$components/message/RenderBody';
 import { profilesCacheAtom } from '$state/userRoomProfile';
 import { roomToParentsAtom } from '$state/room/roomToParents';
-import { roomIdToReplyDraftAtomFamily } from '$state/room/roomInputDrafts';
+import {
+  roomIdToReplyDraftAtomFamily,
+  roomIdToEditNavRequestAtomFamily,
+} from '$state/room/roomInputDrafts';
 import { roomIdToOpenThreadAtomFamily } from '$state/room/roomToOpenThread';
 import {
   getRoomUnreadInfo,
@@ -815,6 +818,46 @@ export function RoomTimeline({
       if (found?.mEvent.getId()) actions.handleEdit(found.mEvent.getId());
     };
   }, [onEditLastMessageRef, mx, actions]);
+
+  // Keep stable refs so the edit-nav effect below doesn't stale-close over them.
+  const editIdRef = useRef(editId);
+  editIdRef.current = editId;
+  const handleEditRef = useRef(handleEdit);
+  handleEditRef.current = handleEdit;
+
+  const editNavRequest = useAtomValue(roomIdToEditNavRequestAtomFamily(room.roomId));
+
+  useEffect(() => {
+    if (!editNavRequest) return;
+    const myUserId = mx.getUserId();
+    const editableEvents = processedEventsRef.current.filter(
+      (e) =>
+        e.mEvent.getSender() === myUserId &&
+        e.mEvent.getType() === 'm.room.message' &&
+        !e.mEvent.isRedacted()
+    );
+    if (editableEvents.length === 0) return;
+
+    const currentEditId = editIdRef.current;
+    const doHandleEdit = handleEditRef.current;
+
+    if (currentEditId === undefined) {
+      // No active edit — start at the most recent editable message.
+      const latest = editableEvents.at(-1)!;
+      const id = latest.mEvent.getId();
+      if (id) doHandleEdit(id);
+      return;
+    }
+
+    const currentIdx = editableEvents.findIndex((e) => e.mEvent.getId() === currentEditId);
+    const next =
+      editNavRequest.dir === 'prev'
+        ? editableEvents[currentIdx - 1]
+        : editableEvents[currentIdx + 1];
+    if (!next) return;
+    const id = next.mEvent.getId();
+    if (id) doHandleEdit(id);
+  }, [editNavRequest, mx]);
 
   useEffect(() => {
     const v = vListRef.current;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -825,7 +825,9 @@ export function RoomTimeline({
   const handleEditRef = useRef(handleEdit);
   handleEditRef.current = handleEdit;
 
-  const [editNavRequest, setEditNavRequest] = useAtom(roomIdToEditNavRequestAtomFamily(room.roomId));
+  const [editNavRequest, setEditNavRequest] = useAtom(
+    roomIdToEditNavRequestAtomFamily(room.roomId)
+  );
 
   useEffect(() => {
     if (!editNavRequest) return;

--- a/src/app/state/room/roomInputDrafts.ts
+++ b/src/app/state/room/roomInputDrafts.ts
@@ -58,3 +58,11 @@ export type TReplyDraftAtom = ReturnType<typeof createReplyDraftAtom>;
 export const roomIdToReplyDraftAtomFamily = atomFamily<string, TReplyDraftAtom>(() =>
   createReplyDraftAtom()
 );
+
+/** Navigation request written by GlobalKeyboardShortcuts, consumed by RoomTimeline. */
+export type IEditNavRequest = { dir: 'prev' | 'next'; nonce: number };
+const createEditNavRequestAtom = () => atom<IEditNavRequest | undefined>(undefined);
+export type TEditNavRequestAtom = ReturnType<typeof createEditNavRequestAtom>;
+export const roomIdToEditNavRequestAtomFamily = atomFamily<string, TEditNavRequestAtom>(() =>
+  createEditNavRequestAtom()
+);


### PR DESCRIPTION
### Description

Add keyboard shortcuts (Ctrl+Alt+Up / Ctrl+Alt+Down) to cycle through the current user's recent editable messages in the active room, without needing to reach for the mouse.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

A `keydown` listener intercepts `Ctrl+Alt+ArrowUp` and `Ctrl+Alt+ArrowDown`, filters the room timeline for `m.room.message` events sent by the local user that are within the editable window, and walks a cursor index through that filtered list. The selected event ID is passed to the existing edit-message handler.