### PR TITLE
fix(mobile): sync resume, iOS layout, and connecting banner fixes

### DIFF
--- a/.changeset/mobile.md
+++ b/.changeset/mobile.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix iOS sync resume, network latency retries, iPad layout, and connecting banner during fast-path sync. Add missing items to mobile long-press message menu; fix bookmark toggle and iOS keyboard cover.

--- a/docs/MOBILE_FIXES.md
+++ b/docs/MOBILE_FIXES.md
@@ -7,12 +7,14 @@ This document tracks mobile-specific issues that need to be addressed in `feat/m
 **Problem**: Sometimes when opening/closing the keyboard on iOS, the jump to present button is displayed incorrectly.
 
 **Root Cause**:
+
 - iOS viewport height changes when keyboard appears/disappears
 - Virtual keyboard causes viewport resize events
 - Timeline scroll position calculation doesn't account for keyboard state
 - Jump button visibility logic triggers on viewport changes
 
 **Proposed Fix**:
+
 - Detect iOS virtual keyboard state changes
 - Exclude keyboard-triggered viewport changes from jump button logic
 - Use `visualViewport` API instead of window.innerHeight on iOS
@@ -20,12 +22,14 @@ This document tracks mobile-specific issues that need to be addressed in `feat/m
 - Store keyboard state and ignore scroll position during keyboard animation
 
 **Implementation Notes**:
+
 - Use `window.visualViewport.height` vs `window.innerHeight` to detect keyboard
 - Listen to `visualViewport` resize events
 - Add keyboard state to timeline context
 - Filter out scroll events during keyboard animation (~300ms)
 
 **Related Files**:
+
 - Timeline scroll handling
 - Jump to present button logic
 - iOS-specific viewport handling

--- a/docs/MOBILE_FIXES.md
+++ b/docs/MOBILE_FIXES.md
@@ -1,0 +1,31 @@
+# Mobile UX Fixes
+
+This document tracks mobile-specific issues that need to be addressed in `feat/mobile`.
+
+## Issue #9: iOS keyboard show/hide triggers jump button
+
+**Problem**: Sometimes when opening/closing the keyboard on iOS, the jump to present button is displayed incorrectly.
+
+**Root Cause**:
+- iOS viewport height changes when keyboard appears/disappears
+- Virtual keyboard causes viewport resize events
+- Timeline scroll position calculation doesn't account for keyboard state
+- Jump button visibility logic triggers on viewport changes
+
+**Proposed Fix**:
+- Detect iOS virtual keyboard state changes
+- Exclude keyboard-triggered viewport changes from jump button logic
+- Use `visualViewport` API instead of window.innerHeight on iOS
+- Debounce jump button visibility checks during keyboard transitions
+- Store keyboard state and ignore scroll position during keyboard animation
+
+**Implementation Notes**:
+- Use `window.visualViewport.height` vs `window.innerHeight` to detect keyboard
+- Listen to `visualViewport` resize events
+- Add keyboard state to timeline context
+- Filter out scroll events during keyboard animation (~300ms)
+
+**Related Files**:
+- Timeline scroll handling
+- Jump to present button logic
+- iOS-specific viewport handling

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, interactive-widget=resizes-content"
+    />
     <title>Sable Client</title>
     <meta name="name" content="Sable" />
     <meta name="author" content="7w1" />

--- a/index.html
+++ b/index.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, interactive-widget=resizes-content, viewport-fit=cover"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <title>Sable Client</title>
     <meta name="name" content="Sable" />
     <meta name="author" content="7w1" />

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, interactive-widget=resizes-content, viewport-fit=cover"
     />
     <title>Sable Client</title>
     <meta name="name" content="Sable" />

--- a/src/app/components/SwipeableChatWrapper.tsx
+++ b/src/app/components/SwipeableChatWrapper.tsx
@@ -44,8 +44,8 @@ export function SwipeableChatWrapper({
       if (active) {
         x.set(val);
       } else {
-        const swipeThreshold = 120;
-        const velocityThreshold = 0.5;
+        const swipeThreshold = 180;
+        const velocityThreshold = 1.2;
 
         if (val > swipeThreshold || (vx > velocityThreshold && dx > 0 && val > 0)) {
           onOpenSidebar?.();

--- a/src/app/components/SwipeableMessageWrapper.tsx
+++ b/src/app/components/SwipeableMessageWrapper.tsx
@@ -18,9 +18,9 @@ function ActiveSwipeWrapper({ children, onReply }: { children: ReactNode; onRepl
       if (active) {
         const val = mx < 0 ? mx : 0;
         x.set(Math.max(-80, val));
-        if (mx < -50 !== isReady) setIsReady(mx < -50);
+        if (mx < -80 !== isReady) setIsReady(mx < -80);
       } else {
-        if (mx < -50) onReply();
+        if (mx < -80) onReply();
         x.set(0);
         setIsReady(false);
       }

--- a/src/app/components/SwipeableOverlayWrapper.tsx
+++ b/src/app/components/SwipeableOverlayWrapper.tsx
@@ -40,8 +40,8 @@ export function SwipeableOverlayWrapper({
       if (active) {
         x.set(val);
       } else {
-        const swipeThreshold = 100;
-        const velocityThreshold = 0.5;
+        const swipeThreshold = 150;
+        const velocityThreshold = 1.2;
 
         const swipedLeft =
           direction === 'left' && (val < -swipeThreshold || (vx > velocityThreshold && dx < 0));

--- a/src/app/components/editor/Editor.css.ts
+++ b/src/app/components/editor/Editor.css.ts
@@ -65,6 +65,9 @@ export const EditorTextarea = style([
   {
     flexGrow: 1,
     height: 'auto',
+    // Detect text direction per-keystroke so RTL text right-aligns automatically.
+    // Matches the unicodeBidi: 'plaintext' pattern used by MessageTextBody.
+    unicodeBidi: 'plaintext',
     padding: `${toRem(13)} 0 0`,
     selectors: {
       [`${EditorTextareaScroll}:first-child &`]: {

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -2,7 +2,7 @@ import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode } from 'rea
 import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Box, Scroll, Text } from 'folds';
 import type { Descendant, Editor } from 'slate';
-import { Node, createEditor } from 'slate';
+import { Node, Transforms, createEditor } from 'slate';
 import type { RenderLeafProps, RenderElementProps, RenderPlaceholderProps } from 'slate-react';
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
 import { withHistory } from 'slate-history';
@@ -445,6 +445,17 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                 // keeps focus after pressing send.
                 onBlur={() => {
                   if (mobileOrTablet()) ReactEditor.focus(editor);
+                }}
+                // iOS Slate.js bug: an empty contenteditable doesn't signal
+                // "start of sentence" to autocapitalize. A no-op text
+                // round-trip primes the input context on focus.
+                onFocus={() => {
+                  if (!mobileOrTablet()) return;
+                  requestAnimationFrame(() => {
+                    if (!ReactEditor.isFocused(editor) || Node.string(editor).length > 0) return;
+                    Transforms.insertText(editor, '\u00a0');
+                    Transforms.delete(editor, { reverse: true });
+                  });
                 }}
               />
             </Scroll>

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -447,14 +447,18 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                   if (mobileOrTablet()) ReactEditor.focus(editor);
                 }}
                 // iOS Slate.js bug: an empty contenteditable doesn't signal
-                // "start of sentence" to autocapitalize. A no-op text
-                // round-trip primes the input context on focus.
+                // "start of sentence" to autocapitalize. A two-frame round-trip
+                // (insert space, then delete it one frame later) lets iOS process
+                // the intermediate "has text" state before seeing the empty field
+                // again — this is what triggers sentence-case on the next keystroke.
                 onFocus={() => {
                   if (!mobileOrTablet()) return;
                   requestAnimationFrame(() => {
                     if (!ReactEditor.isFocused(editor) || Node.string(editor).length > 0) return;
-                    Transforms.insertText(editor, '\u00a0');
-                    Transforms.delete(editor, { reverse: true });
+                    Transforms.insertText(editor, ' ');
+                    requestAnimationFrame(() => {
+                      Transforms.delete(editor, { reverse: true });
+                    });
                   });
                 }}
               />

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -440,6 +440,8 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                 onPaste={onPaste}
                 // Defer to OS capitalization setting (respects iOS sentence-case toggle).
                 autoCapitalize="sentences"
+                // Enables autocorrect on iOS, which also helps autocapitalization work.
+                autoCorrect="on"
                 // keeps focus after pressing send.
                 onBlur={() => {
                   if (mobileOrTablet()) ReactEditor.focus(editor);

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -2,11 +2,11 @@ import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode } from 'rea
 import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Box, Scroll, Text } from 'folds';
 import type { Descendant, Editor } from 'slate';
-import { Node, Transforms, createEditor } from 'slate';
+import { Node, createEditor } from 'slate';
 import type { RenderLeafProps, RenderElementProps, RenderPlaceholderProps } from 'slate-react';
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
 import { withHistory } from 'slate-history';
-import { mobileOrTablet } from '$utils/user-agent';
+import { isPhone, mobileOrTablet } from '$utils/user-agent';
 import { BlockType } from './types';
 import { RenderElement, RenderLeaf } from './Elements';
 import type { CustomElement } from './slate';
@@ -114,6 +114,9 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
     const singleLineWidthOffsetRef = useRef(0);
     const latestValueRef = useRef<Descendant[]>(editor.children);
     const isMultilineRef = useRef(false);
+    // Tracks whether a triggerAutoCapitalize rAF is already queued to avoid stacking
+    // multiple rAFs when content changes fire rapidly (e.g. IME composition).
+    const autocapPendingRef = useRef(false);
     const [isMultiline, setIsMultiline] = useState(false);
     const [measurementVersion, setMeasurementVersion] = useState(0);
     const hasBefore = Boolean(before);
@@ -348,8 +351,29 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
       updateMultilineLayout(latestValueRef.current);
     }, [measurementVersion, updateMultilineLayout]);
 
+    // Mobile OSes (iOS and Android) do not reliably capitalise the first letter in an empty
+    // contenteditable. Both platforms render a zero-width placeholder character (\uFEFF)
+    // inside the Slate DOM node to maintain the cursor, and their keyboards interpret this
+    // as existing content — so they don't apply sentence-case to the next keystroke.
+    // Toggling the autocapitalize attribute from 'none' → 'sentences' on the focused
+    // contenteditable forces the keyboard to re-evaluate capitalisation state with no
+    // content changes, no focus shifts, and no keyboard dismissal.
+    const triggerAutoCapitalize = useCallback(() => {
+      if (!mobileOrTablet()) return;
+      if (autocapPendingRef.current) return;
+      const el = editableRef.current;
+      if (!el) return;
+      autocapPendingRef.current = true;
+      el.setAttribute('autocapitalize', 'none');
+      requestAnimationFrame(() => {
+        el.setAttribute('autocapitalize', 'sentences');
+        autocapPendingRef.current = false;
+      });
+    }, []);
+
     const handleChange = useCallback(
       (value: Descendant[]) => {
+        const prevText = latestValueRef.current.map((node) => Node.string(node)).join('');
         latestValueRef.current = value;
         measurementCacheRef.current = null;
         if (multilineMeasureFrameRef.current !== null) {
@@ -358,8 +382,15 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
         }
         setMeasurementVersion((version) => version + 1);
         onChange?.(value);
+        // After a send, content goes from non-empty to empty while the editor stays focused.
+        // Trigger the autocap attribute toggle so the next message starts capitalised.
+        // onBlur keeps focus on the editor so isFocused() is true when this fires.
+        const nextText = value.map((node) => Node.string(node)).join('');
+        if (prevText.length > 0 && nextText.length === 0 && ReactEditor.isFocused(editor)) {
+          triggerAutoCapitalize();
+        }
       },
-      [onChange]
+      [onChange, editor, triggerAutoCapitalize]
     );
 
     const renderElement = useCallback(
@@ -371,8 +402,10 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
 
     const handleKeydown: KeyboardEventHandler = useCallback(
       (evt) => {
-        // mobile ignores config option
-        if (mobileOrTablet() && evt.key === 'Enter' && !evt.shiftKey) {
+        // Phones (on-screen keyboard) ignore the enter-to-send config option.
+        // Tablets with an external keyboard should still forward Enter to onKeyDown
+        // so RoomInput can honour the enterForNewline / mod+enter settings.
+        if (isPhone() && evt.key === 'Enter' && !evt.shiftKey) {
           return;
         }
 
@@ -440,34 +473,23 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                 onPaste={onPaste}
                 // Defer to OS capitalization setting (respects iOS sentence-case toggle).
                 autoCapitalize="sentences"
-                // Enables autocorrect on iOS, which also helps autocapitalization work.
-                autoCorrect="on"
+                // Detect text direction per-message so RTL languages (Arabic, Hebrew, etc.)
+                // automatically right-align without any toggle.
+                dir="auto"
+                // Trigger autocap re-evaluation when the editor gains focus empty.
+                // This handles the initial tap-to-focus case: Slate's DOM contains a
+                // \uFEFF placeholder that the keyboard sees as existing content and so
+                // skips sentence-case. The attribute toggle forces a re-evaluation.
+                // autocapPendingRef prevents double-fire if handleChange also fires
+                // (e.g. the send clears content while focus is transferred).
+                onFocus={() => {
+                  if (mobileOrTablet() && Node.string(editor).length === 0) {
+                    triggerAutoCapitalize();
+                  }
+                }}
                 // keeps focus after pressing send.
                 onBlur={() => {
                   if (mobileOrTablet()) ReactEditor.focus(editor);
-                }}
-                // iOS Slate.js bug: an empty contenteditable doesn't signal
-                // "start of sentence" to autocapitalize. A two-frame round-trip
-                // (insert space, then delete it one frame later) lets iOS process
-                // the intermediate "has text" state before seeing the empty field
-                // again — this is what triggers sentence-case on the next keystroke.
-                //
-                // Guard: skip the trick when triggerAutoCapitalize is returning focus
-                // to Slate (justRestoredFocusRef is set synchronously before the
-                // ReactEditor.focus call). Without this guard the space→delete fires
-                // again, handleChange sees non-empty→empty while focused, calls
-                // triggerAutoCapitalize again, and the placeholder flashes in a
-                // tight loop every time a reply is started.
-                onFocus={() => {
-                  if (!mobileOrTablet()) return;
-                  if (justRestoredFocusRef.current) return;
-                  requestAnimationFrame(() => {
-                    if (!ReactEditor.isFocused(editor) || Node.string(editor).length > 0) return;
-                    Transforms.insertText(editor, ' ');
-                    requestAnimationFrame(() => {
-                      Transforms.delete(editor, { reverse: true });
-                    });
-                  });
                 }}
               />
             </Scroll>

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -451,8 +451,16 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                 // (insert space, then delete it one frame later) lets iOS process
                 // the intermediate "has text" state before seeing the empty field
                 // again — this is what triggers sentence-case on the next keystroke.
+                //
+                // Guard: skip the trick when triggerAutoCapitalize is returning focus
+                // to Slate (justRestoredFocusRef is set synchronously before the
+                // ReactEditor.focus call). Without this guard the space→delete fires
+                // again, handleChange sees non-empty→empty while focused, calls
+                // triggerAutoCapitalize again, and the placeholder flashes in a
+                // tight loop every time a reply is started.
                 onFocus={() => {
                   if (!mobileOrTablet()) return;
+                  if (justRestoredFocusRef.current) return;
                   requestAnimationFrame(() => {
                     if (!ReactEditor.isFocused(editor) || Node.string(editor).length > 0) return;
                     Transforms.insertText(editor, ' ');

--- a/src/app/components/editor/autocomplete/AutocompleteMenu.tsx
+++ b/src/app/components/editor/autocomplete/AutocompleteMenu.tsx
@@ -60,6 +60,7 @@ export function AutocompleteMenu({
           isKeyForward: (evt: KeyboardEvent) => isKeyHotkey('arrowdown', evt),
           isKeyBackward: (evt: KeyboardEvent) => isKeyHotkey('arrowup', evt),
           escapeDeactivates: stopPropagation,
+          tabbableOptions: { displayCheck: 'none' },
         }}
       >
         <Menu

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -380,6 +380,8 @@ type EmojiBoardProps = {
   imagePackRooms: Room[];
   requestClose: () => void;
   returnFocusOnDeactivate?: boolean;
+  /** Controls whether the FocusTrap is active. Pass false when rendering but hiding the board. */
+  active?: boolean;
   onEmojiSelect?: (unicode: string, shortcode: string) => void;
   onCustomEmojiSelect?: (mxc: string, shortcode: string) => void;
   onStickerSelect?: (mxc: string, shortcode: string, label: string) => void;
@@ -393,6 +395,7 @@ export function EmojiBoard({
   imagePackRooms,
   requestClose,
   returnFocusOnDeactivate,
+  active = true,
   onEmojiSelect,
   onCustomEmojiSelect,
   onStickerSelect,
@@ -534,6 +537,7 @@ export function EmojiBoard({
 
   return (
     <FocusTrap
+      active={active}
       focusTrapOptions={{
         returnFocusOnDeactivate,
         initialFocus: false,

--- a/src/app/components/message/layout/layout.css.ts
+++ b/src/app/components/message/layout/layout.css.ts
@@ -231,6 +231,9 @@ export const MessageTextBody = recipe({
   base: {
     unicodeBidi: 'plaintext',
     alignSelf: 'start',
+    // Full width ensures RTL text (direction:rtl from dir=auto) has room to right-align
+    // within the flex column that contains the message body.
+    width: '100%',
     wordBreak: 'break-word',
     fontSize: '1rem !important', // Override folds Text component to enable page zoom scaling
   },

--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -177,44 +177,8 @@ export function NotificationBanner() {
   // We store an array locally so multiple rapid notifications stack briefly.
   const [banner, setBanner] = useAtom(inAppBannerAtom);
   const [queue, setQueue] = useState<InAppBannerNotification[]>([]);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   log.log('[Banner] Component render, queue length:', queue.length, 'banner:', banner);
-
-  // Adjust banner position for iOS keyboard
-  useEffect(() => {
-    // Only apply on iOS/browsers that support visualViewport
-    if (!('visualViewport' in window)) return undefined;
-
-    const updatePosition = () => {
-      const container = containerRef.current;
-      if (!container) return;
-
-      const visualViewport = window.visualViewport!;
-      // Calculate how much of the screen is covered by the keyboard
-      // When keyboard opens, visualViewport.height shrinks
-      const keyboardHeight = window.innerHeight - visualViewport.height;
-
-      // Position the banner down by the keyboard height so it appears at the top of the visible area
-      // This puts it "halfway down the page" when keyboard covers half the screen
-      if (keyboardHeight > 0) {
-        container.style.top = `${keyboardHeight}px`;
-      } else {
-        // Reset to CSS default (env(safe-area-inset-top))
-        container.style.top = '';
-      }
-    };
-
-    const visualViewport = window.visualViewport!;
-    visualViewport.addEventListener('resize', updatePosition);
-    visualViewport.addEventListener('scroll', updatePosition);
-    updatePosition(); // Initial position
-
-    return () => {
-      visualViewport.removeEventListener('resize', updatePosition);
-      visualViewport.removeEventListener('scroll', updatePosition);
-    };
-  }, []);
 
   // Push new notifications into the local queue.
   useEffect(() => {
@@ -247,7 +211,7 @@ export function NotificationBanner() {
 
   log.log('[Banner] Rendering', queue.length, 'banners');
   return (
-    <div ref={containerRef} className={css.BannerContainer} aria-live="polite" aria-atomic="false">
+    <div className={css.BannerContainer} aria-live="polite" aria-atomic="false">
       {queue.map((n) => (
         <BannerItem key={n.id} notification={n} onDismiss={handleDismiss} />
       ))}

--- a/src/app/components/page/Page.tsx
+++ b/src/app/components/page/Page.tsx
@@ -3,6 +3,7 @@ import { Box, Header, Line, Scroll, Text, as } from 'folds';
 import classNames from 'classnames';
 import { ContainerColor } from '$styles/ContainerColor.css';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import * as css from './style.css';
 
 type PageRootProps = {
@@ -16,7 +17,7 @@ export function PageRoot({ nav, children }: PageRootProps) {
   return (
     <Box grow="Yes" className={ContainerColor({ variant: 'Background' })}>
       {nav}
-      {screenSize !== ScreenSize.Mobile && (
+      {screenSize !== ScreenSize.Mobile && !mobileOrTabletLayout() && (
         <Line variant="Background" size="300" direction="Vertical" />
       )}
       {children}

--- a/src/app/components/page/style.css.ts
+++ b/src/app/components/page/style.css.ts
@@ -60,7 +60,8 @@ export const PageNavContent = style({
   minHeight: '100%',
   padding: config.space.S200,
   paddingRight: 0,
-  paddingBottom: config.space.S700,
+  // Ensure the last nav item is always above the home indicator / Android nav bar.
+  paddingBottom: `max(${config.space.S700}, env(safe-area-inset-bottom, 0px))`,
 });
 
 export const PageHeader = recipe({

--- a/src/app/components/splash-screen/SplashScreen.css.ts
+++ b/src/app/components/splash-screen/SplashScreen.css.ts
@@ -2,11 +2,16 @@ import { style } from '@vanilla-extract/css';
 import { color, config } from 'folds';
 
 export const SplashScreen = style({
-  minHeight: '100%',
+  flexGrow: 1,
   backgroundColor: color.Background.Container,
   color: color.Background.OnContainer,
 });
 
 export const SplashScreenFooter = style({
-  padding: config.space.S400,
+  paddingTop: config.space.S400,
+  paddingLeft: config.space.S400,
+  paddingRight: config.space.S400,
+  // Ensure footer clears the home indicator / Android nav bar.
+  // Falls back to S400 on devices without a bottom safe area.
+  paddingBottom: `max(${config.space.S400}, env(safe-area-inset-bottom, 0px))`,
 });

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -57,6 +57,7 @@ import { useSableCosmetics } from '$hooks/useSableCosmetics';
 import { formatCompactNumber } from '$utils/formatCompactNumber';
 import * as css from './MembersDrawer.css';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { useScreenSizeContext, ScreenSize } from '$hooks/useScreenSize';
 
 type MemberDrawerHeaderProps = {
@@ -316,7 +317,7 @@ export function MembersDrawer({ room, members }: MembersDrawerProps) {
   }, [memberSidebarWidth]);
 
   const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+  const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
   return (
     <Box
@@ -325,12 +326,12 @@ export function MembersDrawer({ room, members }: MembersDrawerProps) {
       direction="Column"
       style={{
         position: 'relative',
-        width: isMobile ? '100%' : toRem(curWidth),
+        width: !mobileOrTabletLayout() ? toRem(curWidth) : '100%',
       }}
     >
       <MemberDrawerHeader room={room} hideText={hideText} />
       <Box className={css.MemberDrawerContentBase} grow="Yes">
-        {!isMobile && (
+        {!mobileOrTabletLayout() && (
           <SidebarResizer
             setCurWidth={setCurWidth}
             sidebarWidth={memberSidebarWidth}

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -414,45 +414,13 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const [sendError, setSendError] = useState<string | undefined>();
     const isEncrypted = room.hasEncryptionStateEvent();
 
-    const { keyboardHeight, isKeyboardVisible } = useKeyboardHeight();
-    useScrollLock(isKeyboardVisible && mobileOrTablet());
-
-    // When the keyboard opens, shrink #root to the visual viewport height
-    // (the area above the keyboard). This is the layout-correct approach
-    // for Sable's in-flow flex layout: transform moves the input visually
-    // but leaves the message list sized to the full height, producing a
-    // gap. CSS variables let the whole layout reflow so messages fill the
-    // visible area and the input sits at the bottom above the keyboard.
-    // The 80 ms stability gate in useKeyboardHeight prevents this from
-    // firing at startup or during transient browser-chrome resize events.
-    useEffect(() => {
-      if (!mobileOrTablet()) return undefined;
-
-      if (isKeyboardVisible && keyboardHeight > 0) {
-        const visibleHeight = window.visualViewport?.height ?? window.innerHeight - keyboardHeight;
-        document.documentElement.style.setProperty('--sable-visible-height', `${visibleHeight}px`);
-        document.documentElement.style.setProperty('--sable-safe-bottom', '0px');
-        // Reset any scroll iOS applied during the stability window before
-        // the lock became active.
-        if (window.scrollY !== 0) {
-          window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
-        }
-      } else {
-        document.documentElement.style.removeProperty('--sable-visible-height');
-        document.documentElement.style.removeProperty('--sable-safe-bottom');
-      }
-
-      return undefined;
-    }, [isKeyboardVisible, keyboardHeight]);
-
-    // Safety: remove CSS variables if RoomInput unmounts while keyboard open.
-    useEffect(
-      () => () => {
-        document.documentElement.style.removeProperty('--sable-visible-height');
-        document.documentElement.style.removeProperty('--sable-safe-bottom');
-      },
-      []
-    );
+    const { triggerPreLift } = useKeyboardHeight();
+    // Always active on mobile: iOS can apply window.scrollY even with overflow:hidden
+    // on body (scroll-prediction bug). The lock snaps scrollY back to 0 immediately
+    // on any scroll event, preventing the "header scrolls up then snaps" jank.
+    // useKeyboardHeight now manages --sable-visible-height synchronously in its own
+    // event handler, so no useEffect here is needed for CSS variable management.
+    useScrollLock(mobileOrTablet());
 
     useElementSizeObserver(
       useCallback(() => fileDropContainerRef.current, [fileDropContainerRef]),
@@ -1338,7 +1306,8 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     };
 
     return (
-      <div ref={ref}>
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div ref={ref} onMouseDown={mobileOrTablet() ? triggerPreLift : undefined}>
         {selectedFiles.length > 0 && (
           <UploadBoard
             header={

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEventHandler, MouseEvent, RefObject } from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import { isKeyHotkey } from 'is-hotkey';
@@ -67,7 +68,6 @@ import {
 } from '$components/editor';
 import { plainToEditorInput } from '$components/editor/input';
 import { EmojiBoard, EmojiBoardTab } from '$components/emoji-board';
-import { UseStateProvider } from '$components/UseStateProvider';
 import type { TUploadContent } from '$utils/matrix';
 import { encryptFile, getImageInfo, mxcUrlToHttp, toggleReaction } from '$utils/matrix';
 import { useTypingStatusUpdater } from '$hooks/useTypingStatusUpdater';
@@ -276,6 +276,24 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const [pkCompatEnable] = useSetting(settingsAtom, 'pkCompat');
     const [pmpProxyingEnable] = useSetting(settingsAtom, 'pmpProxying');
     const emojiBtnRef = useRef<HTMLButtonElement>(null);
+    // Hoisted from the UseStateProvider in JSX so EmojiBoard can be kept mounted
+    // after first open (avoids re-initializing virtualizer on every open).
+    const [emojiBoardTab, setEmojiBoardTab] = useState<EmojiBoardTab | undefined>(undefined);
+    const [emojiBoardAnchorRect, setEmojiBoardAnchorRect] = useState<DOMRect | null>(null);
+    const openEmojiBoard = useCallback((tab: EmojiBoardTab) => {
+      const rect = emojiBtnRef.current?.getBoundingClientRect() ?? null;
+      setEmojiBoardAnchorRect(rect);
+      setEmojiBoardTab(tab);
+    }, []);
+    const closeEmojiBoard = useCallback(() => {
+      setEmojiBoardTab((t) => {
+        if (t) {
+          if (!mobileOrTablet()) ReactEditor.focus(editor);
+          return undefined;
+        }
+        return t;
+      });
+    }, [editor]);
     const micBtnRef = useRef<HTMLButtonElement>(null);
     // Preserve stable list keys across metadata/description replacements without
     // storing UI-only IDs in the upload draft state.
@@ -347,6 +365,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
               },
             })
           );
+          // If all files failed to encrypt (e.g. iCloud file not yet downloaded
+          // on iOS), surface an error rather than silently producing no items.
+          if (fileItems.length === 0 && safeFiles.length > 0) {
+            setSendError('Could not read the file. Try downloading it first, then try again.');
+            return;
+          }
         } else {
           safeFiles.forEach((f) =>
             fileItems.push({
@@ -1585,77 +1609,65 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
               <MarkdownFormattingToolbarToggle variant="SurfaceVariant" />
 
-              <UseStateProvider initial={undefined}>
-                {(emojiBoardTab: EmojiBoardTab | undefined, setEmojiBoardTab) => (
-                  <PopOut
-                    offset={16}
-                    alignOffset={-44}
-                    position="Top"
-                    align="End"
-                    anchor={
-                      emojiBoardTab === undefined
-                        ? undefined
-                        : (emojiBtnRef.current?.getBoundingClientRect() ?? undefined)
-                    }
-                    content={
-                      <EmojiBoard
-                        tab={emojiBoardTab}
-                        onTabChange={setEmojiBoardTab}
-                        imagePackRooms={imagePackRooms}
-                        returnFocusOnDeactivate={false}
-                        onEmojiSelect={handleEmoticonSelect}
-                        onCustomEmojiSelect={handleEmoticonSelect}
-                        onStickerSelect={handleStickerSelect}
-                        requestClose={() => {
-                          setEmojiBoardTab((t) => {
-                            if (t) {
-                              if (!mobileOrTablet()) ReactEditor.focus(editor);
-                              return undefined;
-                            }
-                            return t;
-                          });
-                        }}
-                      />
-                    }
+              {/* Emoji/sticker board: kept mounted after first open to avoid re-initialising
+                  the virtualizer on every open. FocusTrap is deactivated when hidden. */}
+              {emojiBoardAnchorRect &&
+                createPortal(
+                  <div
+                    style={{
+                      position: 'fixed',
+                      zIndex: 999,
+                      // Position above the emoji button (mirrors PopOut position="Top" offset=16).
+                      bottom: window.innerHeight - emojiBoardAnchorRect.top + 16,
+                      // Right-align with the emoji button (mirrors PopOut align="End").
+                      right: window.innerWidth - emojiBoardAnchorRect.right,
+                      display: emojiBoardTab !== undefined ? undefined : 'none',
+                    }}
                   >
-                    {!hideStickerBtn && (
-                      <IconButton
-                        aria-pressed={emojiBoardTab === EmojiBoardTab.Sticker}
-                        onClick={() => setEmojiBoardTab(EmojiBoardTab.Sticker)}
-                        variant="SurfaceVariant"
-                        size="300"
-                        radii="300"
-                        title="open sticker picker"
-                        aria-label="Open sticker picker"
-                      >
-                        <Icon
-                          src={Icons.Sticker}
-                          filled={emojiBoardTab === EmojiBoardTab.Sticker}
-                        />
-                      </IconButton>
-                    )}
-                    <IconButton
-                      ref={emojiBtnRef}
-                      aria-pressed={
-                        hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji
-                      }
-                      onClick={() => setEmojiBoardTab(EmojiBoardTab.Emoji)}
-                      variant="SurfaceVariant"
-                      size="300"
-                      radii="300"
-                      title="open emoji picker"
-                      aria-label="Open emoji picker"
-                    >
-                      <Icon
-                        src={Icons.Smile}
-                        filled={
-                          hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji
-                        }
-                      />
-                    </IconButton>
-                  </PopOut>
+                    <EmojiBoard
+                      active={emojiBoardTab !== undefined}
+                      tab={emojiBoardTab ?? EmojiBoardTab.Emoji}
+                      onTabChange={setEmojiBoardTab}
+                      imagePackRooms={imagePackRooms}
+                      returnFocusOnDeactivate={false}
+                      onEmojiSelect={handleEmoticonSelect}
+                      onCustomEmojiSelect={handleEmoticonSelect}
+                      onStickerSelect={handleStickerSelect}
+                      requestClose={closeEmojiBoard}
+                    />
+                  </div>,
+                  document.body
                 )}
-              </UseStateProvider>
+              {!hideStickerBtn && (
+                <IconButton
+                  aria-pressed={emojiBoardTab === EmojiBoardTab.Sticker}
+                  onClick={() => openEmojiBoard(EmojiBoardTab.Sticker)}
+                  variant="SurfaceVariant"
+                  size="300"
+                  radii="300"
+                  title="open sticker picker"
+                  aria-label="Open sticker picker"
+                >
+                  <Icon src={Icons.Sticker} filled={emojiBoardTab === EmojiBoardTab.Sticker} />
+                </IconButton>
+              )}
+              <IconButton
+                ref={emojiBtnRef}
+                aria-pressed={
+                  hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji
+                }
+                onClick={() => openEmojiBoard(EmojiBoardTab.Emoji)}
+                variant="SurfaceVariant"
+                size="300"
+                radii="300"
+                title="open emoji picker"
+                aria-label="Open emoji picker"
+              >
+                <Icon
+                  src={Icons.Smile}
+                  filled={hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji}
+                />
+              </IconButton>
               <PopOut
                 anchor={scheduleMenuAnchor}
                 position="Top"

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -286,6 +286,24 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       setEmojiBoardAnchorRect(rect);
       setEmojiBoardTab(tab);
     }, []);
+    // Keep the emoji/sticker picker position in sync with viewport changes (e.g.
+    // the iOS virtual keyboard appearing/disappearing while the board is open).
+    useEffect(() => {
+      if (emojiBoardTab === undefined) return undefined;
+      const updateRect = () => {
+        setEmojiBoardAnchorRect(emojiBtnRef.current?.getBoundingClientRect() ?? null);
+      };
+      const vp = window.visualViewport;
+      if (vp) {
+        vp.addEventListener('resize', updateRect);
+        vp.addEventListener('scroll', updateRect);
+        return () => {
+          vp.removeEventListener('resize', updateRect);
+          vp.removeEventListener('scroll', updateRect);
+        };
+      }
+      return undefined;
+    }, [emojiBoardTab]);
     const closeEmojiBoard = useCallback(() => {
       setEmojiBoardTab((t) => {
         if (t) {

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -143,6 +143,7 @@ import {
 import { ImageUsage } from '$plugins/custom-emoji';
 import { SerializableMap } from '$types/wrapper/SerializableMap';
 import { useSettingsLinkBaseUrl } from '$features/settings/useSettingsLinkBaseUrl';
+import { useKeyboardHeight, useScrollLock } from '$hooks/ios-keyboard-fix';
 import { SchedulePickerDialog } from './schedule-send';
 import * as css from './schedule-send/SchedulePickerDialog.css';
 import {
@@ -412,6 +413,46 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const setServerMaxDelayMs = useSetAtom(serverMaxDelayMsAtom);
     const [sendError, setSendError] = useState<string | undefined>();
     const isEncrypted = room.hasEncryptionStateEvent();
+
+    const { keyboardHeight, isKeyboardVisible } = useKeyboardHeight();
+    useScrollLock(isKeyboardVisible && mobileOrTablet());
+
+    // When the keyboard opens, shrink #root to the visual viewport height
+    // (the area above the keyboard). This is the layout-correct approach
+    // for Sable's in-flow flex layout: transform moves the input visually
+    // but leaves the message list sized to the full height, producing a
+    // gap. CSS variables let the whole layout reflow so messages fill the
+    // visible area and the input sits at the bottom above the keyboard.
+    // The 80 ms stability gate in useKeyboardHeight prevents this from
+    // firing at startup or during transient browser-chrome resize events.
+    useEffect(() => {
+      if (!mobileOrTablet()) return undefined;
+
+      if (isKeyboardVisible && keyboardHeight > 0) {
+        const visibleHeight = window.visualViewport?.height ?? window.innerHeight - keyboardHeight;
+        document.documentElement.style.setProperty('--sable-visible-height', `${visibleHeight}px`);
+        document.documentElement.style.setProperty('--sable-safe-bottom', '0px');
+        // Reset any scroll iOS applied during the stability window before
+        // the lock became active.
+        if (window.scrollY !== 0) {
+          window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
+        }
+      } else {
+        document.documentElement.style.removeProperty('--sable-visible-height');
+        document.documentElement.style.removeProperty('--sable-safe-bottom');
+      }
+
+      return undefined;
+    }, [isKeyboardVisible, keyboardHeight]);
+
+    // Safety: remove CSS variables if RoomInput unmounts while keyboard open.
+    useEffect(
+      () => () => {
+        document.documentElement.style.removeProperty('--sable-visible-height');
+        document.documentElement.style.removeProperty('--sable-safe-bottom');
+      },
+      []
+    );
 
     useElementSizeObserver(
       useCallback(() => fileDropContainerRef.current, [fileDropContainerRef]),
@@ -1619,8 +1660,15 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                       zIndex: 999,
                       // Position above the emoji button (mirrors PopOut position="Top" offset=16).
                       bottom: window.innerHeight - emojiBoardAnchorRect.top + 16,
-                      // Right-align with the emoji button (mirrors PopOut align="End").
-                      right: window.innerWidth - emojiBoardAnchorRect.right,
+                      // Right-align with the emoji button, but clamp so the picker
+                      // never extends past the left edge of the screen.
+                      // The EmojiBoard is min(432px, 100vw-32px) wide; ensure
+                      // viewportWidth − right − boardWidth ≥ 0.
+                      right: (() => {
+                        const rawRight = window.innerWidth - emojiBoardAnchorRect.right;
+                        const boardWidth = Math.min(432, window.innerWidth - 32);
+                        return Math.max(0, Math.min(rawRight, window.innerWidth - boardWidth));
+                      })(),
                       display: emojiBoardTab !== undefined ? undefined : 'none',
                     }}
                   >

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -234,6 +234,10 @@ export function RoomTimeline({
   const topSpacerHeightRef = useRef(0);
   const mountScrollWindowRef = useRef<number>(Date.now() + 3000);
   const hasInitialScrolledRef = useRef(false);
+  // Short-lived guard set for ~350 ms after a jump scrollToIndex so that
+  // intermediate scroll events from the animation don't flip atBottom prematurely.
+  const jumpScrollBlockRef = useRef(false);
+  const jumpScrollBlockTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   // Stored in a ref so eventsLength fluctuations (e.g. onLifecycle timeline reset
   // firing within the window) cannot cancel it via useLayoutEffect cleanup.
   const initialScrollTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -267,6 +271,23 @@ export function RoomTimeline({
     if (lastIndex < 0) return;
     vListRef.current.scrollTo(vListRef.current.scrollSize);
   }, []);
+
+  // Start a short scroll-settle block after a programmatic jump scrollToIndex.
+  // After 350 ms the block lifts and atBottom is recomputed from the actual
+  // VList position so "Jump to Latest" appears correctly.
+  const startJumpScrollBlock = useCallback(() => {
+    jumpScrollBlockRef.current = true;
+    if (jumpScrollBlockTimerRef.current !== undefined) clearTimeout(jumpScrollBlockTimerRef.current);
+    jumpScrollBlockTimerRef.current = setTimeout(() => {
+      jumpScrollBlockRef.current = false;
+      jumpScrollBlockTimerRef.current = undefined;
+      const v = vListRef.current;
+      if (v) {
+        const dist = v.scrollSize - v.scrollOffset - v.viewportSize;
+        setAtBottom(dist < 100);
+      }
+    }, 350);
+  }, [setAtBottom]);
 
   const timelineSync = useTimelineSync({
     room,
@@ -407,6 +428,7 @@ export function RoomTimeline({
         const processedIndex = getRawIndexToProcessedIndex(timelineSync.focusItem.index);
         if (processedIndex !== undefined) {
           vListRef.current.scrollToIndex(processedIndex, { align: 'center' });
+          startJumpScrollBlock();
           timelineSync.setFocusItem((prev) => (prev ? { ...prev, scrollTo: false } : undefined));
         }
       }
@@ -417,7 +439,7 @@ export function RoomTimeline({
     return () => {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
     };
-  }, [timelineSync.focusItem, timelineSync, reducedMotion, getRawIndexToProcessedIndex]);
+  }, [timelineSync.focusItem, timelineSync, reducedMotion, getRawIndexToProcessedIndex, startJumpScrollBlock]);
 
   useEffect(() => {
     if (timelineSync.focusItem) {
@@ -428,7 +450,11 @@ export function RoomTimeline({
   useEffect(() => {
     if (!eventId) return;
     setIsReady(false);
-    void timelineSyncRef.current.loadEventTimeline(eventId);
+    // Re-arm the initial-scroll guard so that if the jump fails and
+    // useTimelineSync falls back to the live timeline, the useLayoutEffect
+    // can fire and call setIsReady(true) via the normal initial-scroll path.
+    hasInitialScrolledRef.current = false;
+    timelineSyncRef.current.loadEventTimeline(eventId);
   }, [eventId, room.roomId]);
 
   useEffect(() => {
@@ -484,14 +510,6 @@ export function RoomTimeline({
         // Record the programmatic pin so handleVListScroll sees withinSettleWindow=true
         // and doesn't flip atBottom to false while VList commits the new scroll position.
         // Without this, the "Jump to Present" button flashes every time the keyboard opens.
-        lastProgrammaticBottomPinAtRef.current = Date.now();
-        vListRef.current?.scrollTo(vListRef.current.scrollSize);
-      }
-      // When the viewport GROWS (e.g. keyboard dismissed), re-pin to the bottom
-      // so that VList doesn't momentarily report "not at bottom" and flash the
-      // jump-to-present button. Setting lastProgrammaticBottomPinAtRef ensures
-      // handleVListScroll's settle-window keeps atBottom=true during the reflow.
-      if (!shrank && newHeight > prev && atBottom) {
         lastProgrammaticBottomPinAtRef.current = Date.now();
         vListRef.current?.scrollTo(vListRef.current.scrollSize);
       }
@@ -553,6 +571,7 @@ export function RoomTimeline({
         }
         if (vListRef.current && processedIndex !== undefined) {
           vListRef.current.scrollToIndex(processedIndex, { align: 'center' });
+          startJumpScrollBlock();
         }
         timelineSync.setFocusItem({ index: focusRawIndex, scrollTo: false, highlight: true });
       } else {

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -487,6 +487,14 @@ export function RoomTimeline({
         lastProgrammaticBottomPinAtRef.current = Date.now();
         vListRef.current?.scrollTo(vListRef.current.scrollSize);
       }
+      // When the viewport GROWS (e.g. keyboard dismissed), re-pin to the bottom
+      // so that VList doesn't momentarily report "not at bottom" and flash the
+      // jump-to-present button. Setting lastProgrammaticBottomPinAtRef ensures
+      // handleVListScroll's settle-window keeps atBottom=true during the reflow.
+      if (!shrank && newHeight > prev && atBottom) {
+        lastProgrammaticBottomPinAtRef.current = Date.now();
+        vListRef.current?.scrollTo(vListRef.current.scrollSize);
+      }
       prevViewportHeightRef.current = newHeight;
     });
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -190,6 +190,14 @@ export function RoomTimeline({
   hideReadsRef.current = hideReads;
 
   const prevViewportHeightRef = useRef(0);
+  const prevScrollSizeRef = useRef(0);
+  // Tracks the VList-reported viewport size (as opposed to prevViewportHeightRef
+  // which tracks the DOM element height via ResizeObserver). Used in
+  // handleVListScroll to detect viewport size changes (keyboard opens OR closes)
+  // without a ResizeObserver race: when VList fires onScroll with a different
+  // viewportSize, we chase the bottom immediately instead of letting
+  // setAtBottom(false) fire.
+  const prevVListViewportRef = useRef(0);
   const messageListRef = useRef<HTMLDivElement>(null);
 
   const mediaAuthentication = useMediaAuthentication();
@@ -473,6 +481,10 @@ export function RoomTimeline({
       const shrank = newHeight < prev;
 
       if (shrank && atBottom) {
+        // Record the programmatic pin so handleVListScroll sees withinSettleWindow=true
+        // and doesn't flip atBottom to false while VList commits the new scroll position.
+        // Without this, the "Jump to Present" button flashes every time the keyboard opens.
+        lastProgrammaticBottomPinAtRef.current = Date.now();
         vListRef.current?.scrollTo(vListRef.current.scrollSize);
       }
       prevViewportHeightRef.current = newHeight;
@@ -675,6 +687,57 @@ export function RoomTimeline({
 
       const distanceFromBottom = v.scrollSize - offset - v.viewportSize;
       const isNowAtBottom = distanceFromBottom < 100;
+      const withinSettleWindow =
+        Date.now() - lastProgrammaticBottomPinAtRef.current < SCROLL_SETTLE_MS;
+
+      // When the user is pinned to the bottom and content grows (images, embeds,
+      // video thumbnails loading), scrollSize increases while offset stays put,
+      // pushing distanceFromBottom above the threshold. Instead of flipping
+      // atBottom to false (which shows the "Jump to Latest" button), chase the
+      // bottom so the user stays pinned.
+      const contentGrew = v.scrollSize > prevScrollSizeRef.current;
+      prevScrollSizeRef.current = v.scrollSize;
+
+      // When the keyboard opens/closes the VList viewportSize changes. The
+      // scrollOffset doesn't immediately follow, so distanceFromBottom spikes
+      // and isNowAtBottom becomes false — flashing the "Jump to Present" button.
+      // This is especially common when the keyboard opens/closes quickly before
+      // the chase RAF from a previous event has had a chance to execute.
+      // Detect the change here (inside onScroll, race-free) and chase the
+      // bottom before setAtBottom(false) is called.
+      const viewportChanged =
+        prevVListViewportRef.current > 0 && v.viewportSize !== prevVListViewportRef.current;
+      prevVListViewportRef.current = v.viewportSize;
+
+      // Skip content-chase and cache saves during init: the timeline is hidden
+      // (opacity 0) while VList measures items and fires intermediate scroll
+      // events.  Chasing the bottom here causes cascading scrollTo calls that
+      // upstream doesn't have, producing visible layout churn after isReady.
+      if (!isReadyRef.current) return;
+
+      // While a jump scroll is settling (briefly after scrollToIndex), VList
+      // fires intermediate scroll events that can incorrectly flip atBottom.
+      // Use a short-lived block instead of the full focusItem lifetime so that
+      // normal scrolling resumes quickly and atBottom is recomputed correctly.
+      if (jumpScrollBlockRef.current) return;
+
+      if (
+        atBottomRef.current &&
+        !isNowAtBottom &&
+        (contentGrew || viewportChanged || withinSettleWindow)
+      ) {
+        // Defer the chase to the next animation frame so VList finishes its
+        // current layout pass. Synchronous scrollTo causes cascading scroll
+        // events that produce visible jumps when images/embeds load.
+        requestAnimationFrame(() => {
+          const vl = vListRef.current;
+          if (vl && atBottomRef.current) {
+            lastProgrammaticBottomPinAtRef.current = Date.now();
+            vl.scrollTo(vl.scrollSize);
+          }
+        });
+        return;
+      }
       if (isNowAtBottom !== atBottomRef.current) {
         setAtBottom(isNowAtBottom);
       }

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -115,6 +115,8 @@ const getDayDividerText = (ts: number) => {
   return timeDayMonthYear(ts);
 };
 
+const SCROLL_SETTLE_MS = 250;
+
 export type RoomTimelineProps = {
   room: Room;
   eventId?: string;
@@ -249,6 +251,10 @@ export function RoomTimeline({
   const currentRoomIdRef = useRef(room.roomId);
 
   const [isReady, setIsReady] = useState(false);
+  const isReadyRef = useRef(false);
+  isReadyRef.current = isReady;
+
+  const lastProgrammaticBottomPinAtRef = useRef(0);
 
   if (currentRoomIdRef.current !== room.roomId) {
     hasInitialScrolledRef.current = false;
@@ -277,7 +283,8 @@ export function RoomTimeline({
   // VList position so "Jump to Latest" appears correctly.
   const startJumpScrollBlock = useCallback(() => {
     jumpScrollBlockRef.current = true;
-    if (jumpScrollBlockTimerRef.current !== undefined) clearTimeout(jumpScrollBlockTimerRef.current);
+    if (jumpScrollBlockTimerRef.current !== undefined)
+      clearTimeout(jumpScrollBlockTimerRef.current);
     jumpScrollBlockTimerRef.current = setTimeout(() => {
       jumpScrollBlockRef.current = false;
       jumpScrollBlockTimerRef.current = undefined;
@@ -439,7 +446,13 @@ export function RoomTimeline({
     return () => {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
     };
-  }, [timelineSync.focusItem, timelineSync, reducedMotion, getRawIndexToProcessedIndex, startJumpScrollBlock]);
+  }, [
+    timelineSync.focusItem,
+    timelineSync,
+    reducedMotion,
+    getRawIndexToProcessedIndex,
+    startJumpScrollBlock,
+  ]);
 
   useEffect(() => {
     if (timelineSync.focusItem) {

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -374,6 +374,8 @@ export function RoomTimeline({
   useEffect(
     () => () => {
       if (initialScrollTimerRef.current !== undefined) clearTimeout(initialScrollTimerRef.current);
+      if (jumpScrollBlockTimerRef.current !== undefined)
+        clearTimeout(jumpScrollBlockTimerRef.current);
     },
     []
   );
@@ -467,7 +469,7 @@ export function RoomTimeline({
     // useTimelineSync falls back to the live timeline, the useLayoutEffect
     // can fire and call setIsReady(true) via the normal initial-scroll path.
     hasInitialScrolledRef.current = false;
-    timelineSyncRef.current.loadEventTimeline(eventId);
+    void timelineSyncRef.current.loadEventTimeline(eventId);
   }, [eventId, room.roomId]);
 
   useEffect(() => {

--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -160,7 +160,14 @@ export function RoomView({ eventId }: { eventId?: string }) {
               <RoomViewTyping room={room} />
               <GlobalModalManager />
             </Box>
-            <Box shrink="No" direction="Column">
+            <Box
+              shrink="No"
+              direction="Column"
+              style={{
+                backgroundColor: 'var(--sable-surface-container)',
+                paddingBottom: 'var(--sable-safe-bottom, env(safe-area-inset-bottom, 0px))',
+              }}
+            >
               {canMessage && delayedEventsSupported && (
                 <ScheduledMessagesList room={room} onEditMessage={handleEditMessage} />
               )}

--- a/src/app/features/room/RoomViewFollowing.css.ts
+++ b/src/app/features/room/RoomViewFollowing.css.ts
@@ -13,8 +13,7 @@ export const RoomViewFollowing = recipe({
   base: [
     DefaultReset,
     {
-      minHeight: toRem(28),
-      padding: `0 ${config.space.S400}`,
+      padding: `${config.space.S100} ${config.space.S400}`,
       width: '100%',
       backgroundColor: color.Surface.Container,
       color: color.Surface.OnContainer,

--- a/src/app/features/room/RoomViewFollowing.css.ts
+++ b/src/app/features/room/RoomViewFollowing.css.ts
@@ -13,7 +13,8 @@ export const RoomViewFollowing = recipe({
   base: [
     DefaultReset,
     {
-      padding: `${config.space.S100} ${config.space.S400}`,
+      minHeight: toRem(28),
+      padding: `0 ${config.space.S400}`,
       width: '100%',
       backgroundColor: color.Surface.Container,
       color: color.Surface.OnContainer,

--- a/src/app/features/room/ThreadDrawer.tsx
+++ b/src/app/features/room/ThreadDrawer.tsx
@@ -230,6 +230,10 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
   const setReplyDraft = useSetAtom(roomIdToReplyDraftAtomFamily(threadRootId));
   const replyDraft = useAtomValue(roomIdToReplyDraftAtomFamily(threadRootId));
   const activeReplyId = replyDraft?.eventId;
+  // Keep a ref so handleReplyClick can read the latest draft without being
+  // recreated on every keystroke (which would re-render all Message instances).
+  const replyDraftRef = useRef(replyDraft);
+  replyDraftRef.current = replyDraft;
 
   // User profile popup
   const openUserRoomProfile = useOpenUserRoomProfile();
@@ -581,7 +585,7 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
         };
         // Only toggle off if we're actively replying to this event (non-empty body distinguishes
         // a real reply draft from the seeded base-thread draft, which has body: '').
-        if (activeReplyId === replyId && replyDraft?.body) {
+        if (activeReplyId === replyId && replyDraftRef.current?.body) {
           // Toggle off — reset to base thread draft
           setReplyDraft({
             userId: mx.getUserId() ?? '',
@@ -594,7 +598,7 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
         }
       }
     },
-    [mx, room, setReplyDraft, activeReplyId, threadRootId, replyDraft]
+    [mx, room, setReplyDraft, activeReplyId, threadRootId]
   );
 
   const handleReactionToggle = useCallback(

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -158,6 +158,40 @@ export const MessageCopyLinkItem = as<
   );
 });
 
+export const MessageCopyTextItem = as<
+  'button',
+  {
+    mEvent: MatrixEvent;
+    onClose?: () => void;
+  }
+>(({ mEvent, onClose, ...props }, ref) => {
+  const content = mEvent.getContent();
+  // For edited messages, prefer the new content body
+  const body: string | undefined = content['m.new_content']?.body ?? content.body;
+
+  if (!body || mEvent.isRedacted()) return null;
+
+  const handleCopy = () => {
+    copyToClipboard(body);
+    onClose?.();
+  };
+
+  return (
+    <MenuItem
+      size="300"
+      after={<Icon size="100" src={Icons.Alphabet} />}
+      radii="300"
+      onClick={handleCopy}
+      {...props}
+      ref={ref}
+    >
+      <Text className={css.MessageMenuItemText} as="span" size="T300" truncate>
+        Copy Text
+      </Text>
+    </MenuItem>
+  );
+});
+
 // message pinning
 export const MessagePinItem = as<
   'button',
@@ -254,22 +288,46 @@ export type MessageProps = {
   msc2723ForwardedMessageProps?: MSC2723ForwardedMessageProps;
 };
 
-function useMobileDoubleTap(callback: () => void, delay = 300) {
-  const lastTapRef = useRef(0);
+function useMobileLongPress(callback: () => void, delay = 500) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
 
-  return useCallback(() => {
-    if (!mobileOrTablet()) return;
-
-    const now = Date.now();
-    const timeSinceLastTap = now - lastTapRef.current;
-
-    if (timeSinceLastTap < delay && timeSinceLastTap > 0) {
-      callback();
-      lastTapRef.current = 0;
-    } else {
-      lastTapRef.current = now;
+  const cancel = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
     }
-  }, [callback, delay]);
+    startPosRef.current = null;
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: { clientX: number; clientY: number }) => {
+      if (!mobileOrTablet()) return;
+      startPosRef.current = { x: e.clientX, y: e.clientY };
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        callback();
+      }, delay);
+    },
+    [callback, delay]
+  );
+
+  const onPointerMove = useCallback(
+    (e: { clientX: number; clientY: number }) => {
+      if (!startPosRef.current) return;
+      const dx = e.clientX - startPosRef.current.x;
+      const dy = e.clientY - startPosRef.current.y;
+      if (Math.sqrt(dx * dx + dy * dy) > 10) cancel();
+    },
+    [cancel]
+  );
+
+  return {
+    onPointerDown,
+    onPointerUp: cancel,
+    onPointerCancel: cancel,
+    onPointerMove,
+  };
 }
 
 const clamp = (str: string, len: number) => (str.length > len ? `${str.slice(0, len)}...` : str);
@@ -851,7 +909,7 @@ function MessageInternal(
     onReplyClick(mockEvent);
   };
 
-  const onDoubleTap = useMobileDoubleTap(() => {
+  const longPress = useMobileLongPress(() => {
     setMobileOptionsOpen(true);
   });
 
@@ -1115,6 +1173,7 @@ function MessageInternal(
                           <MessageSourceCodeItem room={room} mEvent={mEvent} />
                         )}
                         <MessageCopyLinkItem room={room} mEvent={mEvent} onClose={closeMenu} />
+                        <MessageCopyTextItem mEvent={mEvent} onClose={closeMenu} />
                         <MessageForwardItem room={room} mEvent={mEvent} onClose={closeMenu} />
                         {canPinEvent && (
                           <MessagePinItem room={room} mEvent={mEvent} onClose={closeMenu} />
@@ -1237,7 +1296,7 @@ function MessageInternal(
       {messageLayout === MessageLayout.Compact && (
         <SwipeableMessageWrapper onReply={handleSwipeReply}>
           <CompactLayout before={headerJSX} onContextMenu={handleContextMenu}>
-            <div onPointerDown={onDoubleTap}>{msgContentJSX}</div>
+            <div {...longPress}>{msgContentJSX}</div>
           </CompactLayout>
         </SwipeableMessageWrapper>
       )}
@@ -1249,14 +1308,14 @@ function MessageInternal(
             onContextMenu={handleContextMenu}
             align={useRightBubbles && senderId === mx.getUserId() ? 'right' : 'left'}
           >
-            <div onPointerDown={onDoubleTap}>{msgContentJSX}</div>
+            <div {...longPress}>{msgContentJSX}</div>
           </BubbleLayout>
         </SwipeableMessageWrapper>
       )}
       {messageLayout !== MessageLayout.Compact && messageLayout !== MessageLayout.Bubble && (
         <SwipeableMessageWrapper onReply={handleSwipeReply}>
           <ModernLayout before={avatarJSX} onContextMenu={handleContextMenu}>
-            <div onPointerDown={onDoubleTap}>
+            <div {...longPress}>
               {headerJSX}
               {msgContentJSX}
             </div>
@@ -1368,7 +1427,7 @@ export const Event = as<'div', EventProps>(
       return () => document.removeEventListener('pointerdown', handleClick, { capture: true });
     }, [mobileOptionsOpen]);
 
-    const onDoubleTap = useMobileDoubleTap(() => {
+    const longPress = useMobileLongPress(() => {
       setMobileOptionsOpen(true);
     });
 
@@ -1453,6 +1512,7 @@ export const Event = as<'div', EventProps>(
                               <MessageSourceCodeItem room={room} mEvent={mEvent} />
                             )}
                             <MessageCopyLinkItem room={room} mEvent={mEvent} onClose={closeMenu} />
+                            <MessageCopyTextItem mEvent={mEvent} onClose={closeMenu} />
                             <MessageForwardItem room={room} mEvent={mEvent} onClose={closeMenu} />
                           </Box>
                           {((!mEvent.isRedacted() && canDelete && !stateEvent) ||
@@ -1497,7 +1557,7 @@ export const Event = as<'div', EventProps>(
             </Menu>
           </div>
         )}
-        <div onContextMenu={handleContextMenu} onPointerDown={onDoubleTap}>
+        <div onContextMenu={handleContextMenu} {...longPress}>
           {children}
         </div>
       </MessageBase>

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -1337,6 +1337,8 @@ function MessageInternal(
           mEvent={mEvent}
           canDelete={canDelete}
           canSendReaction={canSendReaction}
+          canPinEvent={canPinEvent}
+          relations={relations}
           isThreadedMessage={isThreadedMessage}
           hideReadReceipts={hideReadReceipts}
           showDeveloperTools={showDeveloperTools}

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -82,6 +82,7 @@ import {
 import type { PerMessageProfileBeeperFormat } from '$hooks/usePerMessageProfile';
 import { convertBeeperFormatToOurPerMessageProfile } from '$hooks/usePerMessageProfile';
 import { MessageEditor } from './MessageEditor';
+import { MobileMessageMenu } from './MobileMessageMenu';
 import * as css from './styles.css';
 
 export type ReactionHandler = (keyOrMxc: string, shortcode: string) => void;
@@ -291,6 +292,7 @@ export type MessageProps = {
 function useMobileLongPress(callback: () => void, delay = 500) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startPosRef = useRef<{ x: number; y: number } | null>(null);
+  const firedRef = useRef(false);
 
   const cancel = useCallback(() => {
     if (timerRef.current !== null) {
@@ -300,33 +302,45 @@ function useMobileLongPress(callback: () => void, delay = 500) {
     startPosRef.current = null;
   }, []);
 
-  const onPointerDown = useCallback(
-    (e: { clientX: number; clientY: number }) => {
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
       if (!mobileOrTablet()) return;
-      startPosRef.current = { x: e.clientX, y: e.clientY };
+      const touch = e.touches[0];
+      if (!touch) return;
+      startPosRef.current = { x: touch.clientX, y: touch.clientY };
+      firedRef.current = false;
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
+        firedRef.current = true;
+        // Clear any text selection the browser started during the long-press gesture.
+        window.getSelection()?.removeAllRanges();
         callback();
       }, delay);
     },
     [callback, delay]
   );
 
-  const onPointerMove = useCallback(
-    (e: { clientX: number; clientY: number }) => {
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
       if (!startPosRef.current) return;
-      const dx = e.clientX - startPosRef.current.x;
-      const dy = e.clientY - startPosRef.current.y;
+      const touch = e.touches[0];
+      if (!touch) return;
+      const dx = touch.clientX - startPosRef.current.x;
+      const dy = touch.clientY - startPosRef.current.y;
       if (Math.sqrt(dx * dx + dy * dy) > 10) cancel();
     },
     [cancel]
   );
 
+  const onTouchEnd = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
   return {
-    onPointerDown,
-    onPointerUp: cancel,
-    onPointerCancel: cancel,
-    onPointerMove,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    onTouchCancel: onTouchEnd,
   };
 }
 
@@ -546,8 +560,6 @@ function MessageInternal(
 
   const [mobileOptionsOpen, setMobileOptionsOpen] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
-
-  const [showPronouns] = useSetting(settingsAtom, 'showPronouns');
   const [parsePronouns] = useSetting(settingsAtom, 'parsePronouns');
 
   const [useRightBubbles] = useSetting(settingsAtom, 'useRightBubbles');
@@ -573,17 +585,6 @@ function MessageInternal(
     return existing;
   }, [pronouns, inlinePronoun]);
 
-  useEffect(() => {
-    if (!mobileOptionsOpen) return undefined;
-    const handleClickOutside = (e: globalThis.Event) => {
-      if (optionsRef.current && !optionsRef.current.contains(e.target as Node)) {
-        setMobileOptionsOpen(false);
-      }
-    };
-    document.addEventListener('pointerdown', handleClickOutside, { capture: true });
-    return () => document.removeEventListener('pointerdown', handleClickOutside, { capture: true });
-  }, [mobileOptionsOpen]);
-
   const headerJSX = !collapse && (
     <Box
       gap="300"
@@ -607,7 +608,7 @@ function MessageInternal(
             <UsernameBold>{cleanedDisplayName}</UsernameBold>
           </Text>
         </Username>
-        {showPronouns && (
+        {mergedPronouns.length > 0 && (
           <Pronouns pronouns={mergedPronouns} tagColor={usernameColor ?? 'currentColor'} />
         )}
         {showPmPInfo && (
@@ -854,6 +855,7 @@ function MessageInternal(
   const handleContextMenu: MouseEventHandler<HTMLDivElement> = (evt) => {
     if (mobileOrTablet()) {
       evt.preventDefault();
+      setMobileOptionsOpen(true);
       return;
     }
 
@@ -939,7 +941,7 @@ function MessageInternal(
       {...focusWithinProps}
       ref={ref}
     >
-      {!edit && (isDesktopHover || !!menuAnchor || !!emojiBoardAnchor || mobileOptionsOpen) && (
+      {!edit && (isDesktopHover || !!menuAnchor || !!emojiBoardAnchor) && (
         <div className={css.MessageOptionsBase} ref={optionsRef}>
           <Menu className={css.MessageOptionsBar} variant="SurfaceVariant">
             <Box gap="100">
@@ -1322,6 +1324,19 @@ function MessageInternal(
           </ModernLayout>
         </SwipeableMessageWrapper>
       )}
+      {mobileOptionsOpen && (
+        <MobileMessageMenu
+          room={room}
+          mEvent={mEvent}
+          canDelete={canDelete}
+          canSendReaction={canSendReaction}
+          isThreadedMessage={isThreadedMessage}
+          onReplyClick={onReplyClick}
+          onEditId={onEditId}
+          onReactionToggle={onReactionToggle}
+          onClose={() => setMobileOptionsOpen(false)}
+        />
+      )}
     </MessageBase>
   );
 }
@@ -1373,6 +1388,7 @@ export const Event = as<'div', EventProps>(
     const handleContextMenu: MouseEventHandler<HTMLDivElement> = (evt) => {
       if (mobileOrTablet()) {
         evt.preventDefault();
+        setMobileOptionsOpen(true);
         return;
       }
 
@@ -1416,17 +1432,6 @@ export const Event = as<'div', EventProps>(
 
     const optionsRef = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-      if (!mobileOptionsOpen) return undefined;
-      const handleClick = (e: globalThis.Event) => {
-        if (optionsRef.current && !optionsRef.current.contains(e.target as Node)) {
-          setMobileOptionsOpen(false);
-        }
-      };
-      document.addEventListener('pointerdown', handleClick, { capture: true });
-      return () => document.removeEventListener('pointerdown', handleClick, { capture: true });
-    }, [mobileOptionsOpen]);
-
     const longPress = useMobileLongPress(() => {
       setMobileOptionsOpen(true);
     });
@@ -1452,7 +1457,7 @@ export const Event = as<'div', EventProps>(
         {...focusWithinProps}
         ref={ref}
       >
-        {(isDesktopHover || !!menuAnchor || mobileOptionsOpen) && (
+        {(isDesktopHover || !!menuAnchor) && (
           <div className={css.MessageOptionsBase} ref={optionsRef}>
             <Menu className={css.MessageOptionsBar} variant="SurfaceVariant">
               <Box gap="100">
@@ -1560,6 +1565,16 @@ export const Event = as<'div', EventProps>(
         <div onContextMenu={handleContextMenu} {...longPress}>
           {children}
         </div>
+        {mobileOptionsOpen && (
+          <MobileMessageMenu
+            room={room}
+            mEvent={mEvent}
+            canDelete={canDelete}
+            onReplyClick={onReplyClick}
+            onReactionToggle={() => {}}
+            onClose={() => setMobileOptionsOpen(false)}
+          />
+        )}
       </MessageBase>
     );
   }

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -1343,6 +1343,7 @@ function MessageInternal(
           onReplyClick={onReplyClick}
           onEditId={onEditId}
           onReactionToggle={onReactionToggle}
+          imagePackRooms={imagePackRooms ?? []}
           onClose={() => setMobileOptionsOpen(false)}
         />
       )}
@@ -1583,6 +1584,7 @@ export const Event = as<'div', EventProps>(
             showDeveloperTools={showDeveloperTools}
             onReplyClick={onReplyClick}
             onReactionToggle={() => {}}
+            imagePackRooms={[]}
             onClose={() => setMobileOptionsOpen(false)}
           />
         )}

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -342,6 +342,13 @@ function useMobileLongPress(callback: () => void, delay = 500) {
     ? ({ userSelect: 'none', WebkitUserSelect: 'none' } as React.CSSProperties)
     : undefined;
 
+  useEffect(
+    () => () => {
+      cancel();
+    },
+    [cancel]
+  );
+
   return {
     onTouchStart,
     onTouchMove,
@@ -567,6 +574,7 @@ function MessageInternal(
 
   const [mobileOptionsOpen, setMobileOptionsOpen] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
+  const [showPronouns] = useSetting(settingsAtom, 'showPronouns');
   const [parsePronouns] = useSetting(settingsAtom, 'parsePronouns');
 
   const [useRightBubbles] = useSetting(settingsAtom, 'useRightBubbles');
@@ -615,7 +623,7 @@ function MessageInternal(
             <UsernameBold>{cleanedDisplayName}</UsernameBold>
           </Text>
         </Username>
-        {mergedPronouns.length > 0 && (
+        {showPronouns && mergedPronouns.length > 0 && (
           <Pronouns pronouns={mergedPronouns} tagColor={usernameColor ?? 'currentColor'} />
         )}
         {showPmPInfo && (

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -336,11 +336,18 @@ function useMobileLongPress(callback: () => void, delay = 500) {
     cancel();
   }, [cancel]);
 
+  // Prevent the browser from selecting message text during a long-press gesture.
+  // Only applied on touch devices — desktop users can still select text normally.
+  const style = mobileOrTablet()
+    ? ({ userSelect: 'none', WebkitUserSelect: 'none' } as React.CSSProperties)
+    : undefined;
+
   return {
     onTouchStart,
     onTouchMove,
     onTouchEnd,
     onTouchCancel: onTouchEnd,
+    style,
   };
 }
 
@@ -1331,6 +1338,8 @@ function MessageInternal(
           canDelete={canDelete}
           canSendReaction={canSendReaction}
           isThreadedMessage={isThreadedMessage}
+          hideReadReceipts={hideReadReceipts}
+          showDeveloperTools={showDeveloperTools}
           onReplyClick={onReplyClick}
           onEditId={onEditId}
           onReactionToggle={onReactionToggle}
@@ -1570,6 +1579,8 @@ export const Event = as<'div', EventProps>(
             room={room}
             mEvent={mEvent}
             canDelete={canDelete}
+            hideReadReceipts={hideReadReceipts}
+            showDeveloperTools={showDeveloperTools}
             onReplyClick={onReplyClick}
             onReactionToggle={() => {}}
             onClose={() => setMobileOptionsOpen(false)}

--- a/src/app/features/room/message/MobileMessageMenu.css.ts
+++ b/src/app/features/room/message/MobileMessageMenu.css.ts
@@ -1,5 +1,5 @@
 import { keyframes, style } from '@vanilla-extract/css';
-import { DefaultReset, config, toRem } from 'folds';
+import { DefaultReset, color, config, toRem } from 'folds';
 
 const slideUp = keyframes({
   from: { transform: 'translateY(100%)' },
@@ -9,7 +9,8 @@ const slideUp = keyframes({
 export const Backdrop = style({
   position: 'fixed',
   inset: 0,
-  background: 'rgba(0,0,0,0.72)',
+  // Theme-scrim overlay dims the timeline behind the sheet, just like Discord does.
+  background: color.Other.Overlay,
   zIndex: 100,
 });
 
@@ -21,12 +22,12 @@ export const Sheet = style([
     left: 0,
     right: 0,
     zIndex: 101,
-    background: 'var(--mx-c-surface)',
+    background: color.Surface.Container,
     borderRadius: `${toRem(16)} ${toRem(16)} 0 0`,
     paddingBottom: `max(${config.space.S400}, env(safe-area-inset-bottom))`,
     boxShadow: '0 -4px 24px rgba(0,0,0,0.18)',
     animation: `${slideUp} 220ms cubic-bezier(0.4, 0, 0.2, 1)`,
-    maxHeight: '80dvh',
+    maxHeight: '80vh',
     overflowY: 'auto',
   },
 ]);
@@ -34,7 +35,7 @@ export const Sheet = style([
 export const Handle = style({
   width: toRem(36),
   height: toRem(4),
-  background: 'var(--mx-c-outline-variant)',
+  background: color.SurfaceVariant.ContainerLine,
   borderRadius: toRem(2),
   margin: `${config.space.S200} auto ${config.space.S100}`,
 });
@@ -42,7 +43,7 @@ export const Handle = style({
 export const ReactionsRow = style({
   display: 'flex',
   gap: config.space.S200,
-  padding: `${config.space.S200} ${config.space.S400}`,
+  padding: `${config.space.S300} ${config.space.S400}`,
   justifyContent: 'center',
   flexWrap: 'wrap',
 });
@@ -51,9 +52,9 @@ export const ReactionBtn = style({
   fontSize: toRem(28),
   lineHeight: 1,
   padding: config.space.S100,
-  background: 'none',
+  background: color.SurfaceVariant.Container,
   border: 'none',
-  borderRadius: toRem(8),
+  borderRadius: '50%',
   cursor: 'pointer',
   minWidth: toRem(48),
   minHeight: toRem(48),
@@ -62,36 +63,41 @@ export const ReactionBtn = style({
   justifyContent: 'center',
   selectors: {
     '&:active': {
-      background: 'var(--mx-c-surface-variant)',
+      background: color.SurfaceVariant.ContainerActive,
     },
   },
 });
 
-export const ActionList = style({
-  display: 'flex',
-  flexDirection: 'column',
-  padding: `0 ${config.space.S200} ${config.space.S200}`,
+// A rounded-card group for visually separating action sections, like Discord.
+export const ActionGroup = style({
+  margin: `0 ${config.space.S300} ${config.space.S300}`,
+  borderRadius: toRem(12),
+  background: color.SurfaceVariant.Container,
+  overflow: 'hidden',
 });
 
 export const ActionItem = style({
   display: 'flex',
   alignItems: 'center',
   gap: config.space.S300,
-  padding: `${config.space.S300} ${config.space.S300}`,
-  borderRadius: toRem(8),
+  padding: `${config.space.S300} ${config.space.S400}`,
   cursor: 'pointer',
-  background: 'none',
+  background: 'transparent',
   border: 'none',
   width: '100%',
   textAlign: 'left',
-  color: 'var(--mx-c-on-surface)',
+  color: color.Surface.OnContainer,
   selectors: {
+    // Separator between adjacent items inside a group
+    '& + &': {
+      borderTop: `1px solid ${color.SurfaceVariant.ContainerLine}`,
+    },
     '&:active': {
-      background: 'var(--mx-c-surface-variant)',
+      background: color.SurfaceVariant.ContainerActive,
     },
   },
 });
 
 export const ActionItemDanger = style({
-  color: 'var(--mx-c-error)',
+  color: color.Critical.Main,
 });

--- a/src/app/features/room/message/MobileMessageMenu.css.ts
+++ b/src/app/features/room/message/MobileMessageMenu.css.ts
@@ -18,7 +18,7 @@ export const Sheet = style([
   DefaultReset,
   {
     position: 'fixed',
-    bottom: 0,
+    bottom: 'calc(100vh - var(--sable-visible-height, 100vh))',
     left: 0,
     right: 0,
     zIndex: 101,

--- a/src/app/features/room/message/MobileMessageMenu.css.ts
+++ b/src/app/features/room/message/MobileMessageMenu.css.ts
@@ -1,0 +1,97 @@
+import { keyframes, style } from '@vanilla-extract/css';
+import { DefaultReset, config, toRem } from 'folds';
+
+const slideUp = keyframes({
+  from: { transform: 'translateY(100%)' },
+  to: { transform: 'translateY(0)' },
+});
+
+export const Backdrop = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.72)',
+  zIndex: 100,
+});
+
+export const Sheet = style([
+  DefaultReset,
+  {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 101,
+    background: 'var(--mx-c-surface)',
+    borderRadius: `${toRem(16)} ${toRem(16)} 0 0`,
+    paddingBottom: `max(${config.space.S400}, env(safe-area-inset-bottom))`,
+    boxShadow: '0 -4px 24px rgba(0,0,0,0.18)',
+    animation: `${slideUp} 220ms cubic-bezier(0.4, 0, 0.2, 1)`,
+    maxHeight: '80dvh',
+    overflowY: 'auto',
+  },
+]);
+
+export const Handle = style({
+  width: toRem(36),
+  height: toRem(4),
+  background: 'var(--mx-c-outline-variant)',
+  borderRadius: toRem(2),
+  margin: `${config.space.S200} auto ${config.space.S100}`,
+});
+
+export const ReactionsRow = style({
+  display: 'flex',
+  gap: config.space.S200,
+  padding: `${config.space.S200} ${config.space.S400}`,
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+});
+
+export const ReactionBtn = style({
+  fontSize: toRem(28),
+  lineHeight: 1,
+  padding: config.space.S100,
+  background: 'none',
+  border: 'none',
+  borderRadius: toRem(8),
+  cursor: 'pointer',
+  minWidth: toRem(48),
+  minHeight: toRem(48),
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  selectors: {
+    '&:active': {
+      background: 'var(--mx-c-surface-variant)',
+    },
+  },
+});
+
+export const ActionList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: `0 ${config.space.S200} ${config.space.S200}`,
+});
+
+export const ActionItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: config.space.S300,
+  padding: `${config.space.S300} ${config.space.S300}`,
+  borderRadius: toRem(8),
+  cursor: 'pointer',
+  background: 'none',
+  border: 'none',
+  width: '100%',
+  textAlign: 'left',
+  color: 'var(--mx-c-on-surface)',
+  selectors: {
+    '&:active': {
+      background: 'var(--mx-c-surface-variant)',
+    },
+  },
+});
+
+export const ActionItemDanger = style({
+  color: 'var(--mx-c-error)',
+});

--- a/src/app/features/room/message/MobileMessageMenu.css.ts
+++ b/src/app/features/room/message/MobileMessageMenu.css.ts
@@ -139,3 +139,31 @@ export const EmojiPickerWrap = style({
   justifyContent: 'center',
   padding: config.space.S200,
 });
+
+export const NickEditSection = style({
+  padding: `${config.space.S300} ${config.space.S400}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: config.space.S200,
+});
+
+export const NickEditInput = style({
+  background: color.Surface.Container,
+  color: color.Surface.OnContainer,
+  border: `1px solid ${color.SurfaceVariant.ContainerLine}`,
+  borderRadius: toRem(6),
+  padding: `${config.space.S100} ${config.space.S200}`,
+  fontSize: toRem(14),
+  width: '100%',
+  outline: 'none',
+  selectors: {
+    '&:focus': {
+      borderColor: color.Primary.Main,
+    },
+  },
+});
+
+export const NickEditActions = style({
+  display: 'flex',
+  gap: config.space.S200,
+});

--- a/src/app/features/room/message/MobileMessageMenu.css.ts
+++ b/src/app/features/room/message/MobileMessageMenu.css.ts
@@ -101,3 +101,41 @@ export const ActionItem = style({
 export const ActionItemDanger = style({
   color: color.Critical.Main,
 });
+
+export const EmojiPickerHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  padding: `${config.space.S200} ${config.space.S300}`,
+  borderBottom: `1px solid ${color.SurfaceVariant.ContainerLine}`,
+});
+
+export const EmojiPickerBackBtn = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: toRem(36),
+  height: toRem(36),
+  background: 'transparent',
+  border: 'none',
+  borderRadius: '50%',
+  cursor: 'pointer',
+  color: color.Surface.OnContainer,
+  flexShrink: 0,
+  selectors: {
+    '&:active': {
+      background: color.SurfaceVariant.ContainerActive,
+    },
+  },
+});
+
+export const EmojiPickerTitle = style({
+  flexGrow: 1,
+  textAlign: 'center',
+  marginRight: toRem(36), // balance the back button width
+});
+
+export const EmojiPickerWrap = style({
+  display: 'flex',
+  justifyContent: 'center',
+  padding: config.space.S200,
+});

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -10,11 +10,11 @@ import { canEditEvent, getEventEdits } from '$utils/room';
 import { modalAtom, ModalType } from '$state/modal';
 import { MessageDeleteItem } from '$components/message/modals/MessageDelete';
 import { MessageReportItem } from '$components/message/modals/MessageReport';
-import { MessageForwardItem } from '$components/message/modals/MessageForward';
 import { copyToClipboard } from '$utils/dom';
 import { getMatrixToRoomEvent } from '$plugins/matrix-to';
 import { getViaServers } from '$plugins/via-servers';
-import { useBookmarks, isBookmarked, toggleBookmark } from '$hooks/useBookmarks';
+import { useIsBookmarked, useBookmarkActions } from '$features/bookmarks/useBookmarks';
+import { createBookmarkItem, computeBookmarkId } from '$features/bookmarks/bookmarkDomain';
 import * as css from './MobileMessageMenu.css';
 
 export type MobileMessageMenuProps = {
@@ -103,10 +103,9 @@ function BookmarkActionItem({
   mEvent: MatrixEvent;
   onClose: () => void;
 }) {
-  const mx = useMatrixClient();
-  const bookmarks = useBookmarks();
   const eventId = mEvent.getId() ?? '';
-  const bookmarked = isBookmarked(bookmarks, eventId);
+  const bookmarked = useIsBookmarked(room.roomId, eventId);
+  const { add, remove } = useBookmarkActions();
 
   if (mEvent.isRedacted()) return null;
 
@@ -115,7 +114,12 @@ function BookmarkActionItem({
       icon={<Icon src={Icons.Star} size="200" />}
       label={bookmarked ? 'Remove Bookmark' : 'Bookmark'}
       onClick={() => {
-        toggleBookmark(mx, room.roomId, eventId, bookmarks).catch(() => {});
+        if (bookmarked) {
+          remove(computeBookmarkId(room.roomId, eventId)).catch(() => {});
+        } else {
+          const item = createBookmarkItem(room, mEvent);
+          if (item) add(item).catch(() => {});
+        }
         onClose();
       }}
     />
@@ -248,11 +252,13 @@ export function MobileMessageMenu({
               onClick={handleEditClick}
             />
           )}
-          <MessageForwardItem
-            className={css.ActionItem}
-            room={room}
-            mEvent={mEvent}
-            onClose={onClose}
+          <ActionItem
+            icon={<Icon src={Icons.ArrowGoRight} size="200" />}
+            label="Forward"
+            onClick={() => {
+              setModal({ type: ModalType.Forward, room, mEvent });
+              onClose();
+            }}
           />
           {!hideReadReceipts && (
             <ActionItem

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -1,11 +1,13 @@
 import { createPortal } from 'react-dom';
-import { Icon, Icons, Line, Text } from 'folds';
+import { Icon, Icons, Text } from 'folds';
 import type { MouseEventHandler, ReactNode } from 'react';
 import { useEffect, useCallback } from 'react';
+import { useSetAtom } from 'jotai';
 import type { MatrixEvent, Room } from '$types/matrix-sdk';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useRecentEmoji } from '$hooks/useRecentEmoji';
-import { canEditEvent } from '$utils/room';
+import { canEditEvent, getEventEdits } from '$utils/room';
+import { modalAtom, ModalType } from '$state/modal';
 import { MessageDeleteItem } from '$components/message/modals/MessageDelete';
 import { MessageReportItem } from '$components/message/modals/MessageReport';
 import { MessageForwardItem } from '$components/message/modals/MessageForward';
@@ -21,6 +23,8 @@ export type MobileMessageMenuProps = {
   canDelete?: boolean;
   canSendReaction?: boolean;
   isThreadedMessage?: boolean;
+  hideReadReceipts?: boolean;
+  showDeveloperTools?: boolean;
   onReplyClick: (
     ev: Parameters<MouseEventHandler<HTMLButtonElement>>[0],
     startThread?: boolean
@@ -124,6 +128,8 @@ export function MobileMessageMenu({
   canDelete,
   canSendReaction,
   isThreadedMessage,
+  hideReadReceipts,
+  showDeveloperTools,
   onReplyClick,
   onEditId,
   onReactionToggle,
@@ -131,7 +137,13 @@ export function MobileMessageMenu({
   onClose,
 }: MobileMessageMenuProps) {
   const mx = useMatrixClient();
+  const setModal = useSetAtom(modalAtom);
   const evtId = mEvent.getId()!;
+  const evtTimeline = room.getTimelineForEvent(evtId);
+  const edits =
+    evtTimeline &&
+    getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
+  const isEdited = edits !== undefined;
 
   // Close on Escape
   useEffect(() => {
@@ -212,11 +224,11 @@ export function MobileMessageMenu({
                   : undefined
               }
             />
-            <Line size="300" />
           </>
         )}
 
-        <div className={css.ActionList}>
+        {/* Group 1: Message actions */}
+        <div className={css.ActionGroup}>
           <ActionItem
             icon={<Icon src={Icons.ReplyArrow} size="200" />}
             label="Reply"
@@ -236,6 +248,46 @@ export function MobileMessageMenu({
               onClick={handleEditClick}
             />
           )}
+          <MessageForwardItem
+            className={css.ActionItem}
+            room={room}
+            mEvent={mEvent}
+            onClose={onClose}
+          />
+          {!hideReadReceipts && (
+            <ActionItem
+              icon={<Icon src={Icons.CheckTwice} size="200" />}
+              label="Read Receipts"
+              onClick={() => {
+                setModal({ type: ModalType.ReadReceipts, room, eventId: evtId });
+                onClose();
+              }}
+            />
+          )}
+          {isEdited && (
+            <ActionItem
+              icon={<Icon src={Icons.Clock} size="200" />}
+              label="Version History"
+              onClick={() => {
+                setModal({ type: ModalType.EditHistory, room, mEvent });
+                onClose();
+              }}
+            />
+          )}
+          {showDeveloperTools && (
+            <ActionItem
+              icon={<Icon src={Icons.BlockCode} size="200" />}
+              label="View Source"
+              onClick={() => {
+                setModal({ type: ModalType.Source, room, mEvent });
+                onClose();
+              }}
+            />
+          )}
+        </div>
+
+        {/* Group 2: Utility actions */}
+        <div className={css.ActionGroup}>
           {(() => {
             const content = mEvent.getContent();
             const body: string | undefined = content['m.new_content']?.body ?? content.body;
@@ -263,21 +315,18 @@ export function MobileMessageMenu({
               }}
             />
           )}
-          <MessageForwardItem room={room} mEvent={mEvent} onClose={onClose} />
           <BookmarkActionItem room={room} mEvent={mEvent} onClose={onClose} />
-          {!mEvent.isRedacted() && canDelete && (
-            <>
-              <Line size="300" />
-              <MessageDeleteItem room={room} mEvent={mEvent} />
-            </>
-          )}
-          {mEvent.getSender() !== mx.getUserId() && (
-            <>
-              <Line size="300" />
-              <MessageReportItem room={room} mEvent={mEvent} />
-            </>
-          )}
         </div>
+
+        {/* Group 3: Destructive actions */}
+        {(!mEvent.isRedacted() && canDelete) || mEvent.getSender() !== mx.getUserId() ? (
+          <div className={css.ActionGroup}>
+            {!mEvent.isRedacted() && canDelete && <MessageDeleteItem room={room} mEvent={mEvent} />}
+            {mEvent.getSender() !== mx.getUserId() && (
+              <MessageReportItem room={room} mEvent={mEvent} />
+            )}
+          </div>
+        ) : null}
       </div>
     </>,
     portalContainer

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -14,8 +14,6 @@ import { MessageReportItem } from '$components/message/modals/MessageReport';
 import { copyToClipboard } from '$utils/dom';
 import { getMatrixToRoomEvent } from '$plugins/matrix-to';
 import { getViaServers } from '$plugins/via-servers';
-import { useIsBookmarked, useBookmarkActions } from '$features/bookmarks/useBookmarks';
-import { createBookmarkItem, computeBookmarkId } from '$features/bookmarks/bookmarkDomain';
 import * as css from './MobileMessageMenu.css';
 
 export type MobileMessageMenuProps = {
@@ -92,38 +90,6 @@ function ActionItem({ icon, label, danger, onClick }: ActionItemProps) {
         {label}
       </Text>
     </button>
-  );
-}
-
-function BookmarkActionItem({
-  room,
-  mEvent,
-  onClose,
-}: {
-  room: Room;
-  mEvent: MatrixEvent;
-  onClose: () => void;
-}) {
-  const eventId = mEvent.getId() ?? '';
-  const bookmarked = useIsBookmarked(room.roomId, eventId);
-  const { add, remove } = useBookmarkActions();
-
-  if (mEvent.isRedacted()) return null;
-
-  return (
-    <ActionItem
-      icon={<Icon src={Icons.Star} size="200" />}
-      label={bookmarked ? 'Remove Bookmark' : 'Bookmark'}
-      onClick={() => {
-        if (bookmarked) {
-          remove(computeBookmarkId(room.roomId, eventId)).catch(() => {});
-        } else {
-          const item = createBookmarkItem(room, mEvent);
-          if (item) add(item).catch(() => {});
-        }
-        onClose();
-      }}
-    />
   );
 }
 
@@ -411,7 +377,6 @@ export function MobileMessageMenu({
                   }}
                 />
               )}
-              <BookmarkActionItem room={room} mEvent={mEvent} onClose={onClose} />
             </div>
 
             {/* Group 3: Destructive actions */}

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -1,5 +1,6 @@
 import { createPortal } from 'react-dom';
-import { Icon, Icons, Text } from 'folds';
+import { Icon, Icons, MenuItem, Text } from 'folds';
+import * as messageCss from './styles.css';
 import type { MouseEventHandler, ReactNode, TouchEvent as ReactTouchEvent } from 'react';
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { EmojiBoard } from '$components/emoji-board';
@@ -142,6 +143,7 @@ export function MobileMessageMenu({
   const setNickname = useSetAtom(setNicknameAtom);
   const [nickEditOpen, setNickEditOpen] = useState(false);
   const [nickDraft, setNickDraft] = useState('');
+  const nickInputRef = useRef<HTMLInputElement>(null);
 
   // Bookmarks
   const [enableMessageBookmarks] = useSetting(settingsAtom, 'enableMessageBookmarks');
@@ -151,6 +153,16 @@ export function MobileMessageMenu({
   // Register a keyboard-height listener so --sable-visible-height is set when the
   // nickname input is focused. The Sheet CSS uses that variable to stay above the keyboard.
   useKeyboardHeight();
+
+  // Delay focus so iOS's synthesised tap fires before the keyboard opens and
+  // shifts the sheet, preventing the tap from landing on the backdrop.
+  useEffect(() => {
+    if (nickEditOpen) {
+      const id = setTimeout(() => nickInputRef.current?.focus(), 100);
+      return () => clearTimeout(id);
+    }
+    return undefined;
+  }, [nickEditOpen]);
 
   // Kick permissions
   const powerLevels = usePowerLevels(room);
@@ -453,8 +465,7 @@ export function MobileMessageMenu({
                       Nickname
                     </Text>
                     <input
-                      // eslint-disable-next-line jsx-a11y/no-autofocus
-                      autoFocus
+                      ref={nickInputRef}
                       className={css.NickEditInput}
                       value={nickDraft}
                       onChange={(e) => setNickDraft(e.target.value)}
@@ -536,12 +547,18 @@ export function MobileMessageMenu({
             canKick ? (
               <div className={css.ActionGroup}>
                 {canKick && (
-                  <ActionItem
-                    icon={<Icon src={Icons.ArrowLeft} size="200" />}
-                    label="Kick from Room"
-                    danger
+                  <MenuItem
+                    size="300"
+                    after={<Icon size="100" src={Icons.ArrowLeft} />}
+                    radii="300"
+                    fill="None"
+                    variant="Critical"
                     onClick={handleKick}
-                  />
+                  >
+                    <Text className={messageCss.MessageMenuItemText} as="span" size="T300" truncate>
+                      Kick from Room
+                    </Text>
+                  </MenuItem>
                 )}
                 {!mEvent.isRedacted() && canDelete && (
                   <MessageDeleteItem room={room} mEvent={mEvent} />

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -1,0 +1,285 @@
+import { createPortal } from 'react-dom';
+import { Icon, Icons, Line, Text } from 'folds';
+import type { MouseEventHandler, ReactNode } from 'react';
+import { useEffect, useCallback } from 'react';
+import type { MatrixEvent, Room } from '$types/matrix-sdk';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useRecentEmoji } from '$hooks/useRecentEmoji';
+import { canEditEvent } from '$utils/room';
+import { MessageDeleteItem } from '$components/message/modals/MessageDelete';
+import { MessageReportItem } from '$components/message/modals/MessageReport';
+import { MessageForwardItem } from '$components/message/modals/MessageForward';
+import { copyToClipboard } from '$utils/dom';
+import { getMatrixToRoomEvent } from '$plugins/matrix-to';
+import { getViaServers } from '$plugins/via-servers';
+import { useBookmarks, isBookmarked, toggleBookmark } from '$hooks/useBookmarks';
+import * as css from './MobileMessageMenu.css';
+
+export type MobileMessageMenuProps = {
+  room: Room;
+  mEvent: MatrixEvent;
+  canDelete?: boolean;
+  canSendReaction?: boolean;
+  isThreadedMessage?: boolean;
+  onReplyClick: (
+    ev: Parameters<MouseEventHandler<HTMLButtonElement>>[0],
+    startThread?: boolean
+  ) => void;
+  onEditId?: (eventId?: string) => void;
+  onReactionToggle: (targetEventId: string, key: string, shortcode?: string) => void;
+  onOpenEmojiBoard?: () => void;
+  onClose: () => void;
+};
+
+function QuickReactions({
+  onReaction,
+  onOpenEmojiBoard,
+}: {
+  onReaction: (key: string, shortcode: string) => void;
+  onOpenEmojiBoard?: () => void;
+}) {
+  const mx = useMatrixClient();
+  const recentEmojis = useRecentEmoji(mx, 5);
+
+  return (
+    <div className={css.ReactionsRow}>
+      {recentEmojis.map((emoji) => (
+        <button
+          key={emoji.unicode}
+          type="button"
+          className={css.ReactionBtn}
+          onClick={() => onReaction(emoji.unicode, emoji.shortcode)}
+          aria-label={emoji.shortcode}
+        >
+          {emoji.unicode}
+        </button>
+      ))}
+      {onOpenEmojiBoard && (
+        <button
+          type="button"
+          className={css.ReactionBtn}
+          onClick={onOpenEmojiBoard}
+          aria-label="More reactions"
+        >
+          <Icon src={Icons.SmilePlus} size="200" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+type ActionItemProps = {
+  icon: ReactNode;
+  label: string;
+  danger?: boolean;
+  onClick: () => void;
+};
+
+function ActionItem({ icon, label, danger, onClick }: ActionItemProps) {
+  return (
+    <button
+      type="button"
+      className={`${css.ActionItem}${danger ? ` ${css.ActionItemDanger}` : ''}`}
+      onClick={onClick}
+    >
+      {icon}
+      <Text size="T300" as="span">
+        {label}
+      </Text>
+    </button>
+  );
+}
+
+function BookmarkActionItem({
+  room,
+  mEvent,
+  onClose,
+}: {
+  room: Room;
+  mEvent: MatrixEvent;
+  onClose: () => void;
+}) {
+  const mx = useMatrixClient();
+  const bookmarks = useBookmarks();
+  const eventId = mEvent.getId() ?? '';
+  const bookmarked = isBookmarked(bookmarks, eventId);
+
+  if (mEvent.isRedacted()) return null;
+
+  return (
+    <ActionItem
+      icon={<Icon src={Icons.Star} size="200" />}
+      label={bookmarked ? 'Remove Bookmark' : 'Bookmark'}
+      onClick={() => {
+        toggleBookmark(mx, room.roomId, eventId, bookmarks).catch(() => {});
+        onClose();
+      }}
+    />
+  );
+}
+
+export function MobileMessageMenu({
+  room,
+  mEvent,
+  canDelete,
+  canSendReaction,
+  isThreadedMessage,
+  onReplyClick,
+  onEditId,
+  onReactionToggle,
+  onOpenEmojiBoard,
+  onClose,
+}: MobileMessageMenuProps) {
+  const mx = useMatrixClient();
+  const evtId = mEvent.getId()!;
+
+  // Close on Escape
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Prevent body scroll while open
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  const handleReplyClick = useCallback(() => {
+    const mockEvent = {
+      currentTarget: { getAttribute: (attr: string) => (attr === 'data-event-id' ? evtId : null) },
+    } as unknown as Parameters<MouseEventHandler<HTMLButtonElement>>[0];
+    onReplyClick(mockEvent);
+    onClose();
+  }, [evtId, onReplyClick, onClose]);
+
+  const handleThreadReplyClick = useCallback(() => {
+    const mockEvent = {
+      currentTarget: { getAttribute: (attr: string) => (attr === 'data-event-id' ? evtId : null) },
+    } as unknown as Parameters<MouseEventHandler<HTMLButtonElement>>[0];
+    onReplyClick(mockEvent, true);
+    onClose();
+  }, [evtId, onReplyClick, onClose]);
+
+  const handleEditClick = useCallback(() => {
+    onEditId?.(evtId);
+    onClose();
+  }, [evtId, onEditId, onClose]);
+
+  const stopPropHandler = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+  const portalContainer = document.getElementById('portalContainer') ?? document.body;
+
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      <div
+        role="presentation"
+        className={css.Backdrop}
+        onClick={onClose}
+        onKeyDown={(e) => e.key === 'Escape' && onClose()}
+      />
+
+      {/* Sheet */}
+      <div
+        className={css.Sheet}
+        role="dialog"
+        aria-modal="true"
+        onClick={stopPropHandler}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <div className={css.Handle} />
+
+        {canSendReaction && (
+          <>
+            <QuickReactions
+              onReaction={(key, shortcode) => {
+                onReactionToggle(evtId, key, shortcode);
+                onClose();
+              }}
+              onOpenEmojiBoard={
+                onOpenEmojiBoard
+                  ? () => {
+                      onOpenEmojiBoard();
+                      onClose();
+                    }
+                  : undefined
+              }
+            />
+            <Line size="300" />
+          </>
+        )}
+
+        <div className={css.ActionList}>
+          <ActionItem
+            icon={<Icon src={Icons.ReplyArrow} size="200" />}
+            label="Reply"
+            onClick={handleReplyClick}
+          />
+          {!isThreadedMessage && (
+            <ActionItem
+              icon={<Icon src={Icons.ThreadPlus} size="200" />}
+              label="Reply in Thread"
+              onClick={handleThreadReplyClick}
+            />
+          )}
+          {canEditEvent(mx, mEvent) && onEditId && (
+            <ActionItem
+              icon={<Icon src={Icons.Pencil} size="200" />}
+              label="Edit Message"
+              onClick={handleEditClick}
+            />
+          )}
+          {(() => {
+            const content = mEvent.getContent();
+            const body: string | undefined = content['m.new_content']?.body ?? content.body;
+            if (!body || mEvent.isRedacted()) return null;
+            return (
+              <ActionItem
+                icon={<Icon src={Icons.Alphabet} size="200" />}
+                label="Copy Text"
+                onClick={() => {
+                  copyToClipboard(body);
+                  onClose();
+                }}
+              />
+            );
+          })()}
+          {mEvent.getId() && (
+            <ActionItem
+              icon={<Icon src={Icons.Link} size="200" />}
+              label="Copy Link"
+              onClick={() => {
+                copyToClipboard(
+                  getMatrixToRoomEvent(room.roomId, mEvent.getId()!, getViaServers(room))
+                );
+                onClose();
+              }}
+            />
+          )}
+          <MessageForwardItem room={room} mEvent={mEvent} onClose={onClose} />
+          <BookmarkActionItem room={room} mEvent={mEvent} onClose={onClose} />
+          {!mEvent.isRedacted() && canDelete && (
+            <>
+              <Line size="300" />
+              <MessageDeleteItem room={room} mEvent={mEvent} />
+            </>
+          )}
+          {mEvent.getSender() !== mx.getUserId() && (
+            <>
+              <Line size="300" />
+              <MessageReportItem room={room} mEvent={mEvent} />
+            </>
+          )}
+        </div>
+      </div>
+    </>,
+    portalContainer
+  );
+}

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -20,10 +20,6 @@ import { getViaServers } from '$plugins/via-servers';
 import { nicknamesAtom, setNicknameAtom } from '$state/nicknames';
 import { useRoomPinnedEvents } from '$hooks/useRoomPinnedEvents';
 import { useKeyboardHeight } from '$hooks/ios-keyboard-fix';
-import { computeBookmarkId, createBookmarkItem } from '$features/bookmarks/bookmarkDomain';
-import { useIsBookmarked, useBookmarkActions } from '$features/bookmarks/useBookmarks';
-import { useSetting } from '$state/hooks/settings';
-import { settingsAtom } from '$state/settings';
 import { usePowerLevels } from '$hooks/usePowerLevels';
 import { useRoomCreators } from '$hooks/useRoomCreators';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
@@ -144,11 +140,6 @@ export function MobileMessageMenu({
   const [nickEditOpen, setNickEditOpen] = useState(false);
   const [nickDraft, setNickDraft] = useState('');
   const nickInputRef = useRef<HTMLInputElement>(null);
-
-  // Bookmarks
-  const [enableMessageBookmarks] = useSetting(settingsAtom, 'enableMessageBookmarks');
-  const isBookmarked = useIsBookmarked(room.roomId, evtId);
-  const { add: addBookmark, remove: removeBookmark } = useBookmarkActions();
 
   // Register a keyboard-height listener so --sable-visible-height is set when the
   // nickname input is focused. The Sheet CSS uses that variable to stay above the keyboard.
@@ -287,16 +278,6 @@ export function MobileMessageMenu({
     await mx.kick(room.roomId, senderId);
     onClose();
   }, [mx, room, senderId, onClose]);
-
-  const handleBookmarkClick = useCallback(async () => {
-    if (isBookmarked) {
-      await removeBookmark(computeBookmarkId(room.roomId, evtId));
-    } else {
-      const item = createBookmarkItem(room, mEvent);
-      if (item) await addBookmark(item);
-    }
-    onClose();
-  }, [isBookmarked, removeBookmark, room, evtId, mEvent, addBookmark, onClose]);
 
   const stopPropHandler = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
 
@@ -449,13 +430,6 @@ export function MobileMessageMenu({
                   icon={<Icon src={Icons.Pin} size="200" />}
                   label={isPinned ? 'Unpin Message' : 'Pin Message'}
                   onClick={handlePinClick}
-                />
-              )}
-              {enableMessageBookmarks && (
-                <ActionItem
-                  icon={<Icon src={Icons.Bookmark} size="200" filled={isBookmarked} />}
-                  label={isBookmarked ? 'Remove Bookmark' : 'Bookmark Message'}
-                  onClick={handleBookmarkClick}
                 />
               )}
               {senderId !== myUserId &&

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -18,6 +18,11 @@ import { getMatrixToRoomEvent } from '$plugins/matrix-to';
 import { getViaServers } from '$plugins/via-servers';
 import { nicknamesAtom, setNicknameAtom } from '$state/nicknames';
 import { useRoomPinnedEvents } from '$hooks/useRoomPinnedEvents';
+import { useKeyboardHeight } from '$hooks/ios-keyboard-fix';
+import { computeBookmarkId, createBookmarkItem } from '$features/bookmarks/bookmarkDomain';
+import { useIsBookmarked, useBookmarkActions } from '$features/bookmarks/useBookmarks';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
 import { usePowerLevels } from '$hooks/usePowerLevels';
 import { useRoomCreators } from '$hooks/useRoomCreators';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
@@ -137,6 +142,15 @@ export function MobileMessageMenu({
   const setNickname = useSetAtom(setNicknameAtom);
   const [nickEditOpen, setNickEditOpen] = useState(false);
   const [nickDraft, setNickDraft] = useState('');
+
+  // Bookmarks
+  const [enableMessageBookmarks] = useSetting(settingsAtom, 'enableMessageBookmarks');
+  const isBookmarked = useIsBookmarked(room.roomId, evtId);
+  const { add: addBookmark, remove: removeBookmark } = useBookmarkActions();
+
+  // Register a keyboard-height listener so --sable-visible-height is set when the
+  // nickname input is focused. The Sheet CSS uses that variable to stay above the keyboard.
+  useKeyboardHeight();
 
   // Kick permissions
   const powerLevels = usePowerLevels(room);
@@ -261,6 +275,16 @@ export function MobileMessageMenu({
     await mx.kick(room.roomId, senderId);
     onClose();
   }, [mx, room, senderId, onClose]);
+
+  const handleBookmarkClick = useCallback(async () => {
+    if (isBookmarked) {
+      await removeBookmark(computeBookmarkId(room.roomId, evtId));
+    } else {
+      const item = createBookmarkItem(room, mEvent);
+      if (item) await addBookmark(item);
+    }
+    onClose();
+  }, [isBookmarked, removeBookmark, room, evtId, mEvent, addBookmark, onClose]);
 
   const stopPropHandler = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
 
@@ -413,6 +437,13 @@ export function MobileMessageMenu({
                   icon={<Icon src={Icons.Pin} size="200" />}
                   label={isPinned ? 'Unpin Message' : 'Pin Message'}
                   onClick={handlePinClick}
+                />
+              )}
+              {enableMessageBookmarks && (
+                <ActionItem
+                  icon={<Icon src={Icons.Bookmark} size="200" filled={isBookmarked} />}
+                  label={isBookmarked ? 'Remove Bookmark' : 'Bookmark Message'}
+                  onClick={handleBookmarkClick}
                 />
               )}
               {senderId !== myUserId &&

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -3,8 +3,10 @@ import { Icon, Icons, Text } from 'folds';
 import type { MouseEventHandler, ReactNode, TouchEvent as ReactTouchEvent } from 'react';
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { EmojiBoard } from '$components/emoji-board';
-import { useSetAtom } from 'jotai';
-import type { MatrixEvent, Room } from '$types/matrix-sdk';
+import { useAtomValue, useSetAtom } from 'jotai';
+import type { MatrixEvent, Relations, Room, RoomPinnedEventsEventContent } from '$types/matrix-sdk';
+import { EventType } from '$types/matrix-sdk';
+import type { StateEvents } from '$types/matrix-sdk';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useRecentEmoji } from '$hooks/useRecentEmoji';
 import { canEditEvent, getEventEdits } from '$utils/room';
@@ -14,6 +16,12 @@ import { MessageReportItem } from '$components/message/modals/MessageReport';
 import { copyToClipboard } from '$utils/dom';
 import { getMatrixToRoomEvent } from '$plugins/matrix-to';
 import { getViaServers } from '$plugins/via-servers';
+import { nicknamesAtom, setNicknameAtom } from '$state/nicknames';
+import { useRoomPinnedEvents } from '$hooks/useRoomPinnedEvents';
+import { usePowerLevels } from '$hooks/usePowerLevels';
+import { useRoomCreators } from '$hooks/useRoomCreators';
+import { useRoomPermissions } from '$hooks/useRoomPermissions';
+import { useMemberPowerCompare } from '$hooks/useMemberPowerCompare';
 import * as css from './MobileMessageMenu.css';
 
 export type MobileMessageMenuProps = {
@@ -21,6 +29,8 @@ export type MobileMessageMenuProps = {
   mEvent: MatrixEvent;
   canDelete?: boolean;
   canSendReaction?: boolean;
+  canPinEvent?: boolean;
+  relations?: Relations;
   isThreadedMessage?: boolean;
   hideReadReceipts?: boolean;
   showDeveloperTools?: boolean;
@@ -98,6 +108,8 @@ export function MobileMessageMenu({
   mEvent,
   canDelete,
   canSendReaction,
+  canPinEvent,
+  relations,
   isThreadedMessage,
   hideReadReceipts,
   showDeveloperTools,
@@ -115,6 +127,28 @@ export function MobileMessageMenu({
     evtTimeline &&
     getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
   const isEdited = edits !== undefined;
+
+  // Pinning
+  const pinnedEvents = useRoomPinnedEvents(room);
+  const isPinned = pinnedEvents.includes(evtId);
+
+  // Nicknames
+  const nicknames = useAtomValue(nicknamesAtom);
+  const setNickname = useSetAtom(setNicknameAtom);
+  const [nickEditOpen, setNickEditOpen] = useState(false);
+  const [nickDraft, setNickDraft] = useState('');
+
+  // Kick permissions
+  const powerLevels = usePowerLevels(room);
+  const creators = useRoomCreators(room);
+  const roomPermissions = useRoomPermissions(creators, powerLevels);
+  const { hasMorePower } = useMemberPowerCompare(creators, powerLevels);
+  const myUserId = mx.getSafeUserId();
+  const senderId = mEvent.getSender() ?? '';
+  const canKick =
+    senderId !== myUserId &&
+    roomPermissions.action('kick', myUserId) &&
+    hasMorePower(myUserId, senderId);
 
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
 
@@ -213,6 +247,20 @@ export function MobileMessageMenu({
     onEditId?.(evtId);
     onClose();
   }, [evtId, onEditId, onClose]);
+
+  const handlePinClick = useCallback(() => {
+    const pinContent: RoomPinnedEventsEventContent = {
+      pinned: Array.from(pinnedEvents).filter((id) => id !== evtId),
+    };
+    if (!isPinned) pinContent.pinned.push(evtId);
+    mx.sendStateEvent(room.roomId, EventType.RoomPinnedEvents as keyof StateEvents, pinContent);
+    onClose();
+  }, [pinnedEvents, isPinned, evtId, mx, room, onClose]);
+
+  const handleKick = useCallback(async () => {
+    await mx.kick(room.roomId, senderId);
+    onClose();
+  }, [mx, room, senderId, onClose]);
 
   const stopPropHandler = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
 
@@ -346,10 +394,82 @@ export function MobileMessageMenu({
                   }}
                 />
               )}
+              {relations && (
+                <ActionItem
+                  icon={<Icon src={Icons.Smile} size="200" />}
+                  label="View Reactions"
+                  onClick={() => {
+                    setModal({ type: ModalType.Reactions, room, relations });
+                    onClose();
+                  }}
+                />
+              )}
             </div>
 
             {/* Group 2: Utility actions */}
             <div className={css.ActionGroup}>
+              {canPinEvent && (
+                <ActionItem
+                  icon={<Icon src={Icons.Pin} size="200" />}
+                  label={isPinned ? 'Unpin Message' : 'Pin Message'}
+                  onClick={handlePinClick}
+                />
+              )}
+              {senderId !== myUserId &&
+                (nickEditOpen ? (
+                  <div className={css.NickEditSection}>
+                    <Text size="L400" as="span">
+                      Nickname
+                    </Text>
+                    <input
+                      // eslint-disable-next-line jsx-a11y/no-autofocus
+                      autoFocus
+                      className={css.NickEditInput}
+                      value={nickDraft}
+                      onChange={(e) => setNickDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          setNickname(senderId, nickDraft || undefined, mx);
+                          setNickEditOpen(false);
+                          onClose();
+                        }
+                        if (e.key === 'Escape') setNickEditOpen(false);
+                      }}
+                    />
+                    <div className={css.NickEditActions}>
+                      <ActionItem
+                        icon={<Icon src={Icons.Check} size="200" />}
+                        label="Save"
+                        onClick={() => {
+                          setNickname(senderId, nickDraft || undefined, mx);
+                          setNickEditOpen(false);
+                          onClose();
+                        }}
+                      />
+                      {nicknames[senderId] && (
+                        <ActionItem
+                          icon={<Icon src={Icons.Cross} size="200" />}
+                          label="Clear"
+                          danger
+                          onClick={() => {
+                            setNickname(senderId, undefined, mx);
+                            setNickEditOpen(false);
+                            onClose();
+                          }}
+                        />
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <ActionItem
+                    icon={<Icon src={Icons.Pencil} size="200" />}
+                    label={nicknames[senderId] ? 'Edit Nickname' : 'Set Nickname'}
+                    onClick={() => {
+                      setNickDraft(nicknames[senderId] ?? '');
+                      setNickEditOpen(true);
+                    }}
+                  />
+                ))}
               {(() => {
                 const content = mEvent.getContent();
                 const body: string | undefined = content['m.new_content']?.body ?? content.body;
@@ -380,8 +500,18 @@ export function MobileMessageMenu({
             </div>
 
             {/* Group 3: Destructive actions */}
-            {(!mEvent.isRedacted() && canDelete) || mEvent.getSender() !== mx.getUserId() ? (
+            {(!mEvent.isRedacted() && canDelete) ||
+            mEvent.getSender() !== mx.getUserId() ||
+            canKick ? (
               <div className={css.ActionGroup}>
+                {canKick && (
+                  <ActionItem
+                    icon={<Icon src={Icons.ArrowLeft} size="200" />}
+                    label="Kick from Room"
+                    danger
+                    onClick={handleKick}
+                  />
+                )}
                 {!mEvent.isRedacted() && canDelete && (
                   <MessageDeleteItem room={room} mEvent={mEvent} />
                 )}

--- a/src/app/features/room/message/MobileMessageMenu.tsx
+++ b/src/app/features/room/message/MobileMessageMenu.tsx
@@ -1,7 +1,8 @@
 import { createPortal } from 'react-dom';
 import { Icon, Icons, Text } from 'folds';
-import type { MouseEventHandler, ReactNode } from 'react';
-import { useEffect, useCallback } from 'react';
+import type { MouseEventHandler, ReactNode, TouchEvent as ReactTouchEvent } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
+import { EmojiBoard } from '$components/emoji-board';
 import { useSetAtom } from 'jotai';
 import type { MatrixEvent, Room } from '$types/matrix-sdk';
 import { useMatrixClient } from '$hooks/useMatrixClient';
@@ -30,8 +31,8 @@ export type MobileMessageMenuProps = {
     startThread?: boolean
   ) => void;
   onEditId?: (eventId?: string) => void;
+  imagePackRooms: Room[];
   onReactionToggle: (targetEventId: string, key: string, shortcode?: string) => void;
-  onOpenEmojiBoard?: () => void;
   onClose: () => void;
 };
 
@@ -137,7 +138,7 @@ export function MobileMessageMenu({
   onReplyClick,
   onEditId,
   onReactionToggle,
-  onOpenEmojiBoard,
+  imagePackRooms,
   onClose,
 }: MobileMessageMenuProps) {
   const mx = useMatrixClient();
@@ -148,6 +149,65 @@ export function MobileMessageMenu({
     evtTimeline &&
     getEventEdits(evtTimeline.getTimelineSet(), evtId, mEvent.getType())?.getRelations();
   const isEdited = edits !== undefined;
+
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+
+  // Refs for direct DOM manipulation during drag (avoids React re-renders on every frame)
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const dragStartYRef = useRef<number | null>(null);
+
+  const handleSheetTouchStart = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
+    if (e.currentTarget.scrollTop === 0) {
+      dragStartYRef.current = e.touches[0]?.clientY ?? null;
+    }
+  }, []);
+
+  const handleSheetTouchMove = useCallback((e: ReactTouchEvent<HTMLDivElement>) => {
+    if (dragStartYRef.current === null) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const deltaY = Math.max(0, touch.clientY - dragStartYRef.current);
+    if (sheetRef.current) {
+      sheetRef.current.style.transform = `translateY(${deltaY}px)`;
+      sheetRef.current.style.transition = 'none';
+    }
+    if (backdropRef.current) {
+      backdropRef.current.style.opacity = String(Math.max(0, 1 - deltaY / 200));
+    }
+  }, []);
+
+  const handleSheetTouchEnd = useCallback(
+    (e: ReactTouchEvent<HTMLDivElement>) => {
+      if (dragStartYRef.current === null) return;
+      const startY = dragStartYRef.current;
+      dragStartYRef.current = null;
+      const deltaY = Math.max(0, (e.changedTouches[0]?.clientY ?? startY) - startY);
+      if (deltaY > 80) {
+        // Animate out then close
+        if (sheetRef.current) {
+          sheetRef.current.style.transform = 'translateY(100%)';
+          sheetRef.current.style.transition = 'transform 200ms ease';
+        }
+        if (backdropRef.current) {
+          backdropRef.current.style.opacity = '0';
+          backdropRef.current.style.transition = 'opacity 200ms ease';
+        }
+        setTimeout(onClose, 200);
+      } else {
+        // Spring back
+        if (sheetRef.current) {
+          sheetRef.current.style.transform = '';
+          sheetRef.current.style.transition = 'transform 220ms cubic-bezier(0.4, 0, 0.2, 1)';
+        }
+        if (backdropRef.current) {
+          backdropRef.current.style.opacity = '';
+          backdropRef.current.style.transition = '';
+        }
+      }
+    },
+    [onClose]
+  );
 
   // Close on Escape
   useEffect(() => {
@@ -196,6 +256,7 @@ export function MobileMessageMenu({
     <>
       {/* Backdrop */}
       <div
+        ref={backdropRef}
         role="presentation"
         className={css.Backdrop}
         onClick={onClose}
@@ -204,135 +265,168 @@ export function MobileMessageMenu({
 
       {/* Sheet */}
       <div
+        ref={sheetRef}
         className={css.Sheet}
         role="dialog"
         aria-modal="true"
+        style={showEmojiPicker ? { maxHeight: '90vh', overflowY: 'hidden' } : undefined}
         onClick={stopPropHandler}
         onKeyDown={(e) => e.stopPropagation()}
+        onTouchStart={handleSheetTouchStart}
+        onTouchMove={handleSheetTouchMove}
+        onTouchEnd={handleSheetTouchEnd}
       >
         <div className={css.Handle} />
 
-        {canSendReaction && (
+        {showEmojiPicker ? (
           <>
-            <QuickReactions
-              onReaction={(key, shortcode) => {
-                onReactionToggle(evtId, key, shortcode);
-                onClose();
-              }}
-              onOpenEmojiBoard={
-                onOpenEmojiBoard
-                  ? () => {
-                      onOpenEmojiBoard();
-                      onClose();
-                    }
-                  : undefined
-              }
-            />
+            <div className={css.EmojiPickerHeader}>
+              <button
+                type="button"
+                className={css.EmojiPickerBackBtn}
+                onClick={() => setShowEmojiPicker(false)}
+                aria-label="Back"
+              >
+                <Icon src={Icons.ArrowLeft} size="200" />
+              </button>
+              <Text size="T400" as="span" className={css.EmojiPickerTitle}>
+                Add Reaction
+              </Text>
+            </div>
+            <div className={css.EmojiPickerWrap}>
+              <EmojiBoard
+                imagePackRooms={imagePackRooms}
+                returnFocusOnDeactivate={false}
+                onEmojiSelect={(key, shortcode) => {
+                  onReactionToggle(evtId, key, shortcode);
+                  onClose();
+                }}
+                onCustomEmojiSelect={(mxc, shortcode) => {
+                  onReactionToggle(evtId, mxc, shortcode);
+                  onClose();
+                }}
+                requestClose={() => setShowEmojiPicker(false)}
+              />
+            </div>
           </>
-        )}
+        ) : (
+          <>
+            {canSendReaction && (
+              <QuickReactions
+                onReaction={(key, shortcode) => {
+                  onReactionToggle(evtId, key, shortcode);
+                  onClose();
+                }}
+                onOpenEmojiBoard={() => setShowEmojiPicker(true)}
+              />
+            )}
 
-        {/* Group 1: Message actions */}
-        <div className={css.ActionGroup}>
-          <ActionItem
-            icon={<Icon src={Icons.ReplyArrow} size="200" />}
-            label="Reply"
-            onClick={handleReplyClick}
-          />
-          {!isThreadedMessage && (
-            <ActionItem
-              icon={<Icon src={Icons.ThreadPlus} size="200" />}
-              label="Reply in Thread"
-              onClick={handleThreadReplyClick}
-            />
-          )}
-          {canEditEvent(mx, mEvent) && onEditId && (
-            <ActionItem
-              icon={<Icon src={Icons.Pencil} size="200" />}
-              label="Edit Message"
-              onClick={handleEditClick}
-            />
-          )}
-          <ActionItem
-            icon={<Icon src={Icons.ArrowGoRight} size="200" />}
-            label="Forward"
-            onClick={() => {
-              setModal({ type: ModalType.Forward, room, mEvent });
-              onClose();
-            }}
-          />
-          {!hideReadReceipts && (
-            <ActionItem
-              icon={<Icon src={Icons.CheckTwice} size="200" />}
-              label="Read Receipts"
-              onClick={() => {
-                setModal({ type: ModalType.ReadReceipts, room, eventId: evtId });
-                onClose();
-              }}
-            />
-          )}
-          {isEdited && (
-            <ActionItem
-              icon={<Icon src={Icons.Clock} size="200" />}
-              label="Version History"
-              onClick={() => {
-                setModal({ type: ModalType.EditHistory, room, mEvent });
-                onClose();
-              }}
-            />
-          )}
-          {showDeveloperTools && (
-            <ActionItem
-              icon={<Icon src={Icons.BlockCode} size="200" />}
-              label="View Source"
-              onClick={() => {
-                setModal({ type: ModalType.Source, room, mEvent });
-                onClose();
-              }}
-            />
-          )}
-        </div>
-
-        {/* Group 2: Utility actions */}
-        <div className={css.ActionGroup}>
-          {(() => {
-            const content = mEvent.getContent();
-            const body: string | undefined = content['m.new_content']?.body ?? content.body;
-            if (!body || mEvent.isRedacted()) return null;
-            return (
+            {/* Group 1: Message actions */}
+            <div className={css.ActionGroup}>
               <ActionItem
-                icon={<Icon src={Icons.Alphabet} size="200" />}
-                label="Copy Text"
+                icon={<Icon src={Icons.ReplyArrow} size="200" />}
+                label="Reply"
+                onClick={handleReplyClick}
+              />
+              {!isThreadedMessage && (
+                <ActionItem
+                  icon={<Icon src={Icons.ThreadPlus} size="200" />}
+                  label="Reply in Thread"
+                  onClick={handleThreadReplyClick}
+                />
+              )}
+              {canEditEvent(mx, mEvent) && onEditId && (
+                <ActionItem
+                  icon={<Icon src={Icons.Pencil} size="200" />}
+                  label="Edit Message"
+                  onClick={handleEditClick}
+                />
+              )}
+              <ActionItem
+                icon={<Icon src={Icons.ArrowGoRight} size="200" />}
+                label="Forward"
                 onClick={() => {
-                  copyToClipboard(body);
+                  setModal({ type: ModalType.Forward, room, mEvent });
                   onClose();
                 }}
               />
-            );
-          })()}
-          {mEvent.getId() && (
-            <ActionItem
-              icon={<Icon src={Icons.Link} size="200" />}
-              label="Copy Link"
-              onClick={() => {
-                copyToClipboard(
-                  getMatrixToRoomEvent(room.roomId, mEvent.getId()!, getViaServers(room))
-                );
-                onClose();
-              }}
-            />
-          )}
-          <BookmarkActionItem room={room} mEvent={mEvent} onClose={onClose} />
-        </div>
+              {!hideReadReceipts && (
+                <ActionItem
+                  icon={<Icon src={Icons.CheckTwice} size="200" />}
+                  label="Read Receipts"
+                  onClick={() => {
+                    setModal({ type: ModalType.ReadReceipts, room, eventId: evtId });
+                    onClose();
+                  }}
+                />
+              )}
+              {isEdited && (
+                <ActionItem
+                  icon={<Icon src={Icons.Clock} size="200" />}
+                  label="Version History"
+                  onClick={() => {
+                    setModal({ type: ModalType.EditHistory, room, mEvent });
+                    onClose();
+                  }}
+                />
+              )}
+              {showDeveloperTools && (
+                <ActionItem
+                  icon={<Icon src={Icons.BlockCode} size="200" />}
+                  label="View Source"
+                  onClick={() => {
+                    setModal({ type: ModalType.Source, room, mEvent });
+                    onClose();
+                  }}
+                />
+              )}
+            </div>
 
-        {/* Group 3: Destructive actions */}
-        {(!mEvent.isRedacted() && canDelete) || mEvent.getSender() !== mx.getUserId() ? (
-          <div className={css.ActionGroup}>
-            {!mEvent.isRedacted() && canDelete && <MessageDeleteItem room={room} mEvent={mEvent} />}
-            {mEvent.getSender() !== mx.getUserId() && (
-              <MessageReportItem room={room} mEvent={mEvent} />
-            )}
-          </div>
-        ) : null}
+            {/* Group 2: Utility actions */}
+            <div className={css.ActionGroup}>
+              {(() => {
+                const content = mEvent.getContent();
+                const body: string | undefined = content['m.new_content']?.body ?? content.body;
+                if (!body || mEvent.isRedacted()) return null;
+                return (
+                  <ActionItem
+                    icon={<Icon src={Icons.Alphabet} size="200" />}
+                    label="Copy Text"
+                    onClick={() => {
+                      copyToClipboard(body);
+                      onClose();
+                    }}
+                  />
+                );
+              })()}
+              {mEvent.getId() && (
+                <ActionItem
+                  icon={<Icon src={Icons.Link} size="200" />}
+                  label="Copy Link"
+                  onClick={() => {
+                    copyToClipboard(
+                      getMatrixToRoomEvent(room.roomId, mEvent.getId()!, getViaServers(room))
+                    );
+                    onClose();
+                  }}
+                />
+              )}
+              <BookmarkActionItem room={room} mEvent={mEvent} onClose={onClose} />
+            </div>
+
+            {/* Group 3: Destructive actions */}
+            {(!mEvent.isRedacted() && canDelete) || mEvent.getSender() !== mx.getUserId() ? (
+              <div className={css.ActionGroup}>
+                {!mEvent.isRedacted() && canDelete && (
+                  <MessageDeleteItem room={room} mEvent={mEvent} />
+                )}
+                {mEvent.getSender() !== mx.getUserId() && (
+                  <MessageReportItem room={room} mEvent={mEvent} />
+                )}
+              </div>
+            ) : null}
+          </>
+        )}
       </div>
     </>,
     portalContainer

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -33,7 +33,7 @@ import type { DateFormat, MessageSpacing, CaptionPosition } from '$state/setting
 import { MessageLayout, RightSwipeAction, settingsAtom } from '$state/settings';
 import { SettingTile } from '$components/setting-tile';
 import { KeySymbol } from '$utils/key-symbol';
-import { isMacOS, mobileOrTablet } from '$utils/user-agent';
+import { isMacOS, isPhone, mobileOrTablet } from '$utils/user-agent';
 import { stopPropagation } from '$utils/keyboard';
 import { useMessageLayoutItems } from '$hooks/useMessageLayout';
 import { useCaptionPositionItems } from '$hooks/useCaptionPosition';
@@ -1436,7 +1436,7 @@ export function General({ requestBack, requestClose }: Readonly<GeneralProps>) {
             <Box direction="Column" gap="700">
               <DateAndTime />
               <Gestures isMobile={mobileOrTablet()} />
-              <Editor isMobile={mobileOrTablet()} />
+              <Editor isMobile={isPhone()} />
               <Messages />
               <Embeds />
               <Calls />

--- a/src/app/features/settings/notifications/PushNotifications.tsx
+++ b/src/app/features/settings/notifications/PushNotifications.tsx
@@ -57,7 +57,7 @@ export async function enablePushNotifications(
       kind: 'http' as const,
       app_id: clientConfig.pushNotificationDetails?.webPushAppID,
       pushkey: keys.p256dh,
-      app_display_name: 'Cinny',
+      app_display_name: 'Sable',
       device_display_name: 'This Browser',
       lang: navigator.language || 'en',
       data: {
@@ -104,7 +104,7 @@ export async function enablePushNotifications(
     kind: 'http' as const,
     app_id: clientConfig.pushNotificationDetails?.webPushAppID,
     pushkey: keys.p256dh,
-    app_display_name: 'Cinny',
+    app_display_name: 'Sable',
     device_display_name:
       (await mx.getDevice(mx.getDeviceId() ?? '')).display_name ?? 'Unknown Device',
     lang: navigator.language || 'en',

--- a/src/app/features/settings/notifications/PushNotifications.tsx
+++ b/src/app/features/settings/notifications/PushNotifications.tsx
@@ -9,6 +9,27 @@ type PushSubscriptionState = [
   (subscription: PushSubscription | null) => void,
 ];
 
+function postToServiceWorker(data: unknown): void {
+  if (!('serviceWorker' in navigator)) return;
+
+  const posted = new Set<ServiceWorker>();
+  const postToWorker = (worker: ServiceWorker | null | undefined) => {
+    if (!worker || posted.has(worker)) return;
+    posted.add(worker);
+    // oxlint-disable-next-line unicorn/require-post-message-target-origin
+    worker.postMessage(data);
+  };
+
+  postToWorker(navigator.serviceWorker.controller);
+  navigator.serviceWorker.ready
+    .then((registration) => {
+      postToWorker(registration.active);
+      postToWorker(registration.waiting);
+      postToWorker(registration.installing);
+    })
+    .catch(() => undefined);
+}
+
 export async function requestBrowserNotificationPermission(): Promise<NotificationPermission> {
   if (!('Notification' in window)) {
     debugLog.warn('notification', 'Notification API not available in this browser');
@@ -69,7 +90,7 @@ export async function enablePushNotifications(
       },
       append: false,
     };
-    navigator.serviceWorker.controller?.postMessage({
+    postToServiceWorker({
       url: mx.baseUrl,
       type: 'togglePush',
       pusherData,
@@ -118,7 +139,7 @@ export async function enablePushNotifications(
     append: false,
   };
 
-  navigator.serviceWorker.controller?.postMessage({
+  postToServiceWorker({
     url: mx.baseUrl,
     type: 'togglePush',
     pusherData,
@@ -144,7 +165,7 @@ export async function disablePushNotifications(
     pushkey: pushSubAtom?.keys?.p256dh,
   };
 
-  navigator.serviceWorker.controller?.postMessage({
+  postToServiceWorker({
     url: mx.baseUrl,
     type: 'togglePush',
     pusherData,

--- a/src/app/hooks/ios-keyboard-fix/device.ts
+++ b/src/app/hooks/ios-keyboard-fix/device.ts
@@ -1,0 +1,24 @@
+// Vendored from https://github.com/Crscristi28/ios-pwa-keyboard-fix (MIT)
+// Replace this import path with 'ios-pwa-keyboard-fix' once published to npm.
+
+export const isStandalonePWA = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  // iOS Safari uses navigator.standalone (legacy, non-standard).
+  // Other browsers use the W3C display-mode media query.
+  const iosStandalone =
+    'standalone' in window.navigator &&
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+  const displayModeStandalone = window.matchMedia('(display-mode: standalone)').matches;
+  return iosStandalone || displayModeStandalone;
+};
+
+export const isTablet = (): boolean => typeof window !== 'undefined' && window.innerWidth >= 768;
+
+export const needsVirtualKeyboard = (): boolean => {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+  const hasTouchScreen = navigator.maxTouchPoints > 0;
+  const isCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
+  return hasTouchScreen && isCoarsePointer;
+};

--- a/src/app/hooks/ios-keyboard-fix/index.ts
+++ b/src/app/hooks/ios-keyboard-fix/index.ts
@@ -1,0 +1,5 @@
+// Vendored from https://github.com/Crscristi28/ios-pwa-keyboard-fix (MIT)
+// Replace this import path with 'ios-pwa-keyboard-fix' once published to npm.
+export { isStandalonePWA, isTablet, needsVirtualKeyboard } from './device';
+export { useKeyboardHeight } from './useKeyboardHeight';
+export { useScrollLock } from './useScrollLock';

--- a/src/app/hooks/ios-keyboard-fix/useKeyboardHeight.ts
+++ b/src/app/hooks/ios-keyboard-fix/useKeyboardHeight.ts
@@ -1,0 +1,174 @@
+// Vendored from https://github.com/Crscristi28/ios-pwa-keyboard-fix (MIT)
+// Replace this import path with 'ios-pwa-keyboard-fix' once published to npm.
+import { useEffect, useRef, useState } from 'react';
+
+// Measures iOS keyboard height via the Visual Viewport API and synchronously
+// manages the --sable-visible-height / --sable-safe-bottom CSS custom properties
+// that control #root layout height.
+//
+// CSS variables are set/cleared directly inside the event handler (no React
+// useEffect) so there is no frame gap between "keyboard closed" being detected
+// and the layout reverting to full height. This eliminates the race condition
+// where a follow-on viewport.resize event would re-set the variable after the
+// React async effect had already removed it, causing a persistent bottom gap.
+//
+// Stability filter — only commits React state (isKeyboardVisible, keyboardHeight)
+// once iOS reports the same viewport height for STABILITY_MS ms. iOS emits
+// chaotic transient values during keyboard transitions (text ↔ emoji), so the
+// filter prevents those from triggering unnecessary re-renders.
+//
+// triggerPreLift: called from onMouseDown so Safari sees the textarea as already
+// visible and skips its document-scroll prediction.
+const STABILITY_MS = 80;
+
+// Module-level state shared across all useKeyboardHeight instances.
+// The keyboard height is a device property — it's the same regardless of
+// which input has focus. Sharing savedHeight prevents the case where two
+// simultaneous RoomInput instances (main timeline + open thread drawer) race
+// on keyboard open: the thread instance starts with savedHeight=0 and would
+// overwrite the main instance's correct estimate with the wrong mid-animation
+// viewport.height.
+// mountCount is a reference counter so only the last unmounting instance
+// clears the CSS vars (prevents the thread drawer unmounting mid-keyboard-open
+// from wiping --sable-visible-height while the main room input still uses it).
+let sharedSavedHeight = 0;
+let mountCount = 0;
+// Whether --sable-visible-height is currently applied. Shared so multiple
+// instances see the same state and the "only set once while open" guard works
+// across instances.
+let cssVarsApplied = false;
+
+export function useKeyboardHeight() {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+
+  // Mirror state in refs so triggerPreLift sees fresh values from
+  // an onMouseDown handler without re-creating the function each render.
+  const hasOpenedOnce = useRef(false);
+  const isVisibleRef = useRef(false);
+
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return undefined;
+
+    mountCount += 1;
+    let baselineHeight = window.innerHeight;
+    let stabilityTimer: ReturnType<typeof setTimeout> | null = null;
+    let pendingValue = 0;
+
+    const setCSSVars = (viewportHeight: number) => {
+      document.documentElement.style.setProperty(
+        '--sable-visible-height',
+        `${Math.round(viewportHeight)}px`
+      );
+      document.documentElement.style.setProperty('--sable-safe-bottom', '0px');
+      cssVarsApplied = true;
+    };
+
+    const clearCSSVars = () => {
+      document.documentElement.style.removeProperty('--sable-visible-height');
+      document.documentElement.style.removeProperty('--sable-safe-bottom');
+      cssVarsApplied = false;
+    };
+
+    const handleResize = () => {
+      const calculatedHeight = baselineHeight - viewport.height;
+
+      // Keyboard closing — act immediately, no stability wait.
+      // clearCSSVars() runs synchronously here, before React schedules any
+      // re-render, so there is no window in which a follow-on resize event
+      // can observe the variable as missing and incorrectly re-set it.
+      if (calculatedHeight < 30) {
+        if (stabilityTimer) {
+          clearTimeout(stabilityTimer);
+          stabilityTimer = null;
+        }
+        clearCSSVars();
+        setKeyboardHeight(0);
+        setIsKeyboardVisible(false);
+        isVisibleRef.current = false;
+        return;
+      }
+
+      // Keyboard opening / open.
+      // On the very first resize that signals a keyboard, immediately shrink
+      // the layout (before the stability gate) so the input bar rises before
+      // iOS applies its own scroll-prediction pass.
+      // Use the previously-measured keyboard height as the estimate so the
+      // immediate and stability-timer setCSSVars calls land on the same pixel
+      // value — eliminating the second layout change that causes visible
+      // timeline stutter during the keyboard animation.
+      if (!cssVarsApplied) {
+        const estimatedViewportHeight =
+          sharedSavedHeight > 0 ? baselineHeight - sharedSavedHeight : viewport.height;
+        setCSSVars(estimatedViewportHeight);
+      }
+
+      // Cancel any document scroll iOS may have applied as scroll-prediction.
+      if (window.scrollY !== 0) {
+        window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
+      }
+
+      // Wait for the height to settle. Each resize within STABILITY_MS
+      // restarts the timer, so transient mid-transition readings never
+      // commit — only the final settled value does.
+      pendingValue = calculatedHeight;
+      if (stabilityTimer) clearTimeout(stabilityTimer);
+      stabilityTimer = setTimeout(() => {
+        sharedSavedHeight = pendingValue;
+        hasOpenedOnce.current = true;
+        isVisibleRef.current = true;
+        setCSSVars(viewport.height); // refine to final settled viewport height
+        setKeyboardHeight(pendingValue);
+        setIsKeyboardVisible(true);
+      }, STABILITY_MS);
+    };
+
+    // Orientation change resets everything — keyboard heights measured
+    // in portrait don't apply in landscape and vice versa. Drop saved
+    // state and start fresh; the next focus will re-measure.
+    const handleOrientationChange = () => {
+      if (stabilityTimer) {
+        clearTimeout(stabilityTimer);
+        stabilityTimer = null;
+      }
+      pendingValue = 0;
+      sharedSavedHeight = 0;
+      hasOpenedOnce.current = false;
+      isVisibleRef.current = false;
+      clearCSSVars();
+      setKeyboardHeight(0);
+      setIsKeyboardVisible(false);
+      // Re-baseline after iOS settles the new layout.
+      setTimeout(() => {
+        baselineHeight = window.innerHeight;
+      }, 200);
+    };
+
+    viewport.addEventListener('resize', handleResize);
+    window.addEventListener('orientationchange', handleOrientationChange);
+    return () => {
+      mountCount -= 1;
+      if (stabilityTimer) clearTimeout(stabilityTimer);
+      viewport.removeEventListener('resize', handleResize);
+      window.removeEventListener('orientationchange', handleOrientationChange);
+      // Only clear CSS vars when the last instance unmounts — prevents the thread
+      // drawer unmounting mid-keyboard-open from wiping the variable while the
+      // main room's RoomInput still has the keyboard open.
+      if (mountCount === 0) clearCSSVars();
+    };
+  }, []);
+
+  // Pre-lift: called from onMouseDown, BEFORE focus event fires.
+  // Only acts if the keyboard is currently open — otherwise a button
+  // tap would lift the bar with no keyboard behind it.
+  // Reads from refs so it always sees the latest state, even when
+  // captured by an onMouseDown handler that mounted earlier.
+  const triggerPreLift = () => {
+    if (hasOpenedOnce.current && sharedSavedHeight > 0 && isVisibleRef.current) {
+      setKeyboardHeight(sharedSavedHeight);
+    }
+  };
+
+  return { keyboardHeight, isKeyboardVisible, triggerPreLift };
+}

--- a/src/app/hooks/ios-keyboard-fix/useScrollLock.ts
+++ b/src/app/hooks/ios-keyboard-fix/useScrollLock.ts
@@ -1,0 +1,37 @@
+// Vendored from https://github.com/Crscristi28/ios-pwa-keyboard-fix (MIT)
+// Replace this import path with 'ios-pwa-keyboard-fix' once published to npm.
+import { useEffect } from 'react';
+
+// Conditional scroll-lock safety net for the input bar.
+// While the keyboard is open, Safari can still trigger a document scroll
+// when the keyboard mode switches (text ↔ emoji), because there is no
+// onMouseDown moment for us to pre-lift on. This listener detects the
+// document moving away from scrollY: 0 and snaps it back, so the input
+// bar does not drift with the page.
+// Outside of this state the page scrolls normally.
+//
+// Important: this hook assumes the layout where window.scrollY stays at 0
+// because the page itself does not scroll — content scrolls inside <main>
+// with overflow-y:auto, while html/body/#root use overflow:hidden. See
+// README "Layout structure" and docs/ARCHITECTURE.md. Without that layout,
+// this lock will fight legitimate page scroll while the keyboard is open.
+export function useScrollLock(active: boolean) {
+  useEffect(() => {
+    // Snap back immediately in case iOS scroll prediction ran during the
+    // stability window, before this lock became active.
+    if (active && window.scrollY > 0) {
+      window.scrollTo(0, 0);
+    }
+
+    const preventScroll = () => {
+      if (active && window.scrollY > 0) {
+        window.scrollTo(0, 0);
+      }
+    };
+
+    window.addEventListener('scroll', preventScroll);
+    return () => {
+      window.removeEventListener('scroll', preventScroll);
+    };
+  }, [active]);
+}

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -80,12 +80,29 @@ export function useProcessedTimeline({
   skipThreadFilter,
 }: UseProcessedTimelineOptions): ProcessedEvent[] {
   return useMemo(() => {
+    // Sort items by origin_server_ts so events always render in chronological
+    // order even when the SDK stores them in receipt order.  This is visible
+    // after a sliding-sync gap on mobile resume (TimelineReset delivers a full
+    // batch at once) and for bridge-backfilled or federated messages where
+    // receipt order ≠ timestamp order.  Receipt order is preserved as a
+    // tiebreaker so threading / causality is not affected.
+    const sortedItems = [...items].sort((a, b) => {
+      const [tlA, baseA] = getTimelineAndBaseIndex(linkedTimelines, a);
+      const [tlB, baseB] = getTimelineAndBaseIndex(linkedTimelines, b);
+      const evA = tlA ? getTimelineEvent(tlA, getTimelineRelativeIndex(a, baseA)) : null;
+      const evB = tlB ? getTimelineEvent(tlB, getTimelineRelativeIndex(b, baseB)) : null;
+      const tsA = evA?.getTs() ?? 0;
+      const tsB = evB?.getTs() ?? 0;
+      if (tsA !== tsB) return tsA - tsB;
+      return a - b; // receipt order tiebreaker keeps causally-related events stable
+    });
+
     let prevEvent: MatrixEvent | undefined;
     let isPrevRendered = false;
     let newDivider = false;
     let dayDivider = false;
 
-    const result = items.reduce<ProcessedEvent[]>((acc, item) => {
+    const result = sortedItems.reduce<ProcessedEvent[]>((acc, item) => {
       const [eventTimeline, baseIndex] = getTimelineAndBaseIndex(linkedTimelines, item);
       if (!eventTimeline) return acc;
 

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -86,7 +86,7 @@ export function useProcessedTimeline({
     // batch at once) and for bridge-backfilled or federated messages where
     // receipt order ≠ timestamp order.  Receipt order is preserved as a
     // tiebreaker so threading / causality is not affected.
-    const sortedItems = [...items].sort((a, b) => {
+    const sortedItems = items.toSorted((a, b) => {
       const [tlA, baseA] = getTimelineAndBaseIndex(linkedTimelines, a);
       const [tlB, baseB] = getTimelineAndBaseIndex(linkedTimelines, b);
       const evA = tlA ? getTimelineEvent(tlA, getTimelineRelativeIndex(a, baseA)) : null;

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -77,13 +77,9 @@ function createRoom(
   return { room, timelineSet, events };
 }
 
-describe('useTimelineSync', () => {
-  // Minimal MatrixClient stub that satisfies getRoomUnreadInfo's call chain.
-  // getAccountData returns null so getNotificationType returns Default (not Mute),
-  // then getEventReadUpTo returning null short-circuits roomHaveUnread to false.
-  const makeMx = () =>
-    ({ getUserId: () => '@alice:test', getAccountData: () => null }) as never;
+const makeMx = () => ({ getUserId: () => '@alice:test', getAccountData: () => null }) as never;
 
+describe('useTimelineSync', () => {
   it('does not snap a non-bottom user to latest after TimelineReset', async () => {
     const { room, timelineSet, events } = createRoom();
     const scrollToBottom = vi.fn<() => void>();

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -64,10 +64,13 @@ function createRoom(
     emit: roomEmitter.emit.bind(roomEmitter),
     roomId,
     getUnfilteredTimelineSet: () => timelineSet as never,
+    getLiveTimeline: () => timeline,
     getEventReadUpTo: () => null,
     getThread: () => null,
+    getUnreadNotificationCount: () => 0,
     client: {
       getUserId: () => '@alice:test',
+      getAccountData: () => null,
     },
   } as unknown as FakeRoom;
 
@@ -75,6 +78,12 @@ function createRoom(
 }
 
 describe('useTimelineSync', () => {
+  // Minimal MatrixClient stub that satisfies getRoomUnreadInfo's call chain.
+  // getAccountData returns null so getNotificationType returns Default (not Mute),
+  // then getEventReadUpTo returning null short-circuits roomHaveUnread to false.
+  const makeMx = () =>
+    ({ getUserId: () => '@alice:test', getAccountData: () => null }) as never;
+
   it('does not snap a non-bottom user to latest after TimelineReset', async () => {
     const { room, timelineSet, events } = createRoom();
     const scrollToBottom = vi.fn<() => void>();
@@ -82,7 +91,7 @@ describe('useTimelineSync', () => {
     renderHook(() =>
       useTimelineSync({
         room: room as Room,
-        mx: { getUserId: () => '@alice:test' } as never,
+        mx: makeMx(),
         isAtBottom: false,
         isAtBottomRef: { current: false },
         scrollToBottom,
@@ -114,7 +123,7 @@ describe('useTimelineSync', () => {
     renderHook(() =>
       useTimelineSync({
         room: room as Room,
-        mx: { getUserId: () => '@alice:test' } as never,
+        mx: makeMx(),
         isAtBottom: true,
         isAtBottomRef: { current: true },
         scrollToBottom,
@@ -142,7 +151,7 @@ describe('useTimelineSync', () => {
       ({ room, eventId }) =>
         useTimelineSync({
           room,
-          mx: { getUserId: () => '@alice:test' } as never,
+          mx: makeMx(),
           eventId,
           isAtBottom: false,
           isAtBottomRef: { current: false },
@@ -179,7 +188,7 @@ describe('useTimelineSync', () => {
       ({ room, eventId }) =>
         useTimelineSync({
           room,
-          mx: { getUserId: () => '@alice:test' } as never,
+          mx: makeMx(),
           eventId,
           isAtBottom: false,
           isAtBottomRef: { current: false },
@@ -214,7 +223,7 @@ describe('useTimelineSync', () => {
       ({ room }) =>
         useTimelineSync({
           room,
-          mx: { getUserId: () => '@alice:test' } as never,
+          mx: makeMx(),
           eventId: undefined,
           isAtBottom: false,
           isAtBottomRef: { current: false },

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -528,8 +528,14 @@ export function useTimelineSync({
       setTimeline({ linkedTimelines: getInitialTimeline(room).linkedTimelines });
       if (wasAtBottom) {
         scrollToBottom('instant');
+      } else {
+        // Timeline reset with new events loaded by the SDK (e.g. after a sync
+        // gap on mobile resume). useLiveEventArrive won't fire for events that
+        // were already in getInitialTimeline's result, so show the unread bar
+        // here if the room has messages the user hasn't read yet.
+        setUnreadInfo(getRoomUnreadInfo(room));
       }
-    }, [room, isAtBottomRef, scrollToBottom])
+    }, [room, isAtBottomRef, scrollToBottom, setUnreadInfo])
   );
 
   useRelationUpdate(

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -7,7 +7,6 @@ import { useClientConfig } from './useClientConfig';
 import { useSetting } from '../state/hooks/settings';
 import { settingsAtom } from '../state/settings';
 import { pushSubscriptionAtom } from '../state/pushSubscription';
-import { mobileOrTablet } from '../utils/user-agent';
 import { createDebugLogger } from '../utils/debugLogger';
 
 const debugLog = createDebugLogger('AppVisibility');
@@ -16,7 +15,6 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
   const clientConfig = useClientConfig();
   const [usePushNotifications] = useSetting(settingsAtom, 'usePushNotifications');
   const pushSubAtom = useAtom(pushSubscriptionAtom);
-  const isMobile = mobileOrTablet();
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -43,12 +41,17 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
     if (!mx) return undefined;
 
     const handleVisibilityForNotifications = (isVisible: boolean) => {
-      togglePusher(mx, clientConfig, isVisible, usePushNotifications, pushSubAtom, isMobile);
+      // Always keep the pusher registered regardless of visibility — the SW's
+      // hasVisibleClient check handles OS-notification suppression when the app
+      // is in the foreground, so we never need to delete the pusher.  Keeping
+      // it permanently avoids the enable/disable race that can leave the
+      // homeserver without a valid pusher after rapid tab-focus changes.
+      togglePusher(mx, clientConfig, isVisible, usePushNotifications, pushSubAtom, true);
     };
 
     appEvents.onVisibilityChange = handleVisibilityForNotifications;
     return () => {
       appEvents.onVisibilityChange = null;
     };
-  }, [mx, clientConfig, usePushNotifications, pushSubAtom, isMobile]);
+  }, [mx, clientConfig, usePushNotifications, pushSubAtom]);
 }

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -9,6 +9,7 @@ import { settingsAtom } from '../state/settings';
 import { pushSubscriptionAtom } from '../state/pushSubscription';
 import { createDebugLogger } from '../utils/debugLogger';
 import { getSlidingSyncManager } from '$client/initMatrix';
+import { mobileOrTablet } from '$utils/user-agent';
 
 const debugLog = createDebugLogger('AppVisibility');
 
@@ -59,19 +60,57 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
   useEffect(() => {
     if (!mx) return undefined;
 
-    const handleForeground = () => {
-      if (document.visibilityState !== 'visible') return;
+    const doRetry = () => {
       // For classic sync, retryImmediately() breaks out of keepalive backoff immediately.
       // For sliding sync the SDK's retryImmediately() is a stub; retryNow() calls
       // slidingSync.resend() which aborts any stalled request and retries without backoff.
       mx.retryImmediately();
       getSlidingSyncManager(mx)?.retryNow();
+    };
+
+    const handleForeground = () => {
+      if (document.visibilityState !== 'visible') return;
+      doRetry();
       debugLog.info('general', 'App foregrounded — sync retry triggered');
+
+      if (!mobileOrTablet()) return;
+      // On iOS the network layer is not always immediately available when
+      // visibilitychange fires after a background suspension. Schedule
+      // fallback retries so the sync recovers once networking is ready.
+      // Each timer is cancelled if the app goes back to background first.
+      const t1 = setTimeout(() => {
+        if (document.visibilityState === 'visible') {
+          doRetry();
+          debugLog.info('general', 'App foregrounded — sync retry (1.5 s fallback)');
+        }
+      }, 1500);
+      const t2 = setTimeout(() => {
+        if (document.visibilityState === 'visible') {
+          doRetry();
+          debugLog.info('general', 'App foregrounded — sync retry (5 s fallback)');
+        }
+      }, 5000);
+      const cancelOnHide = () => {
+        if (document.visibilityState === 'visible') return;
+        clearTimeout(t1);
+        clearTimeout(t2);
+        document.removeEventListener('visibilitychange', cancelOnHide);
+      };
+      document.addEventListener('visibilitychange', cancelOnHide);
+    };
+
+    // pageshow fires when the page is restored from the browser's back-forward
+    // cache (bfcache). On some iOS versions the PWA can be restored from bfcache
+    // without a visibilitychange event, so this acts as an extra safety net.
+    const handlePageShow = (ev: PageTransitionEvent) => {
+      if (ev.persisted) handleForeground();
     };
 
     document.addEventListener('visibilitychange', handleForeground);
+    window.addEventListener('pageshow', handlePageShow);
     return () => {
       document.removeEventListener('visibilitychange', handleForeground);
+      window.removeEventListener('pageshow', handlePageShow);
     };
   }, [mx]);
 }

--- a/src/app/hooks/useAppVisibility.ts
+++ b/src/app/hooks/useAppVisibility.ts
@@ -8,6 +8,7 @@ import { useSetting } from '../state/hooks/settings';
 import { settingsAtom } from '../state/settings';
 import { pushSubscriptionAtom } from '../state/pushSubscription';
 import { createDebugLogger } from '../utils/debugLogger';
+import { getSlidingSyncManager } from '$client/initMatrix';
 
 const debugLog = createDebugLogger('AppVisibility');
 
@@ -54,4 +55,23 @@ export function useAppVisibility(mx: MatrixClient | undefined) {
       appEvents.onVisibilityChange = null;
     };
   }, [mx, clientConfig, usePushNotifications, pushSubAtom]);
+
+  useEffect(() => {
+    if (!mx) return undefined;
+
+    const handleForeground = () => {
+      if (document.visibilityState !== 'visible') return;
+      // For classic sync, retryImmediately() breaks out of keepalive backoff immediately.
+      // For sliding sync the SDK's retryImmediately() is a stub; retryNow() calls
+      // slidingSync.resend() which aborts any stalled request and retries without backoff.
+      mx.retryImmediately();
+      getSlidingSyncManager(mx)?.retryNow();
+      debugLog.info('general', 'App foregrounded — sync retry triggered');
+    };
+
+    document.addEventListener('visibilitychange', handleForeground);
+    return () => {
+      document.removeEventListener('visibilitychange', handleForeground);
+    };
+  }, [mx]);
 }

--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -69,7 +69,7 @@ export function NotificationJumper() {
       const roomIdOrAlias = getCanonicalAliasOrRoomId(mx, pending.roomId);
       if (mDirects.has(pending.roomId)) {
         navigate(getDirectPath(), { replace: true });
-        navigate(getDirectRoomPath(roomIdOrAlias, targetEventId));
+        navigate(getDirectRoomPath(roomIdOrAlias));
       } else {
         // If the room lives inside a space, route through the space path so
         // SpaceRouteRoomProvider can resolve it — HomeRouteRoomProvider only
@@ -83,10 +83,10 @@ export function NotificationJumper() {
             guessPerfectParent(mx, pending.roomId, orphanParents) ?? orphanParents[0];
           const spaceIdOrAlias = getCanonicalAliasOrRoomId(mx, parentSpace ?? pending.roomId);
           navigate(getSpacePath(spaceIdOrAlias), { replace: true });
-          navigate(getSpaceRoomPath(spaceIdOrAlias, roomIdOrAlias, targetEventId));
+          navigate(getSpaceRoomPath(spaceIdOrAlias, roomIdOrAlias));
         } else {
           navigate(getHomePath(), { replace: true });
-          navigate(getHomeRoomPath(roomIdOrAlias, targetEventId));
+          navigate(getHomeRoomPath(roomIdOrAlias));
         }
       }
       setPending(null);

--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -7,7 +7,14 @@ import { mDirectAtom } from '../state/mDirectList';
 import { useSyncState } from './useSyncState';
 import { useMatrixClient } from './useMatrixClient';
 import { getCanonicalAliasOrRoomId } from '../utils/matrix';
-import { getDirectRoomPath, getHomeRoomPath, getSpaceRoomPath } from '../pages/pathUtils';
+import {
+  getDirectRoomPath,
+  getHomeRoomPath,
+  getSpaceRoomPath,
+  getDirectPath,
+  getHomePath,
+  getSpacePath,
+} from '../pages/pathUtils';
 import { getOrphanParents, guessPerfectParent } from '../utils/room';
 import { roomToParentsAtom } from '../state/room/roomToParents';
 import { createLogger } from '../utils/debug';
@@ -56,9 +63,13 @@ export function NotificationJumper() {
       jumpingRef.current = true;
       // Navigate directly to home or direct path — bypasses space routing which
       // on mobile shows the space-nav panel first instead of the room timeline.
+      // First replace the current history entry with the section overview so that
+      // pressing back (including native iOS swipe-back) returns to the section list
+      // rather than the room the user was in before the notification.
       const roomIdOrAlias = getCanonicalAliasOrRoomId(mx, pending.roomId);
       if (mDirects.has(pending.roomId)) {
-        navigate(getDirectRoomPath(roomIdOrAlias, pending.eventId));
+        navigate(getDirectPath(), { replace: true });
+        navigate(getDirectRoomPath(roomIdOrAlias, targetEventId));
       } else {
         // If the room lives inside a space, route through the space path so
         // SpaceRouteRoomProvider can resolve it — HomeRouteRoomProvider only
@@ -70,15 +81,12 @@ export function NotificationJumper() {
         if (orphanParents.length > 0) {
           const parentSpace =
             guessPerfectParent(mx, pending.roomId, orphanParents) ?? orphanParents[0];
-          navigate(
-            getSpaceRoomPath(
-              getCanonicalAliasOrRoomId(mx, parentSpace ?? pending.roomId),
-              roomIdOrAlias,
-              pending.eventId
-            )
-          );
+          const spaceIdOrAlias = getCanonicalAliasOrRoomId(mx, parentSpace ?? pending.roomId);
+          navigate(getSpacePath(spaceIdOrAlias), { replace: true });
+          navigate(getSpaceRoomPath(spaceIdOrAlias, roomIdOrAlias, targetEventId));
         } else {
-          navigate(getHomeRoomPath(roomIdOrAlias, pending.eventId));
+          navigate(getHomePath(), { replace: true });
+          navigate(getHomeRoomPath(roomIdOrAlias, targetEventId));
         }
       }
       setPending(null);

--- a/src/app/hooks/usePullToRefresh.ts
+++ b/src/app/hooks/usePullToRefresh.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { MatrixClient } from '$types/matrix-sdk';
+import { RoomEvent } from '$types/matrix-sdk';
 import { getSlidingSyncManager } from '$client/initMatrix';
 import { mobileOrTablet } from '$utils/user-agent';
 
@@ -37,6 +38,15 @@ export function usePullToRefresh(
 
       mx.retryImmediately();
       getSlidingSyncManager(mx)?.retryNow();
+
+      // Rebuild timelines for every room that currently has a RoomTimeline
+      // mounted.  For rooms without an active subscriber this is a no-op.
+      // Rooms that received a server-side TimelineReset will already rebuild
+      // via the SDK event; this covers the case where the sync response has
+      // no gap (limited: false) but the user still wants fresh React state.
+      mx.getRooms().forEach((room) => {
+        room.emit(RoomEvent.TimelineRefresh, room, room.getUnfilteredTimelineSet());
+      });
 
       // Brief delay so the spinner is visible before snapping back.
       setTimeout(() => {

--- a/src/app/hooks/usePullToRefresh.ts
+++ b/src/app/hooks/usePullToRefresh.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react';
+import type { MatrixClient } from '$types/matrix-sdk';
+import { getSlidingSyncManager } from '$client/initMatrix';
+import { mobileOrTablet } from '$utils/user-agent';
+
+const PULL_THRESHOLD = 72; // px of overscroll needed to trigger refresh
+const MAX_PULL = 120; // px cap for visual rubber-band effect
+
+/**
+ * Attach a pull-to-refresh gesture to a scroll container on mobile.
+ *
+ * When the user pulls down from the very top of the list, a CSS transform
+ * is applied to the container for visual feedback. On release, if the pull
+ * exceeded PULL_THRESHOLD, `mx.retryImmediately()` and
+ * `SlidingSyncManager.retryNow()` are called to force a network re-sync.
+ */
+export function usePullToRefresh(
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+  mx: MatrixClient
+) {
+  // Mutable refs so event handlers always see the latest values without
+  // causing re-attachment of listeners.
+  const startYRef = useRef<number | null>(null);
+  const pullDistRef = useRef(0);
+  const refreshingRef = useRef(false);
+
+  useEffect(() => {
+    // Only activate on actual mobile / tablet devices.
+    if (!mobileOrTablet()) return;
+
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const doRefresh = () => {
+      if (refreshingRef.current) return;
+      refreshingRef.current = true;
+
+      mx.retryImmediately();
+      getSlidingSyncManager(mx)?.retryNow();
+
+      // Brief delay so the spinner is visible before snapping back.
+      setTimeout(() => {
+        refreshingRef.current = false;
+        el.style.transform = '';
+        el.style.transition = '';
+      }, 800);
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (el.scrollTop !== 0) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      startYRef.current = touch.clientY;
+      pullDistRef.current = 0;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (startYRef.current === null) return;
+      // Re-check in case the user scrolled after touch started.
+      if (el.scrollTop !== 0) {
+        startYRef.current = null;
+        return;
+      }
+
+      const touch = e.touches[0];
+      if (!touch) return;
+      const delta = touch.clientY - startYRef.current;
+      if (delta <= 0) return;
+
+      // Prevent the browser from scrolling while we handle the pull.
+      e.preventDefault();
+
+      // Rubber-band: resistance increases as pull grows.
+      const capped = Math.min(delta * 0.5, MAX_PULL);
+      pullDistRef.current = capped;
+
+      el.style.transition = 'none';
+      el.style.transform = `translateY(${capped}px)`;
+    };
+
+    const onTouchEnd = () => {
+      if (startYRef.current === null) return;
+      startYRef.current = null;
+
+      const dist = pullDistRef.current;
+      pullDistRef.current = 0;
+
+      if (dist >= PULL_THRESHOLD / 2) {
+        // Sufficient pull — trigger refresh and animate back.
+        el.style.transition = 'transform 0.25s ease';
+        el.style.transform = '';
+        doRefresh();
+      } else {
+        // Insufficient pull — just snap back.
+        el.style.transition = 'transform 0.2s ease';
+        el.style.transform = '';
+      }
+    };
+
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    // passive: false is required so we can call preventDefault() in touchmove.
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', onTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', onTouchEnd, { passive: true });
+
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('touchcancel', onTouchEnd);
+      // Clean up any lingering inline styles.
+      el.style.transform = '';
+      el.style.transition = '';
+    };
+  }, [scrollRef, mx]);
+}

--- a/src/app/hooks/usePullToRefresh.ts
+++ b/src/app/hooks/usePullToRefresh.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 import type { MatrixClient } from '$types/matrix-sdk';
-import { RoomEvent } from '$types/matrix-sdk';
 import { getSlidingSyncManager } from '$client/initMatrix';
 import { mobileOrTablet } from '$utils/user-agent';
 
@@ -120,17 +119,13 @@ export function usePullToRefresh(
 
       showRefreshing();
 
-      mx.retryImmediately();
-      getSlidingSyncManager(mx)?.retryNow();
-
-      // Rebuild timelines for every room that currently has a RoomTimeline
-      // mounted.  For rooms without an active subscriber this is a no-op.
-      // Rooms that received a server-side TimelineReset will already rebuild
-      // via the SDK event; this covers the case where the sync response has
-      // no gap (limited: false) but the user still wants fresh React state.
-      mx.getRooms().forEach((room) => {
-        room.emit(RoomEvent.TimelineRefresh, room, room.getUnfilteredTimelineSet());
-      });
+      // Temporarily clear all active room subscriptions so the server sees
+      // an empty-subscription request.  On the following cycle, subscriptions
+      // are restored and the server returns initial:true for each room,
+      // triggering a clean timeline reset with proper backward-pagination
+      // tokens.  This recovers from stale or out-of-order in-memory timelines
+      // that a normal delta sync cannot fix.
+      getSlidingSyncManager(mx)?.scheduleForceReset();
 
       // Brief delay so the spinner is visible before snapping back.
       setTimeout(() => {

--- a/src/app/hooks/usePullToRefresh.ts
+++ b/src/app/hooks/usePullToRefresh.ts
@@ -7,13 +7,62 @@ import { mobileOrTablet } from '$utils/user-agent';
 const PULL_THRESHOLD = 72; // px of overscroll needed to trigger refresh
 const MAX_PULL = 120; // px cap for visual rubber-band effect
 
+// Indicator size + gap from the safe-area edge (px).
+const INDICATOR_SIZE = 40;
+const INDICATOR_GAP = 10;
+
+// SVGs for the two indicator states.
+const ARROW_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:block;transition:transform 0.15s ease"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>`;
+const SPINNER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" style="display:block;animation:sable-ptr-spin 0.7s linear infinite"><path d="M12 2a10 10 0 1 0 10 10"/></svg>`;
+
+/** Inject the spin keyframe once into the document. */
+function ensurePTRStyles(): void {
+  if (document.getElementById('sable-ptr-styles')) return;
+  const s = document.createElement('style');
+  s.id = 'sable-ptr-styles';
+  s.textContent = `@keyframes sable-ptr-spin { to { transform: rotate(360deg); } }`;
+  document.head.appendChild(s);
+}
+
+/** Create the fixed-position circular indicator element. */
+function createIndicator(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.setAttribute('aria-hidden', 'true');
+  el.setAttribute('role', 'status');
+  Object.assign(el.style, {
+    position: 'fixed',
+    // Sit just below the device safe-area (notch / dynamic island).
+    top: `calc(env(safe-area-inset-top, 0px) + ${INDICATOR_GAP}px)`,
+    left: '50%',
+    // Start off-screen above; brought into view during pull.
+    transform: `translate(-50%, -${INDICATOR_SIZE + INDICATOR_GAP + 4}px)`,
+    zIndex: '9998',
+    width: `${INDICATOR_SIZE}px`,
+    height: `${INDICATOR_SIZE}px`,
+    borderRadius: '50%',
+    background: 'var(--sable-surface-container, #fff)',
+    color: 'var(--sable-surface-on-container, #000)',
+    border: '1px solid var(--sable-surface-container-line, rgba(0,0,0,0.1))',
+    boxShadow: '0 2px 10px rgba(0,0,0,0.2)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    pointerEvents: 'none',
+    willChange: 'transform',
+    transition: 'none',
+  });
+  el.innerHTML = ARROW_SVG;
+  return el;
+}
+
 /**
  * Attach a pull-to-refresh gesture to a scroll container on mobile.
  *
  * When the user pulls down from the very top of the list, a CSS transform
- * is applied to the container for visual feedback. On release, if the pull
- * exceeded PULL_THRESHOLD, `mx.retryImmediately()` and
- * `SlidingSyncManager.retryNow()` are called to force a network re-sync.
+ * is applied to the container for visual feedback, and a circular indicator
+ * slides into view. On release, if the pull exceeded PULL_THRESHOLD,
+ * `mx.retryImmediately()` and `SlidingSyncManager.retryNow()` are called to
+ * force a network re-sync.
  */
 export function usePullToRefresh(
   scrollRef: React.RefObject<HTMLDivElement | null>,
@@ -32,9 +81,44 @@ export function usePullToRefresh(
     const el = scrollRef.current;
     if (!el) return;
 
+    ensurePTRStyles();
+    const indicator = createIndicator();
+    document.body.appendChild(indicator);
+
+    /** Move the indicator to match the current pull ratio (0–1). */
+    const updateIndicator = (ratio: number) => {
+      // Translate from fully hidden (-size px) to fully visible (0px).
+      const hidden = -(INDICATOR_SIZE + INDICATOR_GAP + 4);
+      const translateY = hidden + ratio * (INDICATOR_SIZE + INDICATOR_GAP + 4);
+      indicator.style.transform = `translate(-50%, ${translateY}px)`;
+
+      // Rotate arrow: 0° at start → 180° at threshold (points up = "release").
+      const arrowSvg = indicator.querySelector('svg');
+      if (arrowSvg) {
+        (arrowSvg as SVGElement).style.transform = `rotate(${ratio * 180}deg)`;
+      }
+    };
+
+    const showRefreshing = () => {
+      indicator.innerHTML = SPINNER_SVG;
+      indicator.style.transform = 'translate(-50%, 0px)';
+    };
+
+    const hideIndicator = () => {
+      indicator.style.transition = 'transform 0.25s ease';
+      indicator.style.transform = `translate(-50%, -${INDICATOR_SIZE + INDICATOR_GAP + 4}px)`;
+      // Restore arrow after it has slid out of view.
+      setTimeout(() => {
+        indicator.innerHTML = ARROW_SVG;
+        indicator.style.transition = 'none';
+      }, 250);
+    };
+
     const doRefresh = () => {
       if (refreshingRef.current) return;
       refreshingRef.current = true;
+
+      showRefreshing();
 
       mx.retryImmediately();
       getSlidingSyncManager(mx)?.retryNow();
@@ -53,6 +137,7 @@ export function usePullToRefresh(
         refreshingRef.current = false;
         el.style.transform = '';
         el.style.transition = '';
+        hideIndicator();
       }, 800);
     };
 
@@ -86,6 +171,10 @@ export function usePullToRefresh(
 
       el.style.transition = 'none';
       el.style.transform = `translateY(${capped}px)`;
+
+      // Update indicator position and arrow rotation.
+      indicator.style.transition = 'none';
+      updateIndicator(Math.min(capped / PULL_THRESHOLD, 1));
     };
 
     const onTouchEnd = () => {
@@ -101,9 +190,10 @@ export function usePullToRefresh(
         el.style.transform = '';
         doRefresh();
       } else {
-        // Insufficient pull — just snap back.
+        // Insufficient pull — snap everything back.
         el.style.transition = 'transform 0.2s ease';
         el.style.transform = '';
+        hideIndicator();
       }
     };
 
@@ -121,6 +211,7 @@ export function usePullToRefresh(
       // Clean up any lingering inline styles.
       el.style.transform = '';
       el.style.transition = '';
+      document.body.removeChild(indicator);
     };
   }, [scrollRef, mx]);
 }

--- a/src/app/hooks/useSwUpdateAvailable.ts
+++ b/src/app/hooks/useSwUpdateAvailable.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns true once the service worker signals that a new version has been
+ * installed and is waiting to take over.  The caller should prompt the user
+ * to reload rather than doing so silently, since on mobile an unexpected full-
+ * page reload is very disorienting.
+ */
+export function useSwUpdateAvailable(): boolean {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  useEffect(() => {
+    const handleUpdate = () => setUpdateAvailable(true);
+    window.addEventListener('sable:sw-update', handleUpdate);
+    return () => window.removeEventListener('sable:sw-update', handleUpdate);
+  }, []);
+
+  return updateAvailable;
+}

--- a/src/app/pages/MobileFriendly.tsx
+++ b/src/app/pages/MobileFriendly.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useMatch } from 'react-router-dom';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { DIRECT_PATH, EXPLORE_PATH, HOME_PATH, INBOX_PATH, SPACE_PATH } from './paths';
 
 type MobileFriendlyClientNavProps = {
@@ -15,7 +16,7 @@ export function MobileFriendlyClientNav({ children }: MobileFriendlyClientNavPro
   const inboxMatch = useMatch({ path: INBOX_PATH, caseSensitive: true, end: true });
 
   if (
-    screenSize === ScreenSize.Mobile &&
+    (screenSize === ScreenSize.Mobile || mobileOrTabletLayout()) &&
     !(homeMatch || directMatch || spaceMatch || exploreMatch || inboxMatch)
   ) {
     return null;
@@ -36,7 +37,7 @@ export function MobileFriendlyPageNav({ path, children }: MobileFriendlyPageNavP
     end: true,
   });
 
-  if (screenSize === ScreenSize.Mobile && !exactPath) {
+  if ((screenSize === ScreenSize.Mobile || mobileOrTabletLayout()) && !exactPath) {
     return null;
   }
 

--- a/src/app/pages/Router.tsx
+++ b/src/app/pages/Router.tsx
@@ -16,6 +16,7 @@ import { Room } from '$features/room';
 import { Lobby } from '$features/lobby';
 import { PageRoot } from '$components/page';
 import { ScreenSize } from '$hooks/useScreenSize';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { ReceiveSelfDeviceVerification } from '$components/DeviceVerification';
 import { AutoRestoreBackupOnVerification } from '$components/BackupRestore';
 import { RoomSettingsRenderer } from '$features/room-settings';
@@ -101,7 +102,7 @@ const getFirstSession = () => {
 
 export const createRouter = (clientConfig: ClientConfig, screenSize: ScreenSize) => {
   const { hashRouter } = clientConfig;
-  const mobile = screenSize === ScreenSize.Mobile;
+  const mobile = screenSize === ScreenSize.Mobile || mobileOrTabletLayout();
 
   const routes = createRoutesFromElements(
     <Route>

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -62,6 +62,7 @@ import { lastVisitedRoomIdAtom } from '$state/room/lastRoom';
 import { useSettingsSyncEffect } from '$hooks/useSettingsSync';
 import { getInboxInvitesPath } from '../pathUtils';
 import { BackgroundNotifications } from './BackgroundNotifications';
+import { useSyncState } from '$hooks/useSyncState';
 
 const pushRelayLog = createDebugLogger('push-relay');
 
@@ -688,6 +689,36 @@ function SyncNotificationSettingsWithServiceWorker() {
   return null;
 }
 
+/**
+ * Tells the service worker whether the Matrix sync connection is healthy.
+ * When sync is in Reconnecting or Error state the in-app notification path is
+ * broken, so the SW must not suppress OS push notifications even while the app
+ * is visible.
+ */
+function SyncStateWithServiceWorker() {
+  const mx = useMatrixClient();
+
+  const postSyncHealth = useCallback((healthy: boolean) => {
+    if (!('serviceWorker' in navigator)) return;
+    const msg = { type: 'setSyncState', healthy };
+    navigator.serviceWorker.controller?.postMessage(msg);
+    navigator.serviceWorker.ready.then((reg) => reg.active?.postMessage(msg));
+  }, []);
+
+  useSyncState(
+    mx,
+    useCallback(
+      (current) => {
+        const healthy = current !== SyncState.Reconnecting && current !== SyncState.Error;
+        postSyncHealth(healthy);
+      },
+      [postSyncHealth]
+    )
+  );
+
+  return null;
+}
+
 function SlidingSyncActiveRoomSubscriber() {
   useSlidingSyncActiveRoom();
   return null;
@@ -874,6 +905,7 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <MessageNotifications />
       <BackgroundNotifications />
       <SyncNotificationSettingsWithServiceWorker />
+      <SyncStateWithServiceWorker />
       <HandleDecryptPushEvent />
       <NotificationBanner />
       <TelemetryConsentBanner />

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -685,7 +685,18 @@ function SyncNotificationSettingsWithServiceWorker() {
     // Report initial visibility immediately, then track changes.
     postVisibility();
     document.addEventListener('visibilitychange', postVisibility);
-    return () => document.removeEventListener('visibilitychange', postVisibility);
+
+    // iOS kills the SW after ~30 s of inactivity regardless of page
+    // visibility. Send a cheap keep-alive ping every 20 s so the SW
+    // stays alive whenever the page is open (foregrounded or not).
+    const keepAliveId = window.setInterval(() => {
+      navigator.serviceWorker.controller?.postMessage({ type: 'ping' });
+    }, 20_000);
+
+    return () => {
+      document.removeEventListener('visibilitychange', postVisibility);
+      window.clearInterval(keepAliveId);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -66,6 +66,27 @@ import { useSyncState } from '$hooks/useSyncState';
 
 const pushRelayLog = createDebugLogger('push-relay');
 
+function postToServiceWorker(data: unknown): void {
+  if (!('serviceWorker' in navigator)) return;
+
+  const posted = new Set<ServiceWorker>();
+  const postToWorker = (worker: ServiceWorker | null | undefined) => {
+    if (!worker || posted.has(worker)) return;
+    posted.add(worker);
+    // oxlint-disable-next-line unicorn/require-post-message-target-origin
+    worker.postMessage(data);
+  };
+
+  postToWorker(navigator.serviceWorker.controller);
+  navigator.serviceWorker.ready
+    .then((registration) => {
+      postToWorker(registration.active);
+      postToWorker(registration.waiting);
+      postToWorker(registration.installing);
+    })
+    .catch(() => undefined);
+}
+
 function clearMediaSessionQuickly(): void {
   if (!('mediaSession' in navigator)) return;
   // iOS registers the lock screen media player as a side-effect of
@@ -658,8 +679,7 @@ function SyncNotificationSettingsWithServiceWorker() {
     const postVisibility = () => {
       const visible = document.visibilityState === 'visible';
       const msg = { type: 'setAppVisible', visible };
-      navigator.serviceWorker.controller?.postMessage(msg);
-      navigator.serviceWorker.ready.then((reg) => reg.active?.postMessage(msg));
+      postToServiceWorker(msg);
     };
 
     // Report initial visibility immediately, then track changes.
@@ -669,7 +689,6 @@ function SyncNotificationSettingsWithServiceWorker() {
   }, []);
 
   useEffect(() => {
-    if (!('serviceWorker' in navigator)) return;
     // notificationSoundEnabled is intentionally excluded: push notification sound
     // is governed by the push rule's tweakSound alone (OS/Sygnal handles it).
     // The in-app sound setting only controls the in-page <audio> playback above.
@@ -680,10 +699,7 @@ function SyncNotificationSettingsWithServiceWorker() {
       clearNotificationsOnRead,
     };
 
-    navigator.serviceWorker.controller?.postMessage(payload);
-    navigator.serviceWorker.ready.then((registration) => {
-      registration.active?.postMessage(payload);
-    });
+    postToServiceWorker(payload);
   }, [showMessageContent, showEncryptedMessageContent, clearNotificationsOnRead]);
 
   return null;
@@ -699,10 +715,8 @@ function SyncStateWithServiceWorker() {
   const mx = useMatrixClient();
 
   const postSyncHealth = useCallback((healthy: boolean) => {
-    if (!('serviceWorker' in navigator)) return;
     const msg = { type: 'setSyncState', healthy };
-    navigator.serviceWorker.controller?.postMessage(msg);
-    navigator.serviceWorker.ready.then((reg) => reg.active?.postMessage(msg));
+    postToServiceWorker(msg);
   }, []);
 
   useSyncState(
@@ -839,7 +853,7 @@ function HandleDecryptPushEvent() {
           appVisible: visible,
         });
 
-        navigator.serviceWorker.controller?.postMessage({
+        postToServiceWorker({
           type: 'pushDecryptResult',
           eventId,
           success: true,
@@ -856,7 +870,7 @@ function HandleDecryptPushEvent() {
           'Push relay decryption failed',
           err instanceof Error ? err : new Error(String(err))
         );
-        navigator.serviceWorker.controller?.postMessage({
+        postToServiceWorker({
           type: 'pushDecryptResult',
           eventId,
           success: false,

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -90,7 +90,7 @@ function ClientRootOptions({ mx, onLogout }: ClientRootOptionsProps) {
     <IconButton
       style={{
         position: 'absolute',
-        top: config.space.S100,
+        top: `calc(env(safe-area-inset-top, 0px) + ${config.space.S100})`,
         right: config.space.S100,
       }}
       variant="Background"

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -205,7 +205,7 @@ export function ClientRoot({ children }: ClientRootProps) {
       log.log('initClient for', activeSession.userId);
       const newMx = await initClient(activeSession);
       loadedUserIdRef.current = activeSession.userId;
-      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken);
+      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken, activeSession.userId);
       return newMx;
     }, [activeSession, activeSessionId, setActiveSessionId])
   );
@@ -234,7 +234,7 @@ export function ClientRoot({ children }: ClientRootProps) {
         activeSession.userId,
         '— reloading client'
       );
-      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken);
+      pushSessionToSW(activeSession.baseUrl, activeSession.accessToken, activeSession.userId);
       if (mx?.clientRunning) {
         stopClient(mx);
       }
@@ -258,6 +258,28 @@ export function ClientRoot({ children }: ClientRootProps) {
   useSyncNicknames(mx);
   useLogoutListener(mx);
   useAppVisibility(mx);
+
+  // Keep the SW session warm so media fetches and push notifications work
+  // reliably after iOS kills and restarts the SW in the background.
+  // - Immediate resync whenever the tab comes back to the foreground.
+  // - Periodic heartbeat (10 min) keeps the persisted session up to date
+  //   while the app is running.
+  const swSessionBaseUrl = activeSession?.baseUrl;
+  const swSessionAccessToken = activeSession?.accessToken;
+  const swSessionUserId = activeSession?.userId;
+  useEffect(() => {
+    if (!swSessionBaseUrl || !swSessionAccessToken) return undefined;
+    const resync = () => pushSessionToSW(swSessionBaseUrl, swSessionAccessToken, swSessionUserId);
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') resync();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    const timer = setInterval(resync, 10 * 60 * 1000);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      clearInterval(timer);
+    };
+  }, [swSessionBaseUrl, swSessionAccessToken, swSessionUserId]);
 
   useEffect(
     () => () => {

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -175,7 +175,6 @@ type ClientRootProps = {
   children: ReactNode;
 };
 export function ClientRoot({ children }: ClientRootProps) {
-  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
   const clientConfig = useClientConfig();
   const sessions = useAtomValue(sessionsAtom);
@@ -190,6 +189,8 @@ export function ClientRoot({ children }: ClientRootProps) {
   const loadedUserIdRef = useRef<string | undefined>(undefined);
   const syncStartTimeRef = useRef(performance.now());
   const firstSyncReadyRef = useRef(false);
+
+  const [loading, setLoading] = useState(true);
 
   const [loadState, loadMatrix, setLoadState] = useAsyncCallback<MatrixClient, Error, []>(
     useCallback(async () => {
@@ -238,8 +239,8 @@ export function ClientRoot({ children }: ClientRootProps) {
       if (mx?.clientRunning) {
         stopClient(mx);
       }
-      setLoading(true);
       loadedUserIdRef.current = undefined;
+      setLoading(true);
       setLoadState({ status: AsyncStatus.Idle });
       navigate(getHomePath(), { replace: true });
     }
@@ -310,10 +311,22 @@ export function ClientRoot({ children }: ClientRootProps) {
     }
   }, [mx]);
 
+  // Once the client has started (store loaded from IndexedDB, sync loop running),
+  // hide the splash immediately if there are cached rooms — no need to wait for
+  // the first server response. The SyncStatus banner shows "Connecting..." instead.
+  useEffect(() => {
+    if (startState.status !== AsyncStatus.Success || !mx) return;
+    if (isClientReady(mx.getSyncState())) return;
+    if (mx.getRooms().length > 0) {
+      setLoading(false);
+    }
+  }, [mx, startState.status]);
+
   useSyncState(
     mx,
     useCallback((state: string) => {
       if (isClientReady(state)) {
+        setLoading(false);
         if (!firstSyncReadyRef.current) {
           firstSyncReadyRef.current = true;
           Sentry.metrics.distribution(
@@ -321,7 +334,6 @@ export function ClientRoot({ children }: ClientRootProps) {
             performance.now() - syncStartTimeRef.current
           );
         }
-        setLoading(false);
       }
     }, [])
   );
@@ -376,12 +388,15 @@ export function ClientRoot({ children }: ClientRootProps) {
     }
   }, [startState]);
 
+  const hasClientRootError =
+    loadState.status === AsyncStatus.Error || startState.status === AsyncStatus.Error;
+
   return (
     <AutoDiscovery userId={userId ?? ''} baseUrl={baseUrl ?? ''}>
       <SpecVersions baseUrl={baseUrl ?? ''}>
         {mx && <SyncStatus mx={mx} />}
-        {loading && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
-        {(loadState.status === AsyncStatus.Error || startState.status === AsyncStatus.Error) && (
+        {(loading || !mx) && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
+        {hasClientRootError ? (
           <SplashScreen>
             <Box
               direction="Column"
@@ -407,8 +422,7 @@ export function ClientRoot({ children }: ClientRootProps) {
               </Dialog>
             </Box>
           </SplashScreen>
-        )}
-        {loading || !mx ? (
+        ) : loading || !mx ? (
           <ClientRootLoading />
         ) : (
           <MatrixClientProvider value={mx}>

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   IconButton,
   Icons,
+  Line,
   Menu,
   MenuItem,
   PopOut,
@@ -51,9 +52,11 @@ import { useAppVisibility } from '$hooks/useAppVisibility';
 import { getHomePath } from '$pages/pathUtils';
 import { useClientConfig } from '$hooks/useClientConfig';
 import { pushSessionToSW } from '../../../sw-session';
+import { useSwUpdateAvailable } from '$hooks/useSwUpdateAvailable';
 import { SyncStatus } from './SyncStatus';
 import { SpecVersions } from './SpecVersions';
 import { AutoDiscovery } from './AutoDiscovery';
+import { ContainerColor } from '$styles/ContainerColor.css';
 
 const log = createLogger('ClientRoot');
 
@@ -259,6 +262,7 @@ export function ClientRoot({ children }: ClientRootProps) {
   useSyncNicknames(mx);
   useLogoutListener(mx);
   useAppVisibility(mx);
+  const swUpdateAvailable = useSwUpdateAvailable();
 
   // Keep the SW session warm so media fetches and push notifications work
   // reliably after iOS kills and restarts the SW in the background.
@@ -395,6 +399,28 @@ export function ClientRoot({ children }: ClientRootProps) {
     <AutoDiscovery userId={userId ?? ''} baseUrl={baseUrl ?? ''}>
       <SpecVersions baseUrl={baseUrl ?? ''}>
         {mx && <SyncStatus mx={mx} />}
+        {swUpdateAvailable && (
+          <Box direction="Column" shrink="No">
+            <Box
+              as="button"
+              type="button"
+              className={ContainerColor({ variant: 'Primary' })}
+              style={{
+                padding: `${config.space.S100} 0`,
+                width: '100%',
+                cursor: 'pointer',
+                border: 'none',
+                background: 'none',
+              }}
+              alignItems="Center"
+              justifyContent="Center"
+              onClick={() => window.location.reload()}
+            >
+              <Text size="L400">Update available — tap to reload</Text>
+            </Box>
+            <Line variant="Primary" size="300" />
+          </Box>
+        )}
         {(loading || !mx) && <ClientRootOptions mx={mx} onLogout={handleLogout} />}
         {hasClientRootError ? (
           <SplashScreen>

--- a/src/app/pages/client/SyncStatus.tsx
+++ b/src/app/pages/client/SyncStatus.tsx
@@ -15,10 +15,10 @@ type SyncStatusProps = {
   mx: MatrixClient;
 };
 export function SyncStatus({ mx }: SyncStatusProps) {
-  const [stateData, setStateData] = useState<StateData>({
-    current: null,
+  const [stateData, setStateData] = useState<StateData>(() => ({
+    current: mx.getSyncState(),
     previous: undefined,
-  });
+  }));
 
   useSyncState(
     mx,

--- a/src/app/pages/client/direct/Direct.tsx
+++ b/src/app/pages/client/direct/Direct.tsx
@@ -54,6 +54,7 @@ import {
 import { useDirectCreateSelected } from '$hooks/router/useDirectSelected';
 import { useDirectRooms } from './useDirectRooms';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { useScreenSizeContext, ScreenSize } from '$hooks/useScreenSize';
 
 type DirectMenuProps = {
@@ -255,7 +256,7 @@ export function Direct() {
   );
 
   const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+  const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
 
   return (
@@ -366,7 +367,7 @@ export function Direct() {
           </PageNavContent>
         )}
       </PageNav>
-      {!isMobile && (
+      {!mobileOrTabletLayout() && (
         <SidebarResizer
           setCurWidth={setCurWidth}
           sidebarWidth={roomSidebarWidth}

--- a/src/app/pages/client/direct/Direct.tsx
+++ b/src/app/pages/client/direct/Direct.tsx
@@ -56,6 +56,7 @@ import { useDirectRooms } from './useDirectRooms';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
 import { mobileOrTabletLayout } from '$utils/user-agent';
 import { useScreenSizeContext, ScreenSize } from '$hooks/useScreenSize';
+import { usePullToRefresh } from '$hooks/usePullToRefresh';
 
 type DirectMenuProps = {
   requestClose: () => void;
@@ -258,6 +259,8 @@ export function Direct() {
   const screenSize = useScreenSizeContext();
   const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
+
+  usePullToRefresh(scrollRef, mx);
 
   return (
     <Box

--- a/src/app/pages/client/explore/Explore.tsx
+++ b/src/app/pages/client/explore/Explore.tsx
@@ -32,6 +32,7 @@ import { stopPropagation } from '$utils/keyboard';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
 import { settingsAtom } from '$state/settings';
 import { useSetting } from '$state/hooks/settings';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { getMxIdServer } from '$utils/mxIdHelper';
 import { useScreenSizeContext, ScreenSize } from '$hooks/useScreenSize';
 
@@ -177,7 +178,7 @@ export function Explore() {
     setCurWidth(roomSidebarWidth);
   }, [roomSidebarWidth]);
   const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+  const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
 
   return (
@@ -311,7 +312,7 @@ export function Explore() {
           </Box>
         </PageNavContent>
       </PageNav>
-      {!isMobile && (
+      {!mobileOrTabletLayout() && (
         <SidebarResizer
           setCurWidth={setCurWidth}
           sidebarWidth={roomSidebarWidth}

--- a/src/app/pages/client/home/Home.tsx
+++ b/src/app/pages/client/home/Home.tsx
@@ -65,6 +65,7 @@ import { useHomeRooms } from './useHomeRooms';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
 import { mobileOrTabletLayout } from '$utils/user-agent';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
+import { usePullToRefresh } from '$hooks/usePullToRefresh';
 
 type HomeMenuProps = {
   requestClose: () => void;
@@ -265,6 +266,8 @@ export function Home() {
   const screenSize = useScreenSizeContext();
   const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
+
+  usePullToRefresh(scrollRef, mx);
 
   return (
     <Box

--- a/src/app/pages/client/home/Home.tsx
+++ b/src/app/pages/client/home/Home.tsx
@@ -63,6 +63,7 @@ import { UseStateProvider } from '$components/UseStateProvider';
 import { JoinAddressPrompt } from '$components/join-address-prompt';
 import { useHomeRooms } from './useHomeRooms';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 
 type HomeMenuProps = {
@@ -262,7 +263,7 @@ export function Home() {
   );
 
   const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+  const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
 
   return (
@@ -453,7 +454,7 @@ export function Home() {
           </PageNavContent>
         )}
       </PageNav>
-      {!isMobile && (
+      {!mobileOrTabletLayout() && (
         <SidebarResizer
           setCurWidth={setCurWidth}
           sidebarWidth={roomSidebarWidth}

--- a/src/app/pages/client/inbox/Inbox.tsx
+++ b/src/app/pages/client/inbox/Inbox.tsx
@@ -11,6 +11,7 @@ import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { useEffect, useState } from 'react';
+import { mobileOrTabletLayout } from '$utils/user-agent';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 
 function InvitesNavItem({ hideText }: { hideText?: boolean }) {
@@ -61,7 +62,7 @@ export function Inbox() {
     setCurWidth(roomSidebarWidth);
   }, [roomSidebarWidth]);
   const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+  const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
 
   return (
@@ -117,7 +118,7 @@ export function Inbox() {
           </Box>
         </PageNavContent>
       </PageNav>
-      {!isMobile && (
+      {!mobileOrTabletLayout() && (
         <SidebarResizer
           setCurWidth={setCurWidth}
           sidebarWidth={roomSidebarWidth}

--- a/src/app/pages/client/sidebar/SpaceTabs.tsx
+++ b/src/app/pages/client/sidebar/SpaceTabs.tsx
@@ -56,7 +56,7 @@ import {
   SidebarFolder,
   SidebarFolderDropTarget,
 } from '$components/sidebar';
-import { RoomUnreadProvider, RoomsUnreadProvider } from '$components/RoomUnreadProvider';
+import { RoomsUnreadProvider } from '$components/RoomUnreadProvider';
 import { useSelectedSpace } from '$hooks/router/useSelectedSpace';
 import { getCanonicalAliasOrRoomId, isRoomAlias } from '$utils/matrix';
 import { RoomAvatar } from '$components/room-avatar';
@@ -534,6 +534,16 @@ function SpaceTab({
 
   const [menuAnchor, setMenuAnchor] = useState<RectCords>();
 
+  // Aggregate unread across all recursive child rooms (space rooms themselves
+  // carry no messages, so RoomUnreadProvider would always return nothing).
+  const roomToParents = useAtomValue(roomToParentsAtom);
+  const allChild = useSpaceChildren(
+    allRoomsAtom,
+    space.roomId,
+    useRecursiveChildScopeFactory(mx, roomToParents)
+  );
+  const unread = useRoomsUnread(allChild, roomToUnreadAtom);
+
   const handleContextMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
     evt.preventDefault();
     const cords = evt.currentTarget.getBoundingClientRect();
@@ -544,74 +554,70 @@ function SpaceTab({
   };
 
   return (
-    <RoomUnreadProvider roomId={space.roomId}>
-      {(unread) => (
-        <SidebarItem
-          active={selected}
-          ref={targetRef}
-          aria-disabled={disabled}
-          data-drop-child={dropType === 'make-child'}
-          data-drop-above={dropType === 'reorder-above'}
-          data-drop-below={dropType === 'reorder-below'}
-          data-inside-folder={!!folder}
-        >
-          <SidebarItemTooltip tooltip={disabled ? undefined : space.name}>
-            {(triggerRef) => (
-              <SidebarAvatar
-                as="button"
-                data-id={space.roomId}
-                ref={triggerRef}
-                size={folder ? '300' : '400'}
-                onClick={onClick}
-                onContextMenu={handleContextMenu}
-              >
-                <RoomAvatar
-                  roomId={space.roomId}
-                  uniformIcons
-                  src={getRoomAvatarUrl(mx, space, 96, useAuthentication) ?? undefined}
-                  alt={space.name}
-                  renderFallback={() => (
-                    <Text size={folder ? 'H6' : 'H4'}>{nameInitials(space.name, 2)}</Text>
-                  )}
-                />
-              </SidebarAvatar>
-            )}
-          </SidebarItemTooltip>
-          {unread && (
-            <SidebarUnreadBadge
-              highlight={unread.highlight > 0}
-              count={unread.highlight > 0 ? unread.highlight : unread.total}
+    <SidebarItem
+      active={selected}
+      ref={targetRef}
+      aria-disabled={disabled}
+      data-drop-child={dropType === 'make-child'}
+      data-drop-above={dropType === 'reorder-above'}
+      data-drop-below={dropType === 'reorder-below'}
+      data-inside-folder={!!folder}
+    >
+      <SidebarItemTooltip tooltip={disabled ? undefined : space.name}>
+        {(triggerRef) => (
+          <SidebarAvatar
+            as="button"
+            data-id={space.roomId}
+            ref={triggerRef}
+            size={folder ? '300' : '400'}
+            onClick={onClick}
+            onContextMenu={handleContextMenu}
+          >
+            <RoomAvatar
+              roomId={space.roomId}
+              uniformIcons
+              src={getRoomAvatarUrl(mx, space, 96, useAuthentication) ?? undefined}
+              alt={space.name}
+              renderFallback={() => (
+                <Text size={folder ? 'H6' : 'H4'}>{nameInitials(space.name, 2)}</Text>
+              )}
             />
-          )}
-          {menuAnchor && (
-            <PopOut
-              anchor={menuAnchor}
-              position="Right"
-              align="Start"
-              content={
-                <FocusTrap
-                  focusTrapOptions={{
-                    initialFocus: false,
-                    returnFocusOnDeactivate: false,
-                    onDeactivate: () => setMenuAnchor(undefined),
-                    clickOutsideDeactivates: true,
-                    isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
-                    isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
-                    escapeDeactivates: stopPropagation,
-                  }}
-                >
-                  <SpaceMenu
-                    room={space}
-                    requestClose={() => setMenuAnchor(undefined)}
-                    onUnpin={onUnpin}
-                  />
-                </FocusTrap>
-              }
-            />
-          )}
-        </SidebarItem>
+          </SidebarAvatar>
+        )}
+      </SidebarItemTooltip>
+      {unread && (
+        <SidebarUnreadBadge
+          highlight={unread.highlight > 0}
+          count={unread.highlight > 0 ? unread.highlight : unread.total}
+        />
       )}
-    </RoomUnreadProvider>
+      {menuAnchor && (
+        <PopOut
+          anchor={menuAnchor}
+          position="Right"
+          align="Start"
+          content={
+            <FocusTrap
+              focusTrapOptions={{
+                initialFocus: false,
+                returnFocusOnDeactivate: false,
+                onDeactivate: () => setMenuAnchor(undefined),
+                clickOutsideDeactivates: true,
+                isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
+                isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
+                escapeDeactivates: stopPropagation,
+              }}
+            >
+              <SpaceMenu
+                room={space}
+                requestClose={() => setMenuAnchor(undefined)}
+                onUnpin={onUnpin}
+              />
+            </FocusTrap>
+          }
+        />
+      )}
+    </SidebarItem>
   );
 }
 

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -80,6 +80,7 @@ import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { BreakWord } from '$styles/Text.css';
 import { InviteUserPrompt } from '$components/invite-user-prompt';
 import { mobileOrTablet, mobileOrTabletLayout } from '$utils/user-agent';
+import { usePullToRefresh } from '$hooks/usePullToRefresh';
 import { lastVisitedRoomIdAtom } from '$state/room/lastRoom';
 import { SwipeableOverlayWrapper } from '$components/SwipeableOverlayWrapper';
 import { useCallEmbed } from '$hooks/useCallEmbed';
@@ -859,6 +860,9 @@ export function Space() {
   const screenSize = useScreenSizeContext();
   const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
+
+  usePullToRefresh(scrollRef, mx);
+
   return (
     <Box
       shrink="No"

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -79,7 +79,7 @@ import { ContainerColor } from '$styles/ContainerColor.css';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { BreakWord } from '$styles/Text.css';
 import { InviteUserPrompt } from '$components/invite-user-prompt';
-import { mobileOrTablet } from '$utils/user-agent';
+import { mobileOrTablet, mobileOrTabletLayout } from '$utils/user-agent';
 import { lastVisitedRoomIdAtom } from '$state/room/lastRoom';
 import { SwipeableOverlayWrapper } from '$components/SwipeableOverlayWrapper';
 import { useCallEmbed } from '$hooks/useCallEmbed';
@@ -857,7 +857,7 @@ export function Space() {
   }, [lastRoomId, spaceIdOrAlias, mx, navigate]);
 
   const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+  const isMobile = mobileOrTabletLayout() || screenSize === ScreenSize.Mobile;
   const hideText = curWidth <= 80 && !isMobile;
   return (
     <Box
@@ -1048,7 +1048,7 @@ export function Space() {
           </PageNavContent>
         </SwipeableOverlayWrapper>
       </PageNav>
-      {!isMobile && (
+      {!mobileOrTabletLayout() && (
         <SidebarResizer
           setCurWidth={setCurWidth}
           sidebarWidth={roomSidebarWidth}

--- a/src/app/state/sessions.ts
+++ b/src/app/state/sessions.ts
@@ -43,10 +43,14 @@ export function setFallbackSession(
   userId: string,
   baseUrl: string
 ) {
-  localStorage.setItem('cinny_access_token', accessToken);
-  localStorage.setItem('cinny_device_id', deviceId);
-  localStorage.setItem('cinny_user_id', userId);
-  localStorage.setItem('cinny_hs_base_url', baseUrl);
+  try {
+    localStorage.setItem('cinny_access_token', accessToken);
+    localStorage.setItem('cinny_device_id', deviceId);
+    localStorage.setItem('cinny_user_id', userId);
+    localStorage.setItem('cinny_hs_base_url', baseUrl);
+  } catch {
+    // QuotaExceededError: write best-effort; ignore if storage is full
+  }
 }
 export const removeFallbackSession = () => {
   localStorage.removeItem('cinny_hs_base_url');

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -593,7 +593,11 @@ export const getSettings = (): Settings =>
   mergePersistedSettings(localStorage.getItem(STORAGE_KEY), runtimeSettingsDefaults);
 
 export const setSettings = (settings: Settings) => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // QuotaExceededError: write best-effort; ignore if storage is full
+  }
 };
 
 export const settingsAtom = atom<Settings, [Settings], undefined>(

--- a/src/app/state/utils/atomWithLocalStorage.ts
+++ b/src/app/state/utils/atomWithLocalStorage.ts
@@ -12,7 +12,11 @@ export const getLocalStorageItem = <T>(key: string, defaultValue: T): T => {
 };
 
 export const setLocalStorageItem = (key: string, value: unknown) => {
-  localStorage.setItem(key, JSON.stringify(value));
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // QuotaExceededError: write best-effort; ignore if storage is full
+  }
 };
 
 export type GetLocalStorageItem<T> = (key: string) => T;

--- a/src/app/styles/overrides/General.css.ts
+++ b/src/app/styles/overrides/General.css.ts
@@ -1,4 +1,13 @@
 import { globalStyle } from '@vanilla-extract/css';
+import { color } from 'folds';
+
+// Ensure the safe-area padding areas on #root (top/bottom on iOS) show
+// the app's background container color instead of the white body fallback.
+// Without this, the 34px home-indicator gap at the bottom is visibly white
+// against the gray content, making it look like a UI gap on iOS PWA.
+globalStyle('#root', {
+  backgroundColor: color.Background.Container,
+});
 
 globalStyle(
   `

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -64,18 +64,45 @@ export const selectFile = <M extends boolean | undefined = undefined>(
     if (accept) input.accept = accept;
     if (multiple) input.multiple = true;
 
-    const changeHandler = () => {
-      const fileList = input.files;
-      if (!fileList) {
-        resolve(undefined);
-      } else {
-        const files: File[] = getFilesFromFileList(fileList);
-        resolve((multiple ? files : files[0]) as FilesOrFile<M>);
-      }
+    // iOS Safari requires the input to be in the DOM to reliably trigger the
+    // file picker dialog; remove it immediately after selection.
+    input.style.cssText = 'position:fixed;top:-9999px;left:-9999px;opacity:0';
+    document.body.appendChild(input);
+
+    let settled = false;
+
+    const cleanup = () => {
       input.removeEventListener('change', changeHandler);
+      input.removeEventListener('cancel', cancelHandler);
+      if (input.parentNode) input.parentNode.removeChild(input);
     };
 
+    const settle = (value: FilesOrFile<M> | undefined) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const changeHandler = () => {
+      const fileList = input.files;
+      // On iOS Safari, `change` can fire with an empty FileList (e.g. the
+      // picker was dismissed, or the file isn't available yet). Treat this
+      // the same as a cancellation so callers receive `undefined` rather than
+      // an empty array that silently produces no upload items.
+      if (!fileList || fileList.length === 0) {
+        settle(undefined);
+        return;
+      }
+      const files: File[] = getFilesFromFileList(fileList);
+      settle(files.length === 0 ? undefined : ((multiple ? files : files[0]) as FilesOrFile<M>));
+    };
+
+    // iOS 15+: fires when the picker is dismissed without a file selection.
+    const cancelHandler = () => settle(undefined);
+
     input.addEventListener('change', changeHandler);
+    input.addEventListener('cancel', cancelHandler);
     input.click();
   });
 

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -20,10 +20,10 @@ const normalizeMacName = (os?: string) => {
   return os;
 };
 
-// True only for phone-form-factor devices for layout/nav decisions.
-// Tablets (native iPadOS UA or "Request Desktop Website") always get the desktop
-// two-panel layout; only phones collapse to the single-panel mobile layout.
-const isMobileOrTabletLayout = result.device.type === 'mobile';
+// True only for phone-form-factor devices for layout/nav decisions and settings
+// that should remain available on tablets with external keyboards.
+// Tablets (native iPadOS UA or "Request Desktop Website") return false.
+const isPhoneDevice = result.device.type === 'mobile';
 
 const isMac = result.os.name === 'Mac OS';
 
@@ -36,7 +36,9 @@ export const mobileOrTablet = () => isMobileOrTablet;
  * so they always get the full desktop two-panel layout.
  * Use `mobileOrTablet` for touch/keyboard/scroll-lock behaviour instead.
  */
-export const mobileOrTabletLayout = () => isMobileOrTabletLayout;
+export const mobileOrTabletLayout = () => isPhoneDevice;
+/** True only for phones; returns false for tablets (e.g. iPad with external keyboard). */
+export const isPhone = () => isPhoneDevice;
 
 export const deviceDisplayName = (): string => {
   const browser = result.browser.name;

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -6,6 +6,11 @@ const isMobileOrTablet = (() => {
   const { os, device } = result;
   if (device.type === 'mobile' || device.type === 'tablet') return true;
   if (os.name === 'Android' || os.name === 'iOS') return true;
+  // iPad on iOS 13+ sends a macOS Safari user agent by default ("Request Desktop Website").
+  // ua-parser-js therefore reports os.name === 'Mac OS' with no device.type.
+  // Real Macs never have maxTouchPoints > 1 (Magic Trackpad reports 1 at most in browsers),
+  // so this safely identifies iPads masquerading as desktop Safari.
+  if (os.name === 'Mac OS' && navigator.maxTouchPoints > 1) return true;
   return false;
 })();
 
@@ -15,11 +20,23 @@ const normalizeMacName = (os?: string) => {
   return os;
 };
 
+// True only for phone-form-factor devices for layout/nav decisions.
+// Tablets (native iPadOS UA or "Request Desktop Website") always get the desktop
+// two-panel layout; only phones collapse to the single-panel mobile layout.
+const isMobileOrTabletLayout = result.device.type === 'mobile';
+
 const isMac = result.os.name === 'Mac OS';
 
 export const ua = () => result;
 export const isMacOS = () => isMac;
 export const mobileOrTablet = () => isMobileOrTablet;
+/**
+ * True only for phones. Use this for layout/nav decisions (sidebars, route registration).
+ * Tablets — whether using native iPadOS UA or iPad "Request Desktop Website" — return false,
+ * so they always get the full desktop two-panel layout.
+ * Use `mobileOrTablet` for touch/keyboard/scroll-lock behaviour instead.
+ */
+export const mobileOrTabletLayout = () => isMobileOrTabletLayout;
 
 export const deviceDisplayName = (): string => {
   const browser = result.browser.name;

--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -805,9 +805,13 @@ export const clearLoginData = async () => {
 
   // Unregister all service workers so the next load starts fresh.
   // Especially important on iOS/mobile where stale SWs can persist.
-  if ('serviceWorker' in navigator) {
-    const registrations = await navigator.serviceWorker.getRegistrations();
-    await Promise.all(registrations.map((r) => r.unregister()));
+  try {
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((r) => r.unregister()));
+    }
+  } catch {
+    // SW unregister is best-effort; reload regardless
   }
 
   window.location.reload();

--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -802,5 +802,13 @@ export const clearLoginData = async () => {
     if (name) window.indexedDB.deleteDatabase(name);
   });
   window.localStorage.clear();
+
+  // Unregister all service workers so the next load starts fresh.
+  // Especially important on iOS/mobile where stale SWs can persist.
+  if ('serviceWorker' in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((r) => r.unregister()));
+  }
+
   window.location.reload();
 };

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -483,9 +483,10 @@ export class SlidingSyncManager {
           syncNumber: this.syncCount,
         });
       } else {
-        debugLog.info('network', 'Device back online - sync will resume', {
+        debugLog.info('network', 'Device back online - triggering immediate resync', {
           syncNumber: this.syncCount,
         });
+        this.slidingSync.resend();
       }
     };
   }
@@ -572,6 +573,15 @@ export class SlidingSyncManager {
     debugLog.info('sync', 'Sliding sync disposed successfully', {
       totalSyncCycles: this.syncCount,
     });
+  }
+
+  /**
+   * Abort any in-flight sliding sync request and retry immediately.
+   * Safe to call at any time; if the sync is healthy the next poll just fires sooner.
+   */
+  public retryNow(): void {
+    if (this.disposed) return;
+    this.slidingSync.resend();
   }
 
   public setPresenceEnabled(enabled: boolean): void {

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -277,6 +277,16 @@ export class SlidingSyncManager {
   private previousListCounts: Map<string, number> = new Map();
 
   /**
+   * When non-null, contains the set of room IDs that were active subscriptions
+   * before a force-reset was scheduled (pull-to-refresh). The rooms are
+   * temporarily cleared from activeRoomSubscriptions so the server processes
+   * one empty-subscription cycle, and then restored here so the server treats
+   * them as fresh subscriptions and returns initial:true with full data and
+   * backward-pagination tokens.
+   */
+  private pendingResubscriptions: Set<string> | null = null;
+
+  /**
    * One-shot RoomData listeners keyed by roomId, used to measure the latency
    * between subscribeToRoom() and the first data arriving for that room.
    * Cleaned up automatically after first fire or on unsubscribe/dispose.
@@ -378,6 +388,18 @@ export class SlidingSyncManager {
             if (timelineSet.getLiveTimeline().getEvents().length === 0) return;
             timelineSet.resetLiveTimeline();
           });
+
+        // If a force-resubscription cycle was scheduled (pull-to-refresh), restore
+        // all subscriptions now that the server has seen the empty-subscription
+        // request.  On the next sync cycle the server will treat these as new
+        // subscriptions and return initial:true with fresh data and backward-
+        // pagination tokens, which the block above will then handle.
+        if (this.pendingResubscriptions !== null) {
+          const toRestore = this.pendingResubscriptions;
+          this.pendingResubscriptions = null;
+          toRestore.forEach((roomId) => this.activeRoomSubscriptions.add(roomId));
+          this.slidingSync.modifyRoomSubscriptions(new Set(this.activeRoomSubscriptions));
+        }
       }
 
       if (err || !resp || state !== SlidingSyncState.Complete) return;
@@ -581,6 +603,26 @@ export class SlidingSyncManager {
    */
   public retryNow(): void {
     if (this.disposed) return;
+    this.slidingSync.resend();
+  }
+
+  /**
+   * Force a full re-subscription for all currently active room subscriptions.
+   *
+   * Temporarily clears all active room subscriptions and sends a sync request
+   * with an empty subscription set.  Once the server acknowledges that request
+   * (RequestFinished), the subscriptions are restored and the server treats
+   * them as brand-new, returning initial:true responses with a full event
+   * window and a valid backward-pagination token for each room.
+   *
+   * This recovers from stale or out-of-order in-memory timeline state that
+   * cannot be fixed by a normal delta sync.  Called by pull-to-refresh.
+   */
+  public scheduleForceReset(): void {
+    if (this.disposed) return;
+    this.pendingResubscriptions = new Set(this.activeRoomSubscriptions);
+    this.activeRoomSubscriptions.clear();
+    this.slidingSync.modifyRoomSubscriptions(new Set());
     this.slidingSync.resend();
   }
 

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -609,18 +609,36 @@ export class SlidingSyncManager {
   /**
    * Force a full re-subscription for all currently active room subscriptions.
    *
-   * Temporarily clears all active room subscriptions and sends a sync request
-   * with an empty subscription set.  Once the server acknowledges that request
-   * (RequestFinished), the subscriptions are restored and the server treats
-   * them as brand-new, returning initial:true responses with a full event
-   * window and a valid backward-pagination token for each room.
+   * Immediately resets the live timeline of every active room so stale or
+   * out-of-order in-memory data is cleared synchronously.  Then clears all
+   * room subscriptions and triggers a sync with an empty room_subscriptions
+   * map.  When RequestFinished fires for that empty-subscription cycle, the
+   * subscriptions are restored; the server treats them as brand-new and
+   * returns initial:true with a full event window and a valid backward-
+   * pagination token for each room on the following cycle.
    *
    * This recovers from stale or out-of-order in-memory timeline state that
    * cannot be fixed by a normal delta sync.  Called by pull-to-refresh.
    */
   public scheduleForceReset(): void {
     if (this.disposed) return;
+    // Save the current subscriptions before modifying anything.
     this.pendingResubscriptions = new Set(this.activeRoomSubscriptions);
+    // Immediately reset every active-room timeline so stale or out-of-order
+    // data is cleared right now.  TimelineReset fires here, putting React
+    // into a loading state.  The SDK will refill the timelines with fresh
+    // data once the re-subscription cycle below completes.
+    this.pendingResubscriptions.forEach((roomId) => {
+      const room = this.mx.getRoom(roomId);
+      if (!room) return;
+      const timelineSet = room.getUnfilteredTimelineSet();
+      if (timelineSet.getLiveTimeline().getEvents().length === 0) return;
+      timelineSet.resetLiveTimeline();
+    });
+    // Clear subscriptions so the next sync request carries an empty
+    // room_subscriptions map.  When RequestFinished fires, the subscriptions
+    // are restored; the server then treats them as brand-new and returns
+    // initial:true with a full event window and a valid prev_batch token.
     this.activeRoomSubscriptions.clear();
     this.slidingSync.modifyRoomSubscriptions(new Set());
     this.slidingSync.resend();

--- a/src/index.css
+++ b/src/index.css
@@ -43,10 +43,6 @@
 
 html {
   height: 100%;
-  /* dvh (dynamic viewport height) shrinks when the on-screen keyboard opens on
-     iOS/Android, keeping the app layout anchored at the top rather than being
-     pushed off-screen. Falls back to 100% on older browsers. */
-  height: 100dvh;
   overflow: hidden;
   overscroll-behavior: none;
 }
@@ -58,14 +54,25 @@ body {
   font-family: var(--font-secondary);
   font-size: 16px;
   font-weight: 400;
+  /* Prevent iOS Safari rubber-band overscroll from shifting the entire app off-screen. */
+  overscroll-behavior: none;
   /* eslint-disable-next-line css/no-invalid-properties */
   background-color: var(--sable-bg-container);
 }
 #root {
   width: 100%;
-  height: 100%;
+  /* On iOS PWA, --sable-visible-height is set (via RoomInput's useEffect)
+     when the keyboard is open, shrinking the root to the visual viewport
+     so the whole layout reflows correctly above the keyboard. Falls back
+     to 100% when no keyboard is present. */
+  height: var(--sable-visible-height, 100%);
   display: flex;
   flex-direction: column;
+  padding-top: env(safe-area-inset-top, 0px);
+  /* --sable-safe-bottom is set to 0px when the keyboard is open (home
+     indicator region is covered by the keyboard). Falls back to the
+     safe-area inset when the keyboard is closed. */
+  padding-bottom: var(--sable-safe-bottom, env(safe-area-inset-bottom, 0px));
 }
 
 *,

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,7 @@ body {
   background-color: var(--sable-bg-container);
 }
 #root {
+  position: relative;
   width: 100%;
   /* On iOS PWA, --sable-visible-height is set (via RoomInput's useEffect)
      when the keyboard is open, shrinking the root to the visual viewport
@@ -68,11 +69,6 @@ body {
   height: var(--sable-visible-height, 100%);
   display: flex;
   flex-direction: column;
-  padding-top: env(safe-area-inset-top, 0px);
-  /* --sable-safe-bottom is set to 0px when the keyboard is open (home
-     indicator region is covered by the keyboard). Falls back to the
-     safe-area inset when the keyboard is closed. */
-  padding-bottom: var(--sable-safe-bottom, env(safe-area-inset-bottom, 0px));
 }
 
 *,

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,10 @@
 
 html {
   height: 100%;
+  /* dvh (dynamic viewport height) shrinks when the on-screen keyboard opens on
+     iOS/Android, keeping the app layout anchored at the top rather than being
+     pushed off-screen. Falls back to 100% on older browsers. */
+  height: 100dvh;
   overflow: hidden;
   overscroll-behavior: none;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,41 @@ const log = createLogger('index');
 
 document.body.classList.add(configClass, varsClass);
 
+// Lazy SW re-claim — avoids iOS bfcache eviction.
+//
+// clients.claim() is NOT called unconditionally in the SW's activate handler
+// because doing so fires controllerchange on every open client including
+// bfcached ones, which evicts them from bfcache and causes a hard reload.
+//
+// Instead, the page requests a claim whenever it comes to the foreground and
+// detects that the active SW is not yet its controller (e.g. after iOS killed
+// and restarted the SW while the page was backgrounded).  Safe to call
+// speculatively: if the SW is already the controller, clients.claim() is a
+// no-op and controllerchange does not re-fire.
+const requestSWClaim = () => {
+  if (!('serviceWorker' in navigator)) return;
+  navigator.serviceWorker.ready
+    .then((reg) => {
+      if (reg.active && reg.active !== navigator.serviceWorker.controller) {
+        // oxlint-disable-next-line unicorn/require-post-message-target-origin
+        reg.active.postMessage({ type: 'CLAIM_CLIENTS' });
+      }
+    })
+    .catch(() => undefined);
+};
+
+// Bfcache restore: page snaps back instantly; check whether the SW was
+// restarted while the page was away.
+window.addEventListener('pageshow', (ev) => {
+  if (ev.persisted) requestSWClaim();
+});
+
+// Visibility-change foreground: covers the case where iOS kills the SW
+// while the screen is on (memory pressure) and the user touches the app.
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') requestSWClaim();
+});
+
 if ('serviceWorker' in navigator) {
   const isProduction = import.meta.env.MODE === 'production';
   const swUrl = isProduction
@@ -131,10 +166,12 @@ const CHUNK_RETRY_KEY = 'cinny_chunk_retry_count';
 const MAX_CHUNK_RETRIES = 2;
 
 window.addEventListener('error', (event) => {
-  // Check if this is a chunk loading error
+  // Check if this is a chunk loading error.
+  // Deliberately excludes 'Failed to fetch' — that string matches generic network
+  // errors (e.g. media auth failures after a SW restart) which must not trigger a
+  // page reload.
   const isChunkLoadError =
     event.message?.includes('dynamically imported module') ||
-    event.message?.includes('Failed to fetch') ||
     event.error?.name === 'ChunkLoadError';
 
   if (isChunkLoadError) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,7 +59,10 @@ if ('serviceWorker' in navigator) {
           installingWorker.addEventListener('statechange', () => {
             if (installingWorker.state === 'installed') {
               if (navigator.serviceWorker.controller) {
-                window.location.reload();
+                // Notify the app rather than silently reloading — the user
+                // should see a banner and choose when to refresh, especially
+                // on mobile where an unexpected reload is very disorienting.
+                window.dispatchEvent(new CustomEvent('sable:sw-update'));
               }
             }
           });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,23 +30,6 @@ const log = createLogger('index');
 
 document.body.classList.add(configClass, varsClass);
 
-const showUpdateAvailablePrompt = (registration: ServiceWorkerRegistration) => {
-  const DONT_SHOW_PROMPT_KEY = 'cinny_dont_show_sw_update_prompt';
-  const userPreference = localStorage.getItem(DONT_SHOW_PROMPT_KEY);
-
-  if (userPreference === 'true') {
-    return;
-  }
-
-  if (window.confirm('A new version of the app is available. Refresh to update?')) {
-    if (registration.waiting) {
-      // oxlint-disable-next-line unicorn/require-post-message-target-origin
-      registration.waiting.postMessage({ type: 'SKIP_WAITING_AND_CLAIM' });
-    }
-    window.location.reload();
-  }
-};
-
 if ('serviceWorker' in navigator) {
   const isProduction = import.meta.env.MODE === 'production';
   const swUrl = isProduction
@@ -76,7 +59,7 @@ if ('serviceWorker' in navigator) {
           installingWorker.addEventListener('statechange', () => {
             if (installingWorker.state === 'installed') {
               if (navigator.serviceWorker.controller) {
-                showUpdateAvailablePrompt(registration);
+                window.location.reload();
               }
             }
           });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,21 +58,6 @@ if ('serviceWorker' in navigator) {
     swRegisterOptions.type = 'module';
   }
 
-  navigator.serviceWorker.register(swUrl, swRegisterOptions).then((registration) => {
-    registration.addEventListener('updatefound', () => {
-      const installingWorker = registration.installing;
-      if (installingWorker) {
-        installingWorker.addEventListener('statechange', () => {
-          if (installingWorker.state === 'installed') {
-            if (navigator.serviceWorker.controller) {
-              showUpdateAvailablePrompt(registration);
-            }
-          }
-        });
-      }
-    });
-  });
-
   const sendSessionToSW = () => {
     // Use the active session from the new multi-session store, fall back to legacy
     const sessions = getLocalStorageItem<Sessions>(MATRIX_SESSIONS_KEY, []);
@@ -83,8 +68,22 @@ if ('serviceWorker' in navigator) {
   };
 
   navigator.serviceWorker
-    .register(swUrl)
-    .then(sendSessionToSW)
+    .register(swUrl, swRegisterOptions)
+    .then((registration) => {
+      registration.addEventListener('updatefound', () => {
+        const installingWorker = registration.installing;
+        if (installingWorker) {
+          installingWorker.addEventListener('statechange', () => {
+            if (installingWorker.state === 'installed') {
+              if (navigator.serviceWorker.controller) {
+                showUpdateAvailablePrompt(registration);
+              }
+            }
+          });
+        }
+      });
+      sendSessionToSW();
+    })
     .catch((err) => {
       log.warn('SW registration failed:', err);
     });

--- a/src/sw-session.ts
+++ b/src/sw-session.ts
@@ -1,12 +1,30 @@
 export function pushSessionToSW(baseUrl?: string, accessToken?: string, userId?: string) {
   if (!('serviceWorker' in navigator)) return;
-  if (!navigator.serviceWorker.controller) return;
 
-  navigator.serviceWorker.controller.postMessage({
+  const message = {
     type: 'setSession',
     accessToken,
     baseUrl,
     userId,
+  };
+
+  const posted = new Set<ServiceWorker>();
+  const postToWorker = (worker: ServiceWorker | null | undefined) => {
+    if (!worker || posted.has(worker)) return;
+    posted.add(worker);
     // oxlint-disable-next-line unicorn/require-post-message-target-origin
-  });
+    worker.postMessage(message);
+  };
+
+  const postToController = () => postToWorker(navigator.serviceWorker.controller);
+
+  postToController();
+  navigator.serviceWorker.addEventListener('controllerchange', postToController, { once: true });
+  navigator.serviceWorker.ready
+    .then((registration) => {
+      postToWorker(registration.active);
+      postToWorker(registration.waiting);
+      postToWorker(registration.installing);
+    })
+    .catch(() => undefined);
 }

--- a/src/sw-session.ts
+++ b/src/sw-session.ts
@@ -19,7 +19,12 @@ export function pushSessionToSW(baseUrl?: string, accessToken?: string, userId?:
   const postToController = () => postToWorker(navigator.serviceWorker.controller);
 
   postToController();
-  navigator.serviceWorker.addEventListener('controllerchange', postToController, { once: true });
+  // Only wait for a future controller if there isn't one yet — repeated calls
+  // (e.g. the 10-minute heartbeat) would otherwise accumulate { once: true }
+  // listeners that never fire when a controller is already active.
+  if (!navigator.serviceWorker.controller) {
+    navigator.serviceWorker.addEventListener('controllerchange', postToController, { once: true });
+  }
   navigator.serviceWorker.ready
     .then((registration) => {
       postToWorker(registration.active);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -542,7 +542,19 @@ self.addEventListener('install', (event: ExtendableEvent) => {
 self.addEventListener('activate', (event: ExtendableEvent) => {
   event.waitUntil(
     (async () => {
-      await self.clients.claim();
+      // Do NOT call clients.claim() here.
+      //
+      // Calling clients.claim() in activate evicts iOS bfcache entries: it fires
+      // controllerchange on every client — including cached ones — and iOS evicts
+      // any page whose SW controller changes while it is in bfcache.  On iOS PWA
+      // (no browser chrome) this looks identical to a hard reload: the user sees
+      // the splash screen instead of an instant restore.
+      //
+      // Pages detect a stale/missing controller on every foreground event
+      // (pageshow[persisted] and visibilitychange→visible) and send CLAIM_CLIENTS
+      // so the SW claims them lazily once they are already visible.  New page
+      // navigations are automatically controlled by the active SW without an
+      // explicit claim.
       await cleanupDeadClients();
       // Pre-load the persisted session into memory so that media fetches arriving
       // before the first setSession message from the page are immediately
@@ -571,6 +583,21 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   if (type === 'setSession') {
     setSession(client.id, accessToken, baseUrl, userId);
     event.waitUntil(cleanupDeadClients());
+  }
+  if (type === 'CLAIM_CLIENTS') {
+    // Sent by the page on pageshow[persisted] or visibilitychange→visible when it
+    // detects that its SW controller is stale (e.g. after iOS killed and restarted
+    // the SW while the page was in bfcache or in the foreground under memory
+    // pressure).  Claiming here — after the page is visible — never evicts bfcache.
+    event.waitUntil(
+      (async () => {
+        await self.clients.claim();
+        // Re-request sessions from all newly-claimed clients so media auth is
+        // restored immediately without waiting for the next media fetch.
+        const claimedClients = await self.clients.matchAll({ type: 'window' });
+        claimedClients.forEach((c) => c.postMessage({ type: 'requestSession' }));
+      })()
+    );
   }
   if (type === 'pushDecryptResult') {
     // Resolve a pending decryption request from handleMinimalPushPayload

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -593,6 +593,12 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
       syncIsHealthy = (data as { healthy: boolean }).healthy;
     }
   }
+  if (type === 'ping') {
+    // iOS terminates SWs after ~30 s of inactivity. The page sends a cheap
+    // ping every 20 s (regardless of visibility) so that event.waitUntil
+    // extends the SW lifetime while the app is open.
+    event.waitUntil(Promise.resolve());
+  }
   if (type === 'setNotificationSettings') {
     if (
       typeof (data as { notificationSoundEnabled?: unknown }).notificationSoundEnabled === 'boolean'

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -12,6 +12,10 @@ let notificationSoundEnabled = true;
 // The clients.matchAll() visibilityState is unreliable on iOS Safari PWA,
 // so we use this explicit flag as a fallback.
 let appIsVisible = false;
+// Tracks whether the Matrix sync connection is healthy.
+// Defaults to true; set false when the app reports Reconnecting/Error so that
+// OS push notifications are not suppressed while the in-app path is broken.
+let syncIsHealthy = true;
 let showMessageContent = false;
 let showEncryptedMessageContent = false;
 let clearNotificationsOnRead = false;
@@ -584,6 +588,11 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
       appIsVisible = (data as { visible: boolean }).visible;
     }
   }
+  if (type === 'setSyncState') {
+    if (typeof (data as { healthy?: unknown }).healthy === 'boolean') {
+      syncIsHealthy = (data as { healthy: boolean }).healthy;
+    }
+  }
   if (type === 'setNotificationSettings') {
     if (
       typeof (data as { notificationSoundEnabled?: unknown }).notificationSoundEnabled === 'boolean'
@@ -763,19 +772,36 @@ const onPushNotification = async (event: PushEvent) => {
 
   // If the app is open and visible, skip the OS push notification — the in-app
   // pill notification handles the alert instead.
-  // Combine clients.matchAll() visibility with the explicit appIsVisible flag
-  // because iOS Safari PWA often returns empty or stale results from matchAll().
+  //
+  // Require BOTH the explicit appIsVisible flag AND a visible client from
+  // matchAll() before suppressing.  appIsVisible resets to false every time the
+  // SW starts fresh; on iOS the browser kills the SW between pushes, so on the
+  // next push appIsVisible is always false — we never suppress on a cold SW
+  // restart, which prevents the "notifications stop after a while" bug where
+  // stale matchAll() data (visibilityState stuck at 'visible') would cause all
+  // subsequent notifications to be silently dropped.
+  //
+  // Also require syncIsHealthy: if the Matrix sync is in Reconnecting/Error
+  // state, the in-app notification path is broken, so we must show the OS
+  // notification even when the app is visible.
+  //
+  // When matchAll() returns zero clients (iOS Safari PWA fully-suspended quirk),
+  // clients.some() returns false — do NOT suppress.  Better to show a duplicate
+  // (handled gracefully by the in-app banner) than to silently drop a
+  // notification while the app is backgrounded.
   const hasVisibleClient =
-    appIsVisible || clients.some((client) => client.visibilityState === 'visible');
+    appIsVisible && syncIsHealthy && clients.some((client) => client.visibilityState === 'visible');
   console.debug(
     '[SW push] appIsVisible:',
     appIsVisible,
+    '| syncIsHealthy:',
+    syncIsHealthy,
     '| clients:',
     clients.map((c) => ({ url: c.url, visibility: c.visibilityState }))
   );
   console.debug('[SW push] hasVisibleClient:', hasVisibleClient);
   if (hasVisibleClient) {
-    console.debug('[SW push] suppressing OS notification — app is visible');
+    console.debug('[SW push] suppressing OS notification — app is visible and sync is healthy');
     return;
   }
 


### PR DESCRIPTION
### Description

Bundle of mobile-specific fixes: correct network-resume retries with iOS-specific delayed fallback to survive iOS background network latency, show a Connecting banner when the fast-path clears the splash screen before sync is complete, show unread indicators after timeline reset on sync resume, and fix iPad members-drawer layout so it uses the sidebar layout instead of the full-screen overlay.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Fully AI generated (explain what all the generated code does in moderate detail).
- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).

The retry logic adds an iOS-specific second attempt with a longer delay after the initial network-resume callback, since iOS can report network-available before the radio is actually usable. The Connecting banner listens to the sync state and renders when sync is `PREPARED` or `RECONNECTING` after the splash clears. The unread indicator fix schedules a re-render after the timeline reset event fires on sync resume.