### PR TITLE
fix(auth): preserve addAccount param through SSO redirect

### DIFF
--- a/.changeset/auth-sso-addaccount.md
+++ b/.changeset/auth-sso-addaccount.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Preserve addAccount parameter through SSO redirect.

--- a/src/app/pages/auth/login/Login.tsx
+++ b/src/app/pages/auth/login/Login.tsx
@@ -41,14 +41,14 @@ export function Login() {
   const { loginFlows } = useAuthFlows();
   const [searchParams] = useSearchParams();
   const loginSearchParams = useLoginSearchParams(searchParams);
-  
+
   // Preserve addAccount parameter through SSO redirect
   const baseRedirectUrl = usePathWithOrigin(getLoginPath(server));
   const isAddingAccount = searchParams.get('addAccount') === '1';
   const ssoRedirectUrl = isAddingAccount
     ? withSearchParam(baseRedirectUrl, { addAccount: '1' })
     : baseRedirectUrl;
-  
+
   const loginTokenForHashRouter = getLoginTokenSearchParam();
   const absoluteLoginPath = usePathWithOrigin(getLoginPath(server));
 

--- a/src/app/pages/auth/login/Login.tsx
+++ b/src/app/pages/auth/login/Login.tsx
@@ -41,7 +41,14 @@ export function Login() {
   const { loginFlows } = useAuthFlows();
   const [searchParams] = useSearchParams();
   const loginSearchParams = useLoginSearchParams(searchParams);
-  const ssoRedirectUrl = usePathWithOrigin(getLoginPath(server));
+  
+  // Preserve addAccount parameter through SSO redirect
+  const baseRedirectUrl = usePathWithOrigin(getLoginPath(server));
+  const isAddingAccount = searchParams.get('addAccount') === '1';
+  const ssoRedirectUrl = isAddingAccount
+    ? withSearchParam(baseRedirectUrl, { addAccount: '1' })
+    : baseRedirectUrl;
+  
   const loginTokenForHashRouter = getLoginTokenSearchParam();
   const absoluteLoginPath = usePathWithOrigin(getLoginPath(server));
 

--- a/src/app/pages/auth/register/Register.tsx
+++ b/src/app/pages/auth/register/Register.tsx
@@ -6,7 +6,7 @@ import { useAuthServer } from '$hooks/useAuthServer';
 import { RegisterFlowStatus, useAuthFlows } from '$hooks/useAuthFlows';
 import { useParsedLoginFlows } from '$hooks/useParsedLoginFlows';
 import { SupportedUIAFlowsLoader } from '$components/SupportedUIAFlowsLoader';
-import { getLoginPath } from '$pages/pathUtils';
+import { getLoginPath, withSearchParam } from '$pages/pathUtils';
 import { usePathWithOrigin } from '$hooks/usePathWithOrigin';
 import type { RegisterPathSearchParams } from '$pages/paths';
 import { SSOLogin } from '$pages/auth/SSOLogin';
@@ -30,8 +30,13 @@ export function Register() {
   const registerSearchParams = useRegisterSearchParams(searchParams);
   const { sso } = useParsedLoginFlows(loginFlows.flows);
 
-  // redirect to /login because only that path handle m.login.token
-  const ssoRedirectUrl = usePathWithOrigin(getLoginPath(server));
+  // redirect to /login because only that path handles m.login.token
+  // Preserve addAccount parameter through SSO redirect
+  const baseRedirectUrl = usePathWithOrigin(getLoginPath(server));
+  const isAddingAccount = searchParams.get('addAccount') === '1';
+  const ssoRedirectUrl = isAddingAccount
+    ? withSearchParam(baseRedirectUrl, { addAccount: '1' })
+    : baseRedirectUrl;
 
   return (
     <Box direction="Column" gap="500">


### PR DESCRIPTION
### Description

When an SSO login is initiated for a second account (with `?addAccount=true`), the parameter was not preserved across the provider redirect and was silently discarded. The returning user was logged in as a new primary session instead of being added to the multi-account switcher. This fix threads the `addAccount` parameter through the SSO callback URL so it survives the redirect.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The fix reads `addAccount` from the pre-redirect query string and appends it to the `redirectUri` passed to the identity provider, so after the provider redirects back to Sable the login handler adds the session to the multi-account switcher instead of replacing the current session.