### PR TITLE
fix(navigation): route DM rooms to /direct before checking space parents

### DIFF
--- a/.changeset/dm-routing.md
+++ b/.changeset/dm-routing.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Route DM rooms to /direct before checking space parents to fix incorrect navigation.

--- a/src/app/hooks/useRoomNavigate.test.ts
+++ b/src/app/hooks/useRoomNavigate.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createStore, Provider } from 'jotai';
+import { mDirectAtom } from '$state/mDirectList';
+import { roomToParentsAtom } from '$state/room/roomToParents';
+import { useRoomNavigate } from './useRoomNavigate';
+
+const mockNavigate = vi.fn<(path: string) => void>();
+
+// Preserve the real generatePath (used by $pages/pathUtils) while stubbing useNavigate.
+vi.mock('react-router-dom', async (importOriginal) => {
+  const original = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('$hooks/useMatrixClient', () => ({
+  useMatrixClient: () => ({ getRoom: vi.fn<() => null>() }),
+}));
+
+// Return the roomId as-is so path assertions are straightforward.
+vi.mock('$utils/matrix', () => ({
+  getCanonicalAliasOrRoomId: (_mx: unknown, roomId: string) => roomId,
+}));
+
+vi.mock('$hooks/router/useSelectedSpace', () => ({
+  useSelectedSpace: () => undefined,
+}));
+
+vi.mock('$state/hooks/settings', () => ({
+  useSetting: () => [false, vi.fn()],
+}));
+
+function makeWrapper(store: ReturnType<typeof createStore>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store }, children);
+  };
+}
+
+describe('useRoomNavigate', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  describe('navigateRoom', () => {
+    it('routes a DM room to /direct even when it has space parents (regression)', () => {
+      // Regression guard: before the fix, a DM room that also appeared in
+      // roomToParents would be routed to the space path instead of /direct.
+      const store = createStore();
+      const dmRoomId = '!dm:example.org';
+      const spaceId = '!space:example.org';
+
+      store.set(mDirectAtom, { type: 'INITIALIZE', rooms: new Set([dmRoomId]) });
+      const roomToParents = new Map<string, Set<string>>();
+      roomToParents.set(dmRoomId, new Set([spaceId]));
+      store.set(roomToParentsAtom, { type: 'INITIALIZE', roomToParents });
+
+      const { result } = renderHook(() => useRoomNavigate(), {
+        wrapper: makeWrapper(store),
+      });
+
+      result.current.navigateRoom(dmRoomId);
+
+      expect(mockNavigate).toHaveBeenCalledOnce();
+      expect(mockNavigate.mock.calls[0]![0]).toMatch(/^\/direct\//);
+    });
+
+    it('routes a non-DM room with an orphan space parent through the space path', () => {
+      const store = createStore();
+      const roomId = '!room:example.org';
+      const spaceId = '!space:example.org';
+
+      store.set(mDirectAtom, { type: 'INITIALIZE', rooms: new Set() });
+      // spaceId is a parent of roomId and is itself an orphan (top-level space)
+      const roomToParents = new Map<string, Set<string>>();
+      roomToParents.set(roomId, new Set([spaceId]));
+      store.set(roomToParentsAtom, { type: 'INITIALIZE', roomToParents });
+
+      const { result } = renderHook(() => useRoomNavigate(), {
+        wrapper: makeWrapper(store),
+      });
+
+      result.current.navigateRoom(roomId);
+
+      expect(mockNavigate).toHaveBeenCalledOnce();
+      const navigatedPath = mockNavigate.mock.calls[0]![0] as string;
+      expect(navigatedPath).not.toMatch(/^\/direct\//);
+      expect(navigatedPath).not.toMatch(/^\/home\//);
+    });
+
+    it('routes an orphan room with no parents to /home', () => {
+      const store = createStore();
+      const roomId = '!room:example.org';
+
+      store.set(mDirectAtom, { type: 'INITIALIZE', rooms: new Set() });
+      store.set(roomToParentsAtom, { type: 'INITIALIZE', roomToParents: new Map() });
+
+      const { result } = renderHook(() => useRoomNavigate(), {
+        wrapper: makeWrapper(store),
+      });
+
+      result.current.navigateRoom(roomId);
+
+      expect(mockNavigate).toHaveBeenCalledOnce();
+      expect(mockNavigate.mock.calls[0]![0]).toMatch(/^\/home\//);
+    });
+  });
+});

--- a/src/app/hooks/useRoomNavigate.ts
+++ b/src/app/hooks/useRoomNavigate.ts
@@ -36,6 +36,13 @@ export const useRoomNavigate = () => {
   const navigateRoom = useCallback(
     (roomId: string, eventId?: string, opts?: NavigateOptions) => {
       const roomIdOrAlias = getCanonicalAliasOrRoomId(mx, roomId);
+
+      // DM rooms always navigate to /direct, regardless of space membership.
+      if (mDirects.has(roomId)) {
+        navigate(getDirectRoomPath(roomIdOrAlias, eventId), opts);
+        return;
+      }
+
       const openSpaceTimeline = developerTools && spaceSelectedId === roomId;
 
       const orphanParents = openSpaceTimeline ? [roomId] : getOrphanParents(roomToParents, roomId);
@@ -53,11 +60,6 @@ export const useRoomNavigate = () => {
           getSpaceRoomPath(pSpaceIdOrAlias, openSpaceTimeline ? roomId : roomIdOrAlias, eventId),
           opts
         );
-        return;
-      }
-
-      if (mDirects.has(roomId)) {
-        navigate(getDirectRoomPath(roomIdOrAlias, eventId), opts);
         return;
       }
 


### PR DESCRIPTION
### Description

DM rooms with a space parent were being routed to the space URL instead of `/direct`. The navigation logic now checks whether the room is a DM first and routes to `/direct/{roomId}` regardless of space membership.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The fix inserts an early `isDM(room)` guard at the top of the navigation URL resolver so DM rooms short-circuit to `/direct/{roomId}` before the space-parent walk runs.