### PR TITLE
fix(settings-sync): exclude enterForNewline from cross-device sync

### DIFF
--- a/.changeset/settings-sync.md
+++ b/.changeset/settings-sync.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Exclude enterForNewline from cross-device settings sync.

--- a/src/app/utils/settingsSync.test.ts
+++ b/src/app/utils/settingsSync.test.ts
@@ -32,6 +32,7 @@ describe('NON_SYNCABLE_KEYS', () => {
       'isWidgetDrawer',
       'memberSortFilterIndex',
       'developerTools',
+      'enterForNewline',
       'settingsSyncEnabled',
     ] as const;
 

--- a/src/app/utils/settingsSync.test.ts
+++ b/src/app/utils/settingsSync.test.ts
@@ -34,6 +34,7 @@ describe('NON_SYNCABLE_KEYS', () => {
       'developerTools',
       'enterForNewline',
       'settingsSyncEnabled',
+      'searchIndexMessageLimit',
     ] as const;
 
     expected.forEach((key) => {

--- a/src/app/utils/settingsSync.test.ts
+++ b/src/app/utils/settingsSync.test.ts
@@ -34,7 +34,6 @@ describe('NON_SYNCABLE_KEYS', () => {
       'developerTools',
       'enterForNewline',
       'settingsSyncEnabled',
-      'searchIndexMessageLimit',
     ] as const;
 
     expected.forEach((key) => {

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -21,9 +21,6 @@ export const NON_SYNCABLE_KEYS = new Set<keyof Settings>([
   'enterForNewline',
   // Sync toggle itself must never be uploaded (it's device-local)
   'settingsSyncEnabled',
-  // Search index capacity varies by device (mobile is capped at 50 MB, desktop at 300 MB),
-  // so each device should keep its own limit rather than inheriting a desktop value.
-  'searchIndexMessageLimit',
 ]);
 
 export const SETTINGS_SYNC_VERSION = 1;

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -16,6 +16,8 @@ export const NON_SYNCABLE_KEYS = new Set<keyof Settings>([
   'memberSortFilterIndex',
   // Developer / diagnostic
   'developerTools',
+  // Input behaviour — mobile disables enter-for-newline; syncing would override that
+  'enterForNewline',
   // Sync toggle itself must never be uploaded (it's device-local)
   'settingsSyncEnabled',
 ]);

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -21,6 +21,9 @@ export const NON_SYNCABLE_KEYS = new Set<keyof Settings>([
   'enterForNewline',
   // Sync toggle itself must never be uploaded (it's device-local)
   'settingsSyncEnabled',
+  // Search index capacity varies by device (mobile is capped at 50 MB, desktop at 300 MB),
+  // so each device should keep its own limit rather than inheriting a desktop value.
+  'searchIndexMessageLimit',
 ]);
 
 export const SETTINGS_SYNC_VERSION = 1;

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -16,7 +16,8 @@ export const NON_SYNCABLE_KEYS = new Set<keyof Settings>([
   'memberSortFilterIndex',
   // Developer / diagnostic
   'developerTools',
-  // Input behaviour — mobile disables enter-for-newline; syncing would override that
+  // Input behaviour — on mobile the Enter-for-newline toggle is disabled, so syncing a
+  // desktop value would inadvertently re-enable Enter-to-send on the user's phone
   'enterForNewline',
   // Sync toggle itself must never be uploaded (it's device-local)
   'settingsSyncEnabled',


### PR DESCRIPTION
### Description

`enterForNewline` is a device-ergonomic setting — a keyboard user on desktop typically wants Enter to send, while the same user on mobile may prefer Enter to insert a newline. Syncing this setting across devices causes one device to override the other's preference. This change excludes `enterForNewline` from the cross-device settings sync set.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The change removes the key from the set of setting keys included in the cross-device sync payload so each device retains its own value independently.