### PR TITLE
Fix OIDC logins silently failing when switching accounts

### DIFF
--- a/.changeset/fix-oidc-account-switcher.md
+++ b/.changeset/fix-oidc-account-switcher.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix account switching and logging in with multiple (SSO) accounts silently failing

--- a/src/app/pages/Router.tsx
+++ b/src/app/pages/Router.tsx
@@ -119,6 +119,7 @@ export const createRouter = (clientConfig: ClientConfig, screenSize: ScreenSize)
           // Allow reaching the login page with ?addAccount=1 even when already logged in
           const url = new URL(request.url);
           if (url.searchParams.get('addAccount') === '1') return null;
+          if (url.searchParams.has('loginToken')) return null;
           if (hasStoredSession()) return redirect(getHomePath());
           return null;
         }}


### PR DESCRIPTION
Fix OIDC logins in the account switcher failing due to the router ignoring login attempts. Closes #40 and probably more related issues.

### Description

The router only lets you visit `/home` or the like if `addAccount` is unset, but this did not account for `loginToken`. Now, if `loginToken` is set, you visit the `/login/server` route instead of being redirected to `/home`, allowing the account switcher to work as intended.

Fixes #40
Fixes #284

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (does not apply)
- [x] I have made corresponding changes to the documentation (does not apply)
- [x] My changes generate no new warnings

### AI disclosure:

No AI assists.