### PR TITLE
Fix unset User Profile cards having incorectly colored text.

### DIFF
--- a/.changeset/fix_unset_usercards.md
+++ b/.changeset/fix_unset_usercards.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix unset User Profile cards having incorectly colored text.

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -283,8 +283,13 @@ export const useUserProfile = (
     const resolvedPronouns = localPronouns || spacePronouns || data?.pronouns;
 
     const rawHeroBrightness = data?.heroColorScheme?.brightness;
-    const heroCardsAllowed = shouldApplyUserHeroCards(renderUserCardsMode, rawHeroBrightness);
-    const validHeroColor = heroCardsAllowed ? isValidHex(data?.heroColorScheme?.color) : undefined;
+    const rawHeroColor = data?.heroColorScheme?.color;
+    const heroCardsAllowed = shouldApplyUserHeroCards(
+      renderUserCardsMode,
+      rawHeroBrightness,
+      rawHeroColor
+    );
+    const validHeroColor = heroCardsAllowed ? isValidHex(rawHeroColor) : undefined;
     const heroBrightness = heroCardsAllowed ? rawHeroBrightness : undefined;
     const testUserHeroColor = shadeColor(validHeroColor, heroBrightness === 'dark' ? -80 : 80);
 

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -68,11 +68,12 @@ export function isPixelatedViewerRendering(mode: PixelatedImageRenderingMode): b
 
 export function shouldApplyUserHeroCards(
   mode: RenderUserCardsMode,
-  brightness: string | undefined
+  brightness?: string,
+  color?: string
 ): boolean {
+  if (!color || (brightness !== 'light' && brightness !== 'dark')) return false;
   if (mode === 'none') return false;
   if (mode === 'both') return true;
-  if (brightness !== 'light' && brightness !== 'dark') return false;
   return brightness === mode;
 }
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Fixes this:

(how it would look sometimes)
<img width="347" height="309" alt="image" src="https://github.com/user-attachments/assets/2caac23e-744c-4e8e-8085-72a4c8845daf" />

(this is how it should and will look)
<img width="344" height="307" alt="image" src="https://github.com/user-attachments/assets/053336be-1fea-474c-930d-f23fbbee2adb" />

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Accidentally pressing control enter convinced me to create the PR

Signed-off-by: Shea Duma <nu@she-a.eu>