### PR TITLE
Fix math parsing in color

### DIFF
--- a/.changeset/fix-math-in-color.md
+++ b/.changeset/fix-math-in-color.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix math parsing inside of color blocks not being parsed properly.

--- a/src/app/plugins/markdown/extensions/matrix-math.ts
+++ b/src/app/plugins/markdown/extensions/matrix-math.ts
@@ -221,10 +221,16 @@ function isIgnorableMathContent(latex: string): boolean {
  * - the closing `$` is not preceded by whitespace, and
  * - the closing `$` is not immediately followed by an ASCII digit.
  */
+/** Opening `$[fg.color=…]` / `$[bg.color=…]` */
+const MFM_COLOR_FN_OPEN = /^\$\[(?:fg|bg)\.color=/;
+
 function tryTokenizeInlineMath(
   src: string
 ): { type: 'math'; raw: string; latex: string } | undefined {
   if (!src.startsWith('$')) {
+    return undefined;
+  }
+  if (MFM_COLOR_FN_OPEN.test(src)) {
     return undefined;
   }
   if (src.startsWith('$$') && (src.length < 3 || src.charAt(2) !== '$')) {
@@ -256,7 +262,7 @@ export const matrixMathExtension = {
   name: 'math',
   level: 'inline',
   start(src: string) {
-    if (/^\$\[(?:fg|bg)\.color=/.test(src)) return -1;
+    if (MFM_COLOR_FN_OPEN.test(src)) return -1;
     return src.indexOf('$');
   },
   tokenizer(src: string) {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes math parsing inside of color blocks not being parsed as math with color.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
