### PR TITLE
Image viewer changes

### DIFF
--- a/.changeset/change-pixelation-behavior.md
+++ b/.changeset/change-pixelation-behavior.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Change image rendering to allow enabling anti-aliasing in the image viewer

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -45,6 +45,7 @@ import { PdfViewer } from './Pdf-viewer';
 import { TextViewer } from './text-viewer';
 import { ClientSideHoverFreeze } from './ClientSideHoverFreeze';
 import { CuteEventType, MCuteEvent } from './message/MCuteEvent';
+import type { IImageInfo } from '$types/matrix/common';
 
 type RenderMessageContentProps = {
   displayName: string;
@@ -334,7 +335,7 @@ function RenderMessageContentInternal({
   }
 
   if (msgType === (MsgType.Image as string)) {
-    const info = (content as { info?: { mimetype?: string } }).info;
+    const { info } = content as { info?: IImageInfo };
     const isGif =
       info?.mimetype === 'image/gif' ||
       info?.mimetype === 'image/apng' ||

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -359,11 +359,11 @@ function RenderMessageContentInternal({
               if (isGif && !autoplayGifs && p.src) {
                 return (
                   <ClientSideHoverFreeze src={p.src}>
-                    <Image {...p} loading="lazy" />
+                    <Image info={info} {...p} loading="lazy" />
                   </ClientSideHoverFreeze>
                 );
               }
-              return <Image {...p} loading="lazy" />;
+              return <Image info={info} {...p} loading="lazy" />;
             }}
             renderViewer={(p) => <ImageViewer {...p} />}
           />

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -28,8 +28,6 @@ export const ImageViewer = as<'div', ImageViewerProps>(
     const [isPixelated, setIsPixelated] = useState(
       isPixelatedRendering(pixelatedImageRendering, info)
     );
-    // oxlint-disable-next-line no-console
-    console.log(info);
 
     const {
       transforms,
@@ -98,7 +96,7 @@ export const ImageViewer = as<'div', ImageViewerProps>(
               radii="Pill"
               onClick={() => setIsPixelated(!isPixelated)}
               aria-label="Toggle Pixelation"
-              title={`Turn ${isPixelated ? 'Antialiasing' : 'Pixelation'} on`}
+              title={`Turn ${isPixelated ? 'Anti-aliasing' : 'Pixelation'} on`}
             >
               <CheckerboardIcon size={20} weight={isPixelated ? 'duotone' : 'fill'} />
             </IconButton>

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -4,24 +4,32 @@ import classNames from 'classnames';
 import { Box, Chip, Header, Icon, IconButton, Icons, Text, as } from 'folds';
 import { useImageGestures } from '$hooks/useImageGestures';
 import { useSetting } from '$state/hooks/settings';
-import { isPixelatedViewerRendering, settingsAtom } from '$state/settings';
+import { isPixelatedRendering, settingsAtom } from '$state/settings';
 import { downloadMedia } from '$utils/matrix';
 import * as css from './ImageViewer.css';
+import type { IImageInfo } from '$types/matrix/common';
+import { CheckerboardIcon } from '@phosphor-icons/react';
 
 export type ImageViewerProps = {
   alt: string;
   src: string;
   requestClose: () => void;
+  info?: IImageInfo;
 };
 
 export const ImageViewer = as<'div', ImageViewerProps>(
-  ({ className, alt, src, requestClose, ...props }, ref) => {
+  ({ className, alt, src, requestClose, info, ...props }, ref) => {
     const zoomInputRef = useRef<HTMLInputElement>(null);
     const [pixelatedImageRendering] = useSetting(settingsAtom, 'pixelatedImageRendering');
 
     const [isImageReady, setIsImageReady] = useState(false);
     const [isEditingZoom, setIsEditingZoom] = useState(false);
     const [zoomInput, setZoomInput] = useState('100');
+    const [isPixelated, setIsPixelated] = useState(
+      isPixelatedRendering(pixelatedImageRendering, info)
+    );
+    // oxlint-disable-next-line no-console
+    console.log(info);
 
     const {
       transforms,
@@ -84,6 +92,16 @@ export const ImageViewer = as<'div', ImageViewerProps>(
             </Text>
           </Box>
           <Box shrink="No" alignItems="Center" gap="200">
+            <IconButton
+              variant="Surface"
+              size="300"
+              radii="Pill"
+              onClick={() => setIsPixelated(!isPixelated)}
+              aria-label="Toggle Pixelation"
+              title={`Turn ${isPixelated ? 'Antialiasing' : 'Pixelation'} on`}
+            >
+              <CheckerboardIcon size={20} weight={isPixelated ? 'duotone' : 'fill'} />
+            </IconButton>
             <IconButton
               variant="Surface"
               style={{
@@ -225,10 +243,7 @@ export const ImageViewer = as<'div', ImageViewerProps>(
           onPointerDown={onPointerDown}
         >
           <img
-            className={classNames(
-              css.ImageViewerImg,
-              isPixelatedViewerRendering(pixelatedImageRendering) && css.ImageViewerImgPixelated
-            )}
+            className={classNames(css.ImageViewerImg, isPixelated && css.ImageViewerImgPixelated)}
             draggable={false}
             data-gestures="ignore"
             style={{

--- a/src/app/components/media/Image.tsx
+++ b/src/app/components/media/Image.tsx
@@ -2,7 +2,7 @@ import type { ImgHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 import classNames from 'classnames';
 import { useSetting } from '$state/hooks/settings';
-import { isPixelatedChatRendering, settingsAtom } from '$state/settings';
+import { isPixelatedRendering, settingsAtom } from '$state/settings';
 import * as css from './media.css';
 
 export const Image = forwardRef<HTMLImageElement, ImgHTMLAttributes<HTMLImageElement>>(
@@ -13,7 +13,7 @@ export const Image = forwardRef<HTMLImageElement, ImgHTMLAttributes<HTMLImageEle
       <img
         className={classNames(
           css.Image,
-          isPixelatedChatRendering(pixelatedImageRendering) && css.ImagePixelated,
+          isPixelatedRendering(pixelatedImageRendering) && css.ImagePixelated,
           className
         )}
         alt={alt}

--- a/src/app/components/media/Image.tsx
+++ b/src/app/components/media/Image.tsx
@@ -4,16 +4,19 @@ import classNames from 'classnames';
 import { useSetting } from '$state/hooks/settings';
 import { isPixelatedRendering, settingsAtom } from '$state/settings';
 import * as css from './media.css';
+import type { IImageInfo } from '$types/matrix/common';
 
-export const Image = forwardRef<HTMLImageElement, ImgHTMLAttributes<HTMLImageElement>>(
-  ({ className, alt, ...props }, ref) => {
+type ImageProps = ImgHTMLAttributes<HTMLImageElement> & { info?: IImageInfo };
+
+export const Image = forwardRef<HTMLImageElement, ImageProps>(
+  ({ className, alt, info, ...props }, ref) => {
     const [pixelatedImageRendering] = useSetting(settingsAtom, 'pixelatedImageRendering');
 
     return (
       <img
         className={classNames(
           css.Image,
-          isPixelatedRendering(pixelatedImageRendering) && css.ImagePixelated,
+          isPixelatedRendering(pixelatedImageRendering, info) && css.ImagePixelated,
           className
         )}
         alt={alt}

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -59,6 +59,7 @@ type RenderViewerProps = {
   src: string;
   alt: string;
   requestClose: () => void;
+  info?: IImageInfo;
 };
 type RenderImageProps = {
   alt: string;
@@ -242,6 +243,7 @@ export const ImageContent = as<'div', ImageContentProps>(
                     src: viewerFullSrc ?? srcState.data,
                     alt: body,
                     requestClose: () => setViewer(false),
+                    info: info,
                   })}
                 </Modal>
               </FocusTrap>

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -305,6 +305,7 @@ export const UrlPreviewCard = as<
               renderViewer={(p) => <ImageViewer {...p} />}
               renderImage={(p) => (
                 <Image
+                  info={ogImageInfo}
                   {...p}
                   style={{
                     display: 'block',

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -222,10 +222,9 @@ function ThemeVisualPreferences() {
     'pixelatedImageRendering'
   );
   const pixelatedImageRenderingOptions: SettingMenuOption<PixelatedImageRenderingMode>[] = [
-    { value: 'both', label: 'Both' },
-    { value: 'chat', label: 'Chat' },
-    { value: 'viewer', label: 'Image viewer' },
-    { value: 'none', label: 'Neither' },
+    { value: 'always', label: 'Always' },
+    { value: 'smart', label: 'Smart' },
+    { value: 'never', label: 'never' },
   ];
   const [incomingInlineImagesDefaultHeight, setIncomingInlineImagesDefaultHeight] = useSetting(
     settingsAtom,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -1,6 +1,7 @@
 import { atom, type WritableAtom } from 'jotai';
 import type { Store } from 'jotai/vanilla/store';
 import { mobileOrTablet } from '$utils/user-agent';
+import type { IImageInfo } from '$types/matrix/common';
 
 const STORAGE_KEY = 'settings';
 export type DateFormat = 'D MMM YYYY' | 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY/MM/DD' | '';
@@ -56,14 +57,14 @@ export type ThemeRemoteTweakFavorite = {
 export type RenderUserCardsMode = 'both' | 'light' | 'dark' | 'none';
 
 /** Where to use crisp nearest-neighbor (pixelated) image scaling. */
-export type PixelatedImageRenderingMode = 'both' | 'chat' | 'viewer' | 'none';
+export type PixelatedImageRenderingMode = 'always' | 'smart' | 'never';
 
-export function isPixelatedChatRendering(mode: PixelatedImageRenderingMode): boolean {
-  return mode === 'both' || mode === 'chat';
-}
-
-export function isPixelatedViewerRendering(mode: PixelatedImageRenderingMode): boolean {
-  return mode === 'both' || mode === 'viewer';
+export function isPixelatedRendering(
+  mode: PixelatedImageRenderingMode,
+  info?: IImageInfo
+): boolean {
+  if (mode === 'smart') return !info || !info.w || !info.h || info.w < 192 || info.h < 192;
+  return mode === 'always';
 }
 
 export function shouldApplyUserHeroCards(
@@ -302,7 +303,7 @@ export const defaultSettings: Settings = {
   autoplayGifs: true,
   autoplayStickers: true,
   autoplayEmojis: true,
-  pixelatedImageRendering: 'viewer',
+  pixelatedImageRendering: 'smart',
   incomingInlineImagesDefaultHeight: 32,
   incomingInlineImagesMaxHeight: 64,
   linkPreviewImageMaxHeight: 640,
@@ -382,10 +383,9 @@ function migrateParsedLocalStorage(parsed: Record<string, unknown>): void {
   if (typeof parsed.pixelatedImageRendering === 'boolean') {
     parsed.pixelatedImageRendering = parsed.pixelatedImageRendering ? 'both' : 'none';
   } else if (
-    parsed.pixelatedImageRendering !== 'both' &&
-    parsed.pixelatedImageRendering !== 'chat' &&
-    parsed.pixelatedImageRendering !== 'viewer' &&
-    parsed.pixelatedImageRendering !== 'none'
+    parsed.pixelatedImageRendering !== 'always' &&
+    parsed.pixelatedImageRendering !== 'smart' &&
+    parsed.pixelatedImageRendering !== 'never'
   ) {
     delete parsed.pixelatedImageRendering;
   }
@@ -514,9 +514,7 @@ function sanitizeSettingsKey(key: keyof Settings, val: unknown): unknown {
         ? val
         : undefined;
     case 'pixelatedImageRendering':
-      return val === 'both' || val === 'chat' || val === 'viewer' || val === 'none'
-        ? val
-        : undefined;
+      return val === 'always' || val === 'smart' || val === 'never' ? val : undefined;
     case 'jumboEmojiSize':
       return typeof val === 'string' && JUMBO_EMOJI_VALUES.has(val as JumboEmojiSize)
         ? val

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -63,7 +63,7 @@ export function isPixelatedRendering(
   mode: PixelatedImageRenderingMode,
   info?: IImageInfo
 ): boolean {
-  if (mode === 'smart') return !info || !info.w || !info.h || info.w < 192 || info.h < 192;
+  if (mode === 'smart') return !!info && !!info.w && !!info.h && (info.w < 192 || info.h < 192);
   return mode === 'always';
 }
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Change Pixelation options to be never smart or always, removing the chat/image-viewer distinction 

The 'smart' setting marks images smaller than 192 (128+64) as pixelart by default, this means that the image will appear crisp in the regular chat, and will default to crisp in the image viewer, and if the image is any bigger it will become anti-aliased in both.

However, if someone wants to see an image of a higher resolution as pixelart they now have a button next to the reset view options to toggle pixelation and anti-alias.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
This code was written with the boredom of not having anything better to do