### PR TITLE
Fix more highlighting problems and 1767 events reply setting issues

### DIFF
--- a/src/app/features/room/ThreadDrawer.tsx
+++ b/src/app/features/room/ThreadDrawer.tsx
@@ -66,6 +66,7 @@ import { RoomViewFollowing, RoomViewFollowingPlaceholder } from './RoomViewFollo
 import * as css from './ThreadDrawer.css';
 import { SidebarResizer } from '$pages/client/sidebar/SidebarResizer';
 import { mobileOrTablet } from '$utils/user-agent';
+import { M_TEXT } from 'matrix-js-sdk';
 
 /**
  * Resolve the list of reply events to show in the thread drawer.
@@ -574,12 +575,17 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
       const editedReply = getEditedEvent(replyId, replyEvt, room.getUnfilteredTimelineSet());
       const content = editedReply?.getContent()['m.new_content'] ?? replyEvt.getContent();
       const { body, formatted_body: formattedBody } = content;
+      const msc1767body = content[M_TEXT.name];
       const senderId = replyEvt.getSender();
       if (senderId) {
         const draft: IReplyDraft = {
           userId: senderId,
           eventId: replyId,
-          body: typeof body === 'string' ? body : '',
+          body:
+            (body as string) ??
+            (msc1767body as string) ??
+            (msc1767body as { body: string }).body ??
+            '',
           formattedBody,
           relation: { rel_type: RelationType.Thread, event_id: threadRootId },
         };

--- a/src/app/hooks/timeline/useTimelineActions.ts
+++ b/src/app/hooks/timeline/useTimelineActions.ts
@@ -10,6 +10,7 @@ import { getMxIdLocalPart, toggleReaction } from '$utils/matrix';
 import { getMemberDisplayName, getEditedEvent } from '$utils/room';
 import { createMentionElement, moveCursor } from '$components/editor';
 import * as prefix from '$unstable/prefixes';
+import { M_TEXT } from 'matrix-js-sdk';
 
 export interface UseTimelineActionsOptions {
   room: Room;
@@ -144,6 +145,7 @@ export function useTimelineActions({
 
       const content: IContent = (editedNewContent ?? replyEvt.getContent()) as IContent;
       const { body, formatted_body: formattedBody } = content;
+      const msc1767body = content[M_TEXT.name];
 
       const { 'm.relates_to': relation } = startThread
         ? { 'm.relates_to': { rel_type: 'm.thread', event_id: replyId } }
@@ -155,7 +157,11 @@ export function useTimelineActions({
         setReplyDraft({
           userId: senderId,
           eventId: replyId,
-          body: typeof body === 'string' ? body : '',
+          body:
+            (body as string) ??
+            (msc1767body as string) ??
+            (msc1767body as { body: string }).body ??
+            '',
           formattedBody: typeof formattedBody === 'string' ? formattedBody : '',
           relation,
         });

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -378,7 +378,7 @@ export function useTimelineEventRenderer({
         const reactions = reactionRelations?.getSortedAnnotationsByKey();
         const hasReactions = reactions && reactions.length > 0;
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId && suppressMark !== true;
+        const marked = activeReplyId === mEventId && !suppressMark;
 
         const pushActions = pushProcessor.actionsForEvent(mEvent);
         let notifyHighlight: 'silent' | 'loud' | undefined;
@@ -542,7 +542,7 @@ export function useTimelineEventRenderer({
         const reactions = reactionRelations?.getSortedAnnotationsByKey();
         const hasReactions = reactions && reactions.length > 0;
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderDisplayName =
           getMemberDisplayName(room, senderId, nicknames) ?? getMxIdLocalPart(senderId) ?? senderId;
@@ -720,7 +720,7 @@ export function useTimelineEventRenderer({
         const reactions = reactionRelations?.getSortedAnnotationsByKey();
         const hasReactions = reactions && reactions.length > 0;
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderDisplayName =
           getMemberDisplayName(room, senderId, nicknames) ?? getMxIdLocalPart(senderId) ?? senderId;
@@ -845,7 +845,7 @@ export function useTimelineEventRenderer({
         const reactions = reactionRelations?.getSortedAnnotationsByKey();
         const hasReactions = reactions && reactions.length > 0;
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
 
         const pushActions = pushProcessor.actionsForEvent(mEvent);
         let notifyHighlight: 'silent' | 'loud' | undefined;
@@ -999,7 +999,7 @@ export function useTimelineEventRenderer({
         if (!membershipChanged && hideNickAvatarEvents) return null;
 
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const parsed = parseMemberEvent(mEvent);
 
         const timeJSX = (
@@ -1044,7 +1044,7 @@ export function useTimelineEventRenderer({
       },
       [EventType.RoomName]: (mEventId, mEvent, item, timelineSet, collapse) => {
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderName =
           getMemberDisplayName(room, senderId, nicknames) || getMxIdLocalPart(senderId);
@@ -1091,7 +1091,7 @@ export function useTimelineEventRenderer({
       },
       [EventType.RoomTopic]: (mEventId, mEvent, item, timelineSet, collapse) => {
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderName =
           getMemberDisplayName(room, senderId, nicknames) || getMxIdLocalPart(senderId);
@@ -1139,7 +1139,7 @@ export function useTimelineEventRenderer({
       },
       [EventType.RoomAvatar]: (mEventId, mEvent, item, timelineSet, collapse) => {
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderName =
           getMemberDisplayName(room, senderId, nicknames) || getMxIdLocalPart(senderId);
@@ -1187,7 +1187,7 @@ export function useTimelineEventRenderer({
       },
       [EventType.GroupCallMemberPrefix]: (mEventId, mEvent, item, timelineSet, collapse) => {
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderName = getMemberDisplayName(room, senderId) || getMxIdLocalPart(senderId);
 
@@ -1243,7 +1243,7 @@ export function useTimelineEventRenderer({
       [EventType.RoomPinnedEvents]: (mEventId, mEvent, item, timelineSet, collapse) => {
         if (!showHiddenEvents) return null;
         const highlighted = focusItem?.index === item && focusItem.highlight;
-        const marked = activeReplyId === mEventId;
+        const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
         const senderName =
           getMemberDisplayName(room, senderId, nicknames) || getMxIdLocalPart(senderId);
@@ -1332,7 +1332,7 @@ export function useTimelineEventRenderer({
     (mEventId, mEvent, item, timelineSet, collapse) => {
       if (!showHiddenEvents) return null;
       const highlighted = focusItem?.index === item && focusItem.highlight;
-      const marked = activeReplyId === mEventId;
+      const marked = activeReplyId === mEventId && !suppressMark;
       const senderId = mEvent.getSender() ?? '';
       const senderName =
         getMemberDisplayName(room, senderId, nicknames) || getMxIdLocalPart(senderId);
@@ -1387,7 +1387,7 @@ export function useTimelineEventRenderer({
       if (mEvent.isRedaction()) return null;
 
       const highlighted = focusItem?.index === item && focusItem.highlight;
-      const marked = activeReplyId === mEventId;
+      const marked = activeReplyId === mEventId && !suppressMark;
       const senderId = mEvent.getSender() ?? '';
       const senderName =
         getMemberDisplayName(room, senderId, nicknames) || getMxIdLocalPart(senderId);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This PR fixes even more highlighting issues and fixes replying to msc1767 only compliant events (events that would miss a .body but would have a M_TEXT as a body or a M_TEXT.body as the body)

This is marked internal as this is only the case for events specially crafted from weird clients, and because of polls

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

written with the assistance of my blahaj