### PR TITLE
Feat: Add snooping to polls

### DIFF
--- a/.changeset/feat_add_snooping_polls.md
+++ b/.changeset/feat_add_snooping_polls.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add 'Show Results' to show their poll's result before casting an answer

--- a/src/app/components/message/PollEvent.css.ts
+++ b/src/app/components/message/PollEvent.css.ts
@@ -21,6 +21,7 @@ export const PollEventSeparator = style({
 export const PollAnswerCount = style({
   color: color.SurfaceVariant.OnContainer,
   paddingLeft: config.space.S100,
+  cursor: 'pointer',
 });
 // These are only here for the potential modding of event by themes
 export const PollAnswersBody = style({});

--- a/src/app/components/message/PollEvent.tsx
+++ b/src/app/components/message/PollEvent.tsx
@@ -72,6 +72,7 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
   answers.forEach((item) => (votes[item.id] = 0));
 
   const [ViewVotersAnswer, setViewVotersAnswer] = useState<PollAnswerItem | undefined>(undefined);
+  const [isSnooping, setIsSnooping] = useState<boolean>(false);
 
   // This should technically request the permissions at the time of the end of the event but that doesnt seem to be supported by the sdk
   const getEndIndex = useCallback(
@@ -164,6 +165,7 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
     ? userSelectionContent[M_POLL_RESPONSE.name]?.answers
     : undefined;
   const hasVoted = userSelection?.length > 0;
+  const showAnswers = (isDisclosed && (hasVoted || isSnooping)) || isEnded;
 
   function handleNewVote(id: string) {
     if (!eventId || !roomId || maxSelections < 1) return;
@@ -263,7 +265,7 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
                   <Box justifyContent="SpaceBetween" grow="Yes" alignItems="Center">
                     <Text>{optionBody}</Text>
 
-                    {((isDisclosed && hasVoted) || isEnded) && (
+                    {showAnswers && (
                       <Text
                         size="T200"
                         className={css.PollAnswerCount}
@@ -277,7 +279,7 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
                 {(isDisclosed || isEnded) && (
                   <ProgressBar
                     size="400"
-                    value={hasVoted || isEnded ? (voteCount ?? 0) / voters.size : 0}
+                    value={showAnswers ? (voteCount ?? 0) / voters.size : 0}
                     max={1}
                     variant={isSelected ? 'Primary' : 'Secondary'}
                     title={voteCount ? `${Math.round((voteCount / voters.size) * 100)}%` : '0%'}
@@ -288,12 +290,17 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
             );
           })}
           <Box gap="200" grow="Yes" shrink="No" justifyContent="SpaceBetween" alignItems="Center">
-            <Text size="T200">
-              {(isDisclosed && hasVoted) || isEnded
-                ? `${totalVotes} vote${totalVotes !== 1 ? 's' : ''} ${totalVotes !== voters.size ? `by ${voters.size} voter${voters.size !== 1 ? 's' : ''}` : ''}`
-                : (isDisclosed && 'Cast a vote to see ongoing results') ||
-                  'Results will be shown when the poll is over'}
-            </Text>
+            {showAnswers ? (
+              <Text size="T200">
+                {`${totalVotes} vote${totalVotes !== 1 ? 's' : ''} ${totalVotes !== voters.size ? `by ${voters.size} voter${voters.size !== 1 ? 's' : ''}` : ''}`}
+              </Text>
+            ) : isDisclosed ? (
+              <Text onClick={() => setIsSnooping(true)} style={{ cursor: 'pointer' }} size="T200">
+                Click here to show results
+              </Text>
+            ) : (
+              <Text size="T200">Results will be shown when the poll is over </Text>
+            )}
             <Box alignItems="Center" gap="200">
               <Text size="T200">
                 {maxSelections !== 1 && maxSelections !== answers.length


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Thanks to popular suggestion I am adding a button to show results as the vote is ongoing similar to akkoma.

This is however a more fragile view since it resets every time the poll is reloaded, which is to say every time you scroll away.

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Written w the hunger of not eating any food before fixing this