### PR TITLE
Fix right aligned bubbles message header order

### DIFF
--- a/.changeset/fix-right-aligned-bubbles-message-header-order.md
+++ b/.changeset/fix-right-aligned-bubbles-message-header-order.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Reverse the order of message header elements in the right aligned bubbles layout.

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -620,12 +620,25 @@ function MessageInternal(
   const headerJSX = !collapse && (
     <Box
       gap="300"
-      direction={messageLayout === MessageLayout.Compact ? 'RowReverse' : 'Row'}
+      direction={
+        messageLayout === MessageLayout.Compact ||
+        (messageLayout === MessageLayout.Bubble && useRightBubbles && senderId === mx.getUserId())
+          ? 'RowReverse'
+          : 'Row'
+      }
       justifyContent="SpaceBetween"
       alignItems="Baseline"
       grow="Yes"
     >
-      <Box alignItems="Center" gap="100">
+      <Box
+        alignItems="Center"
+        gap="100"
+        direction={
+          messageLayout === MessageLayout.Bubble && useRightBubbles && senderId === mx.getUserId()
+            ? 'RowReverse'
+            : undefined
+        }
+      >
         <Username
           as="button"
           style={{


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes the order of username, pronoun, power icon and timestamp in right aligned bubbles message layout, making the username appear next to the user's avatar

(previously)
<img width="323" height="82" alt="image" src="https://github.com/user-attachments/assets/01a6fb6e-e014-4dfe-8921-a8231bc764df" />
(now)
<img width="302" height="69" alt="image" src="https://github.com/user-attachments/assets/31fcaa6a-cdca-49a2-be3d-780fc3e28d16" />

#### Changes

Set direction to RowReverse for user's own messages when useRightBubble is true in Box elements in the message header row

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
