### PR TITLE
Add gif functionality using klipy

### DIFF
--- a/.changeset/added_a_gif_search_functionality.md
+++ b/.changeset/added_a_gif_search_functionality.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Added a GIF search functionality

--- a/config.json
+++ b/config.json
@@ -44,5 +44,10 @@
   "hashRouter": {
     "enabled": false,
     "basename": "/"
+  },
+
+  "gifs": {
+    "proxyUrl": "gifs.sable.moe",
+    "klipyApiKey": "SET_YOUR_TOKEN_HERE"
   }
 }

--- a/config.json
+++ b/config.json
@@ -48,6 +48,6 @@
 
   "gifs": {
     "proxyUrl": "gifs.sable.moe",
-    "klipyApiKey": "SET_YOUR_TOKEN_HERE"
+    "klipyApiKey": "IfeIBlDMvq0av2BcKPDuxwRqbnYRbS90yNqFHEkK2Ja207tkR5nssh3NIlJRCr76"
   }
 }

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -165,7 +165,11 @@ const useGroups = (
   return [emojiGroupItems, stickerGroupItems, gifGroupItems];
 };
 
-const useItemRenderer = (tab: EmojiBoardTab, saveStickerEmojiBandwidth: boolean) => {
+const useItemRenderer = (
+  tab: EmojiBoardTab,
+  saveStickerEmojiBandwidth: boolean,
+  onGifSelect?: (gif: GifData, spoiler?: boolean) => void
+) => {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
 
@@ -448,7 +452,7 @@ type EmojiBoardProps = {
   onEmojiSelect?: (unicode: string, shortcode: string) => void;
   onCustomEmojiSelect?: (mxc: string, shortcode: string) => void;
   onStickerSelect?: (mxc: string, shortcode: string, label: string) => void;
-  onGifSelect?: (gif: GifData) => void;
+  onGifSelect?: (gif: GifData, spoiler?: boolean) => void;
   allowTextCustomEmoji?: boolean;
   addToRecentEmoji?: boolean;
   isFullWidth?: boolean;
@@ -550,6 +554,7 @@ export function EmojiBoard({
         preview_url: preview?.url || fullRes?.url || '',
         width,
         height,
+        size: fullRes?.size || preview?.size || 0,
       };
     }, []);
 
@@ -631,7 +636,7 @@ export function EmojiBoard({
           : gifGroupItems,
   };
   const groups = groupsByTab[tab];
-  const renderItem = useItemRenderer(tab, saveStickerEmojiBandwidth);
+  const renderItem = useItemRenderer(tab, saveStickerEmojiBandwidth, onGifSelect);
 
   const handleOnChange: ChangeEventHandler<HTMLInputElement> = useDebounce(
     useCallback(
@@ -707,7 +712,8 @@ export function EmojiBoard({
     if (emojiInfo.type === EmojiType.Gif) {
       const gifDataStr = targetEl.getAttribute('data-gif-data');
       const gifData = gifDataStr ? JSON.parse(gifDataStr) : null;
-      onGifSelect?.(gifData);
+      const isSpoiler = targetEl.getAttribute('data-gif-spoiler') === 'true';
+      onGifSelect?.(gifData, isSpoiler);
     }
     if (!evt.altKey && !evt.shiftKey) requestClose();
   };
@@ -777,6 +783,7 @@ export function EmojiBoard({
               key={tab}
               query={emojiResult?.query}
               onChange={handleOnChange}
+              tab={tab}
               allowTextCustomEmoji={allowTextCustomEmoji}
               onTextCustomEmojiSelect={handleTextCustomEmojiSelect}
             />

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -5,7 +5,7 @@ import type {
   ReactNode,
   RefObject,
 } from 'react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, config, Scroll } from 'folds';
 import { ClockCounterClockwise } from '$components/icons/phosphor';
 import FocusTrap from 'focus-trap-react';
@@ -44,10 +44,12 @@ import {
   SidebarDivider,
   Sidebar,
   NoStickerPacks,
+  GifStatus,
   createPreviewDataAtom,
   Preview,
   EmojiItem,
   StickerItem,
+  GifItem,
   CustomEmojiItem,
   ImageGroupIcon,
   GroupIcon,
@@ -55,7 +57,10 @@ import {
   EmojiGroup,
   EmojiBoardLayout,
 } from './components';
-import { EmojiBoardTab, EmojiType } from './types';
+import { EmojiBoardTab, EmojiType, GifData } from './types';
+import { GitDiffIcon } from '@phosphor-icons/react';
+import { useClientConfig } from '$hooks/useClientConfig';
+import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 
 const RECENT_GROUP_ID = 'recent_group';
 const SEARCH_GROUP_ID = 'search_group';
@@ -70,11 +75,20 @@ type StickerGroupItem = {
   name: string;
   items: Array<PackImageReader>;
 };
+type GifGroupItem = {
+  id: string;
+  name: string;
+  items: GifData[];
+};
 
 const useGroups = (
   tab: EmojiBoardTab,
-  imagePacks: ImagePack[]
-): [EmojiGroupItem[], StickerGroupItem[]] => {
+  imagePacks: ImagePack[],
+  data: {
+    gifs: GifData[];
+    favorites: GifData[];
+  }
+): [EmojiGroupItem[], StickerGroupItem[], GifGroupItem[]] => {
   const mx = useMatrixClient();
 
   const recentEmojis = useRecentEmoji(mx, 21);
@@ -134,17 +148,64 @@ const useGroups = (
     return g;
   }, [mx, imagePacks, tab]);
 
-  return [emojiGroupItems, stickerGroupItems];
+  const gifGroupItems = useMemo(() => {
+    if (tab !== EmojiBoardTab.Gif) return [];
+    return [
+      {
+        id: 'gif_group',
+        name: 'GIFs',
+        items: data.gifs,
+      },
+    ];
+  }, [tab, data]);
+
+  return [emojiGroupItems, stickerGroupItems, gifGroupItems];
 };
 
 const useItemRenderer = (tab: EmojiBoardTab, saveStickerEmojiBandwidth: boolean) => {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
 
-  const renderItem = (emoji: IEmoji | PackImageReader, index: number) => {
-    if ('unicode' in emoji) {
-      return <EmojiItem key={emoji.unicode + index} emoji={emoji} />;
+  const renderItem = (item: IEmoji | PackImageReader | GifData, index: number) => {
+    if (tab === EmojiBoardTab.Gif) {
+      const gif = item as GifData;
+
+      let initialGifUrl = gif.preview_url ?? gif.url;
+      let gifUrl = initialGifUrl.startsWith('mxc://')
+        ? (mxcUrlToHttp(mx, initialGifUrl, useAuthentication) ?? '')
+        : initialGifUrl;
+      const aspectRatio =
+        gif.width && gif.height && gif.width > 0 && gif.height > 0
+          ? `${gif.width} / ${gif.height}`
+          : '1 / 1';
+
+      return (
+        <GifItem
+          key={gif.id + index}
+          label={gif.title}
+          type={EmojiType.Gif}
+          data={gif.url}
+          shortcode={gif.title}
+          gif={gif}
+          style={{ aspectRatio }}
+        >
+          <img
+            loading="lazy"
+            alt=""
+            aria-hidden
+            src={gifUrl}
+            style={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        </GifItem>
+      );
     }
+
+    if ('unicode' in item) {
+      return <EmojiItem key={item.unicode + index} emoji={item} />;
+    }
+
+    const emoji = item as PackImageReader;
+
     if (tab === EmojiBoardTab.Sticker) {
       return (
         <StickerItem
@@ -384,10 +445,13 @@ type EmojiBoardProps = {
   onEmojiSelect?: (unicode: string, shortcode: string) => void;
   onCustomEmojiSelect?: (mxc: string, shortcode: string) => void;
   onStickerSelect?: (mxc: string, shortcode: string, label: string) => void;
+  onGifSelect?: (gif: GifData) => void;
   allowTextCustomEmoji?: boolean;
   addToRecentEmoji?: boolean;
   isFullWidth?: boolean;
 };
+
+const getGifName = (v: GifData) => v.title;
 
 export function EmojiBoard({
   tab = EmojiBoardTab.Emoji,
@@ -398,6 +462,7 @@ export function EmojiBoard({
   onEmojiSelect,
   onCustomEmojiSelect,
   onStickerSelect,
+  onGifSelect,
   allowTextCustomEmoji,
   addToRecentEmoji = true,
   isFullWidth,
@@ -406,18 +471,17 @@ export function EmojiBoard({
   const [saveStickerEmojiBandwidth] = useSetting(settingsAtom, 'saveStickerEmojiBandwidth');
 
   const emojiTab = tab === EmojiBoardTab.Emoji;
+  const gifTab = tab === EmojiBoardTab.Gif;
   const usage = emojiTab ? ImageUsage.Emoticon : ImageUsage.Sticker;
 
   const previewAtom = useMemo(
-    () => createPreviewDataAtom(emojiTab ? DefaultEmojiPreview : undefined),
-    [emojiTab]
+    () => createPreviewDataAtom(tab === EmojiBoardTab.Emoji ? DefaultEmojiPreview : undefined),
+    [tab]
   );
   const activeGroupIdAtom = useMemo(() => atom<string | undefined>(undefined), []);
   const setActiveGroupId = useSetAtom(activeGroupIdAtom);
   const imagePacks = useRelevantImagePacks(usage, imagePackRooms);
-  const [emojiGroupItems, stickerGroupItems] = useGroups(tab, imagePacks);
-  const groups = emojiTab ? emojiGroupItems : stickerGroupItems;
-  const renderItem = useItemRenderer(tab, saveStickerEmojiBandwidth);
+  const favoriteGifs = useFavoriteGifs().gifs as GifData[];
 
   const searchList = useMemo(() => {
     let list: Array<PackImageReader | IEmoji> = [];
@@ -426,22 +490,165 @@ export function EmojiBoard({
     return list;
   }, [emojiTab, usage, imagePacks]);
 
-  const [result, search, resetSearch] = useAsyncSearch(
+  const [emojiResult, emojiSearch, resetEmojiSearch] = useAsyncSearch(
     searchList,
     getEmoticonSearchStr,
     SEARCH_OPTIONS
   );
 
-  const searchedItems = result?.items.slice(0, 100);
+  const [gifResult, gifSearch, resetGifSearch] = useAsyncSearch(
+    favoriteGifs,
+    getGifName,
+    SEARCH_OPTIONS
+  );
+
+  const searchedItems = emojiResult?.items.slice(0, 100);
+  const searchedGifItems = gifResult?.items.slice(0, 100) ?? favoriteGifs;
+
+  function useGifSearch() {
+    const [gifs, setGifs] = useState<{
+      gifs: GifData[];
+      favorites: GifData[];
+    }>({
+      gifs: [],
+      favorites: favoriteGifs,
+    });
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const clientConfig = useClientConfig();
+    const klipyApiKey = clientConfig.gifs?.klipyApiKey ?? '';
+
+    const parseKlipyResult = useCallback((klipyResult: any): GifData => {
+      const SIZE_LIMIT = 3 * 1024 * 1024; // 3MB
+
+      const formats = klipyResult.file || {};
+      const preview = formats.xs.gif || formats.sm.gif || formats.md.gif;
+
+      // Start with full resolution GIF
+      let fullRes = formats.hd.gif;
+      // If full res is too large and medium exists, use medium instead
+      if (fullRes && fullRes.size > SIZE_LIMIT && formats.md) {
+        fullRes = formats.md.gif;
+      }
+
+      // Fallback if no suitable format found
+      if (!fullRes) {
+        fullRes = formats.md || preview;
+      }
+
+      // Get dimensions from the selected full resolution format
+      const width = fullRes?.width || preview?.width || 0;
+      const height = fullRes?.height || preview?.height || 0;
+
+      return {
+        id: klipyResult.id,
+        title: klipyResult.title || 'GIF',
+        url: fullRes?.url || '',
+        preview_url: preview?.url || fullRes?.url || '',
+        width,
+        height,
+      };
+    }, []);
+
+    const searchGifs = useCallback(
+      async (query: string) => {
+        const trimmedQuery = query.trim();
+
+        setLoading(true);
+        setError(null);
+
+        gifSearch(trimmedQuery);
+
+        try {
+          const url = new URL('https://api.klipy.com');
+          url.pathname = `/api/v1/${klipyApiKey}/gifs/search`;
+          url.searchParams.set('q', trimmedQuery);
+          url.searchParams.set('per_page', '50'); // TODO: infinite scroll?
+
+          const response = await fetch(url.toString());
+
+          if (response.status === 200) {
+            const data = await response.json();
+            const results = data.data.data as any[] | undefined;
+
+            if (results) {
+              const gifData: GifData[] = results.map(parseKlipyResult);
+              setGifs((old) => ({
+                ...old,
+                gifs: gifData,
+              }));
+            } else {
+              setGifs((old) => ({
+                ...old,
+                gifs: [],
+              }));
+            }
+          } else {
+            throw new Error(`HTTP ${response.status}`);
+          }
+        } catch {
+          setError('Failed to search GIFs');
+          setGifs((old) => ({
+            ...old,
+            gifs: [],
+          }));
+        } finally {
+          setLoading(false);
+        }
+      },
+      [parseKlipyResult]
+    );
+
+    return { gifs, loading, error, searchGifs };
+  }
+
+  const { gifs, loading: gifsLoading, error: gifsError, searchGifs } = useGifSearch();
+  const [emojiGroupItems, stickerGroupItems, gifGroupItems] = useGroups(tab, imagePacks, gifs);
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(true);
+  const groupsByTab = {
+    [EmojiBoardTab.Emoji]: emojiGroupItems,
+    [EmojiBoardTab.Sticker]: stickerGroupItems,
+    [EmojiBoardTab.Gif]:
+      showFavoritesOnly && gifs.favorites.length > 0
+        ? [
+            {
+              id: 'favorites_group',
+              name: 'Favorites',
+              items: searchedGifItems,
+            },
+          ]
+        : searchedGifItems.length > 0
+          ? [
+              {
+                id: 'favorites_group',
+                name: 'Favorites',
+                items: searchedGifItems,
+              },
+            ].concat(gifGroupItems)
+          : gifGroupItems,
+  };
+  const groups = groupsByTab[tab];
+  const renderItem = useItemRenderer(tab, saveStickerEmojiBandwidth);
 
   const handleOnChange: ChangeEventHandler<HTMLInputElement> = useDebounce(
     useCallback(
       (evt) => {
         const term = evt.target.value;
-        if (term) search(term);
-        else resetSearch();
+        if (tab === EmojiBoardTab.Gif) {
+          if (term) {
+            setShowFavoritesOnly(false);
+            searchGifs(term);
+          } else {
+            setShowFavoritesOnly(true);
+            resetGifSearch();
+          }
+        } else if (term) {
+          emojiSearch(term);
+        } else {
+          resetEmojiSearch();
+        }
       },
-      [search, resetSearch]
+      [emojiSearch, resetEmojiSearch, searchGifs, resetGifSearch, tab]
     ),
     { wait: 200 }
   );
@@ -494,6 +701,11 @@ export function EmojiBoard({
     if (emojiInfo.type === EmojiType.Sticker) {
       onStickerSelect?.(emojiInfo.data, emojiInfo.shortcode, emojiInfo.label);
     }
+    if (emojiInfo.type === EmojiType.Gif) {
+      const gifDataStr = targetEl.getAttribute('data-gif-data');
+      const gifData = gifDataStr ? JSON.parse(gifDataStr) : null;
+      onGifSelect?.(gifData);
+    }
     if (!evt.altKey && !evt.shiftKey) requestClose();
   };
 
@@ -518,7 +730,7 @@ export function EmojiBoard({
       const group = inViewVItem ? groups[inViewVItem?.index] : undefined;
       setActiveGroupId(group?.id);
     }
-  }, [vItems, groups, setActiveGroupId, result?.query]);
+  }, [vItems, groups, setActiveGroupId, emojiResult?.query, gifResult?.query]);
 
   // reset scroll position on search
   useEffect(() => {
@@ -526,7 +738,7 @@ export function EmojiBoard({
     if (scrollElement) {
       scrollElement.scrollTo({ top: 0 });
     }
-  }, [result?.query]);
+  }, [emojiResult?.query, gifResult?.query]);
 
   // reset scroll position on tab change
   useEffect(() => {
@@ -560,7 +772,7 @@ export function EmojiBoard({
             {onTabChange && <EmojiBoardTabs tab={tab} onTabChange={onTabChange} />}
             <SearchInput
               key={tab}
-              query={result?.query}
+              query={emojiResult?.query}
               onChange={handleOnChange}
               allowTextCustomEmoji={allowTextCustomEmoji}
               onTextCustomEmojiSelect={handleTextCustomEmojiSelect}
@@ -576,12 +788,14 @@ export function EmojiBoard({
               onScrollToGroup={handleScrollToGroup}
             />
           ) : (
-            <StickerSidebar
-              activeGroupAtom={activeGroupIdAtom}
-              packs={imagePacks}
-              saveStickerEmojiBandwidth={saveStickerEmojiBandwidth}
-              onScrollToGroup={handleScrollToGroup}
-            />
+            !gifTab && (
+              <StickerSidebar
+                activeGroupAtom={activeGroupIdAtom}
+                packs={imagePacks}
+                saveStickerEmojiBandwidth={saveStickerEmojiBandwidth}
+                onScrollToGroup={handleScrollToGroup}
+              />
+            )
           )
         }
         isFullWidth={isFullWidth}
@@ -593,7 +807,7 @@ export function EmojiBoard({
             previewAtom={previewAtom}
             onGroupItemClick={handleGroupItemClick}
           >
-            {searchedItems && (
+            {tab !== EmojiBoardTab.Gif && searchedItems && (
               <EmojiGroup
                 id={SEARCH_GROUP_ID}
                 label={searchedItems.length ? 'Search Results' : 'No Results found'}
@@ -618,7 +832,7 @@ export function EmojiBoard({
                     ref={virtualizer.measureElement}
                     key={vItem.index}
                   >
-                    <EmojiGroup key={group.id} id={group.id} label={group.name}>
+                    <EmojiGroup key={group.id} id={group.id} label={group.name} isGifGroup={gifTab}>
                       {group.items.map(renderItem)}
                     </EmojiGroup>
                   </VirtualTile>
@@ -626,9 +840,16 @@ export function EmojiBoard({
               })}
             </div>
             {tab === EmojiBoardTab.Sticker && groups.length === 0 && <NoStickerPacks />}
+            {gifTab && (
+              <GifStatus
+                loading={gifsLoading}
+                error={gifsError}
+                isEmpty={groups.flatMap((v) => v.items.map((i) => 'gif')).length === 0}
+              />
+            )}
           </EmojiGroupHolder>
         </Box>
-        <Preview previewAtom={previewAtom} />
+        {!gifTab && <Preview previewAtom={previewAtom} />}
       </EmojiBoardLayout>
     </FocusTrap>
   );

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -165,11 +165,7 @@ const useGroups = (
   return [emojiGroupItems, stickerGroupItems, gifGroupItems];
 };
 
-const useItemRenderer = (
-  tab: EmojiBoardTab,
-  saveStickerEmojiBandwidth: boolean,
-  onGifSelect?: (gif: GifData, spoiler?: boolean) => void
-) => {
+const useItemRenderer = (tab: EmojiBoardTab, saveStickerEmojiBandwidth: boolean) => {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
 
@@ -636,7 +632,7 @@ export function EmojiBoard({
           : gifGroupItems,
   };
   const groups = groupsByTab[tab];
-  const renderItem = useItemRenderer(tab, saveStickerEmojiBandwidth, onGifSelect);
+  const renderItem = useItemRenderer(tab, saveStickerEmojiBandwidth);
 
   const handleOnChange: ChangeEventHandler<HTMLInputElement> = useDebounce(
     useCallback(

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -472,6 +472,7 @@ export function EmojiBoard({
 }: Readonly<EmojiBoardProps>) {
   const mx = useMatrixClient();
   const [saveStickerEmojiBandwidth] = useSetting(settingsAtom, 'saveStickerEmojiBandwidth');
+  const [showGifPicker] = useSetting(settingsAtom, 'enableGifPicker');
 
   const emojiTab = tab === EmojiBoardTab.Emoji;
   const gifTab = tab === EmojiBoardTab.Gif;
@@ -556,6 +557,10 @@ export function EmojiBoard({
 
     const searchGifs = useCallback(
       async (query: string) => {
+        if (!showGifPicker) {
+          return;
+        }
+
         const trimmedQuery = query.trim();
 
         setLoading(true);

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -57,10 +57,13 @@ import {
   EmojiGroup,
   EmojiBoardLayout,
 } from './components';
-import { EmojiBoardTab, EmojiType, GifData } from './types';
-import { GitDiffIcon } from '@phosphor-icons/react';
+import type { GifData } from './types';
+import { EmojiBoardTab, EmojiType } from './types';
 import { useClientConfig } from '$hooks/useClientConfig';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
+
+/* oxlint-disable typescript/no-explicit-any */
+// TODO: type klipy api properly
 
 const RECENT_GROUP_ID = 'recent_group';
 const SEARCH_GROUP_ID = 'search_group';
@@ -596,7 +599,7 @@ export function EmojiBoard({
           setLoading(false);
         }
       },
-      [parseKlipyResult]
+      [parseKlipyResult, klipyApiKey]
     );
 
     return { gifs, loading, error, searchGifs };
@@ -844,7 +847,7 @@ export function EmojiBoard({
               <GifStatus
                 loading={gifsLoading}
                 error={gifsError}
-                isEmpty={groups.flatMap((v) => v.items.map((i) => 'gif')).length === 0}
+                isEmpty={groups.flatMap((v) => v.items.map(() => 'gif')).length === 0}
               />
             )}
           </EmojiGroupHolder>

--- a/src/app/components/emoji-board/components/Group.tsx
+++ b/src/app/components/emoji-board/components/Group.tsx
@@ -10,9 +10,10 @@ export const EmojiGroup = as<
   {
     id: string;
     label: string;
+    isGifGroup?: boolean;
     children: ReactNode;
   }
->(({ className, id, label, children, ...props }, ref) => (
+>(({ className, id, label, isGifGroup, children, ...props }, ref) => (
   <Box
     id={getDOMGroupId(id)}
     data-group-id={id}
@@ -25,10 +26,17 @@ export const EmojiGroup = as<
     <Text id={`EmojiGroup-${id}-label`} as="label" className={css.EmojiGroupLabel} size="O400">
       {label}
     </Text>
-    <div aria-labelledby={`EmojiGroup-${id}-label`} className={css.EmojiGroupContent}>
-      <Box wrap="Wrap" justifyContent="Center">
-        {children}
-      </Box>
+    <div
+      aria-labelledby={`EmojiGroup-${id}-label`}
+      className={isGifGroup ? css.GifGroupContent : css.EmojiGroupContent}
+    >
+      {isGifGroup ? (
+        children
+      ) : (
+        <Box wrap="Wrap" justifyContent="Center">
+          {children}
+        </Box>
+      )}
     </div>
   </Box>
 ));

--- a/src/app/components/emoji-board/components/Item.tsx
+++ b/src/app/components/emoji-board/components/Item.tsx
@@ -226,7 +226,16 @@ export function GifItem({
                     setFavorited(true);
                     await mx
                       .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-                        gifs: [...favoritedContent.gifs, { ...gif, url: mxcUrl }],
+                        gifs: [
+                          ...favoritedContent.gifs,
+                          {
+                            title: gif.title,
+                            url: mxcUrl,
+                            width: gif.width,
+                            height: gif.height,
+                            size: gif.size,
+                          },
+                        ],
                       })
                       .catch(() => setFavorited(false));
                   } else {

--- a/src/app/components/emoji-board/components/Item.tsx
+++ b/src/app/components/emoji-board/components/Item.tsx
@@ -9,9 +9,11 @@ import type { CSSProperties, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import * as css from './styles.css';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
-import { Star, menuIcon } from '$components/icons/phosphor';
+import { Star, Eye, EyeSlash, menuIcon } from '$components/icons/phosphor';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '$unstable/prefixes';
 import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useClientConfig } from '$hooks/useClientConfig';
+import { getKlipyMxcUrl } from '$utils/klipy';
 
 const ANIMATED_MIME_TYPES = new Set(['image/gif', 'image/apng']);
 
@@ -165,16 +167,28 @@ export function GifItem({
   children: ReactNode;
 }) {
   const [isHovered, setIsHovered] = useState(false);
-  const initialFavorited = useFavoriteGifs();
-  const [favoritedContent, setFavoritedContent] = useState(initialFavorited);
+  const favoritedContent = useFavoriteGifs();
+  const clientConfig = useClientConfig();
+  
+  const mxcUrl = gif?.url ? getKlipyMxcUrl(gif.url, clientConfig.gifs?.proxyUrl) : '';
+
   const [favorited, setFavorited] = useState(
-    favoritedContent.gifs.find((v) => v.url == gif?.url) != undefined
+    favoritedContent.gifs.some((v) => {
+      const vMxc = getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl);
+      return vMxc === mxcUrl && mxcUrl !== '';
+    })
   );
+  const [isSpoiler, setIsSpoiler] = useState(false);
   const mx = useMatrixClient();
 
   useEffect(() => {
-    setFavoritedContent(initialFavorited);
-  }, [initialFavorited]);
+    setFavorited(
+      favoritedContent.gifs.some((v) => {
+        const vMxc = getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl);
+        return vMxc === mxcUrl && mxcUrl !== '';
+      })
+    );
+  }, [favoritedContent, mxcUrl, clientConfig.gifs?.proxyUrl]);
 
   return (
     <Box
@@ -190,6 +204,7 @@ export function GifItem({
       data-emoji-data={data}
       data-emoji-shortcode={shortcode}
       data-gif-data={gif ? JSON.stringify(gif) : undefined}
+      data-gif-spoiler={isSpoiler ? 'true' : 'false'}
       onPointerEnter={() => setIsHovered(true)}
       onPointerLeave={() => setIsHovered(false)}
     >
@@ -206,18 +221,19 @@ export function GifItem({
                 title={favorited ? 'Unfavorite gif' : 'Favorite gif'}
                 onClick={async (e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   if (!favorited) {
                     setFavorited(true);
                     await mx
                       .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-                        gifs: [...favoritedContent.gifs, gif],
+                        gifs: [...favoritedContent.gifs, { ...gif, url: mxcUrl }],
                       })
                       .catch(() => setFavorited(false));
                   } else {
                     setFavorited(false);
                     await mx
                       .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-                        gifs: favoritedContent.gifs.filter((v) => v.url != gif.url),
+                        gifs: favoritedContent.gifs.filter((v) => getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl) !== mxcUrl),
                       })
                       .catch(() => setFavorited(true));
                   }
@@ -226,6 +242,23 @@ export function GifItem({
                 {menuIcon(Star, {
                   weight: favorited ? 'fill' : 'regular',
                   color: favorited ? color.Warning.MainHover : color.Surface.OnContainer,
+                })}
+              </MenuItem>
+              <MenuItem
+                size="300"
+                radii="0"
+                fill="Soft"
+                variant="Secondary"
+                title={isSpoiler ? 'Remove spoiler' : 'Mark as spoiler'}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsSpoiler(!isSpoiler);
+                }}
+              >
+                {menuIcon(isSpoiler ? EyeSlash : Eye, {
+                  weight: isSpoiler ? 'fill' : 'regular',
+                  color: color.Surface.OnContainer,
                 })}
               </MenuItem>
             </Box>

--- a/src/app/components/emoji-board/components/Item.tsx
+++ b/src/app/components/emoji-board/components/Item.tsx
@@ -3,14 +3,15 @@ import type { MatrixClient } from '$types/matrix-sdk';
 import type { PackImageReader } from '$plugins/custom-emoji';
 import type { IEmoji } from '$plugins/emoji';
 import { mxcUrlToHttp } from '$utils/matrix';
-import { EmojiItemInfo, EmojiType, GifData } from '$components/emoji-board/types';
-import { CSSProperties, ReactNode, useEffect, useState } from 'react';
+import type { EmojiItemInfo, GifData } from '$components/emoji-board/types';
+import { EmojiType } from '$components/emoji-board/types';
+import type { CSSProperties, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import * as css from './styles.css';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 import { Star, menuIcon } from '$components/icons/phosphor';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '$unstable/prefixes';
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import classNames from 'classnames';
 
 const ANIMATED_MIME_TYPES = new Set(['image/gif', 'image/apng']);
 

--- a/src/app/components/emoji-board/components/Item.tsx
+++ b/src/app/components/emoji-board/components/Item.tsx
@@ -169,7 +169,7 @@ export function GifItem({
   const [isHovered, setIsHovered] = useState(false);
   const favoritedContent = useFavoriteGifs();
   const clientConfig = useClientConfig();
-  
+
   const mxcUrl = gif?.url ? getKlipyMxcUrl(gif.url, clientConfig.gifs?.proxyUrl) : '';
 
   const [favorited, setFavorited] = useState(
@@ -233,7 +233,9 @@ export function GifItem({
                     setFavorited(false);
                     await mx
                       .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-                        gifs: favoritedContent.gifs.filter((v) => getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl) !== mxcUrl),
+                        gifs: favoritedContent.gifs.filter(
+                          (v) => getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl) !== mxcUrl
+                        ),
                       })
                       .catch(() => setFavorited(true));
                   }

--- a/src/app/components/emoji-board/components/Item.tsx
+++ b/src/app/components/emoji-board/components/Item.tsx
@@ -1,11 +1,16 @@
-import { Box } from 'folds';
+import { Box, color, config, Menu, MenuItem } from 'folds';
 import type { MatrixClient } from '$types/matrix-sdk';
 import type { PackImageReader } from '$plugins/custom-emoji';
 import type { IEmoji } from '$plugins/emoji';
 import { mxcUrlToHttp } from '$utils/matrix';
-import type { EmojiItemInfo } from '$components/emoji-board/types';
-import { EmojiType } from '$components/emoji-board/types';
+import { EmojiItemInfo, EmojiType, GifData } from '$components/emoji-board/types';
+import { CSSProperties, ReactNode, useEffect, useState } from 'react';
 import * as css from './styles.css';
+import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
+import { Star, menuIcon } from '$components/icons/phosphor';
+import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '$unstable/prefixes';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import classNames from 'classnames';
 
 const ANIMATED_MIME_TYPES = new Set(['image/gif', 'image/apng']);
 
@@ -137,6 +142,95 @@ export function StickerItem({
         alt={image.body || image.shortcode}
         src={getPackImageSrc(mx, image, useAuthentication, saveStickerEmojiBandwidth, 125, 125)}
       />
+    </Box>
+  );
+}
+
+export function GifItem({
+  label,
+  type,
+  data,
+  shortcode,
+  gif,
+  style,
+  children,
+}: {
+  label: string;
+  type: EmojiType;
+  data: string;
+  shortcode: string;
+  gif: GifData;
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  const [isHovered, setIsHovered] = useState(false);
+  const initialFavorited = useFavoriteGifs();
+  const [favoritedContent, setFavoritedContent] = useState(initialFavorited);
+  const [favorited, setFavorited] = useState(
+    favoritedContent.gifs.find((v) => v.url == gif?.url) != undefined
+  );
+  const mx = useMatrixClient();
+
+  useEffect(() => {
+    setFavoritedContent(initialFavorited);
+  }, [initialFavorited]);
+
+  return (
+    <Box
+      as="button"
+      className={css.GifItem}
+      type="button"
+      style={style}
+      alignItems="Center"
+      justifyContent="Center"
+      title={label}
+      aria-label={`${label} gif`}
+      data-emoji-type={type}
+      data-emoji-data={data}
+      data-emoji-shortcode={shortcode}
+      data-gif-data={gif ? JSON.stringify(gif) : undefined}
+      onPointerEnter={() => setIsHovered(true)}
+      onPointerLeave={() => setIsHovered(false)}
+    >
+      {children}
+      {isHovered && (
+        <Box style={{ padding: config.space.S200, right: 0, top: 0, position: 'absolute' }}>
+          <Menu style={{ padding: config.space.S0 }}>
+            <Box>
+              <MenuItem
+                size="300"
+                radii="0"
+                fill="Soft"
+                variant="Secondary"
+                title={favorited ? 'Unfavorite gif' : 'Favorite gif'}
+                onClick={async (e) => {
+                  e.preventDefault();
+                  if (!favorited) {
+                    setFavorited(true);
+                    await mx
+                      .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
+                        gifs: [...favoritedContent.gifs, gif],
+                      })
+                      .catch(() => setFavorited(false));
+                  } else {
+                    setFavorited(false);
+                    await mx
+                      .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
+                        gifs: favoritedContent.gifs.filter((v) => v.url != gif.url),
+                      })
+                      .catch(() => setFavorited(true));
+                  }
+                }}
+              >
+                {menuIcon(Star, {
+                  weight: favorited ? 'fill' : 'regular',
+                  color: favorited ? color.Warning.MainHover : color.Surface.OnContainer,
+                })}
+              </MenuItem>
+            </Box>
+          </Menu>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/app/components/emoji-board/components/NoGifResults.tsx
+++ b/src/app/components/emoji-board/components/NoGifResults.tsx
@@ -1,0 +1,63 @@
+import { SmileySadIcon } from '@phosphor-icons/react';
+import { Box, toRem, config, Text } from 'folds';
+
+export function GifSearching() {
+  return (
+    <Box
+      style={{ padding: `${toRem(60)} ${config.space.S500}` }}
+      alignItems="Center"
+      justifyContent="Center"
+      direction="Column"
+      gap="300"
+    >
+      <Text>Loading GIFs...</Text>
+    </Box>
+  );
+}
+
+export function GifSearchError({ error }: { error: string }) {
+  return (
+    <Box
+      style={{ padding: `${toRem(60)} ${config.space.S500}` }}
+      alignItems="Center"
+      justifyContent="Center"
+      direction="Column"
+      gap="300"
+    >
+      <Text>Error: {error}</Text>
+    </Box>
+  );
+}
+
+export function NoGifResults() {
+  return (
+    <Box
+      style={{ padding: `${toRem(60)} ${config.space.S500}` }}
+      alignItems="Center"
+      justifyContent="Center"
+      direction="Column"
+      gap="300"
+    >
+      <SmileySadIcon size="48" />
+      <Box direction="Inherit">
+        <Text align="Center">No GIFs found!</Text>
+        <Text priority="300" align="Center" size="T200">
+          Try searching for something else or favoriting some gifs.
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+type GifStatusProps = {
+  loading: boolean;
+  error: string | null;
+  isEmpty: boolean;
+};
+
+export function GifStatus({ loading, error, isEmpty }: Readonly<GifStatusProps>) {
+  if (loading) return <GifSearching />;
+  if (error) return <GifSearchError error={error} />;
+  if (isEmpty) return <NoGifResults />;
+  return null;
+}

--- a/src/app/components/emoji-board/components/SearchInput.tsx
+++ b/src/app/components/emoji-board/components/SearchInput.tsx
@@ -10,12 +10,14 @@ type SearchInputProps = {
   onChange: ChangeEventHandler<HTMLInputElement>;
   allowTextCustomEmoji?: boolean;
   onTextCustomEmojiSelect?: (text: string) => void;
+  tab?: EmojiBoardTab;
 };
 export function SearchInput({
   query,
   onChange,
   allowTextCustomEmoji,
   onTextCustomEmojiSelect,
+  tab,
 }: SearchInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -31,11 +33,15 @@ export function SearchInput({
       variant="SurfaceVariant"
       size="400"
       placeholder={
-        allowTextCustomEmoji && !EmojiBoardTab.Gif ? 'Search or Text Reaction ' : 'Search'
+        tab === EmojiBoardTab.Gif
+          ? 'Search KLIPY'
+          : allowTextCustomEmoji
+            ? 'Search or Text Reaction '
+            : 'Search'
       }
       maxLength={50}
       after={
-        allowTextCustomEmoji && query && !EmojiBoardTab.Gif ? (
+        allowTextCustomEmoji && query && tab !== EmojiBoardTab.Gif ? (
           <Chip
             variant="Primary"
             radii="Pill"

--- a/src/app/components/emoji-board/components/SearchInput.tsx
+++ b/src/app/components/emoji-board/components/SearchInput.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { Input, Chip, Text } from 'folds';
 import { mobileOrTablet } from '$utils/user-agent';
 import { ArrowRight, sizedIcon, MagnifyingGlass } from '$components/icons/phosphor';
+import { EmojiBoardTab } from '../types';
 
 type SearchInputProps = {
   query?: string;
@@ -29,10 +30,12 @@ export function SearchInput({
       ref={inputRef}
       variant="SurfaceVariant"
       size="400"
-      placeholder={allowTextCustomEmoji ? 'Search or Text Reaction ' : 'Search'}
+      placeholder={
+        allowTextCustomEmoji && !EmojiBoardTab.Gif ? 'Search or Text Reaction ' : 'Search'
+      }
       maxLength={50}
       after={
-        allowTextCustomEmoji && query ? (
+        allowTextCustomEmoji && query && !EmojiBoardTab.Gif ? (
           <Chip
             variant="Primary"
             radii="Pill"

--- a/src/app/components/emoji-board/components/Tabs.tsx
+++ b/src/app/components/emoji-board/components/Tabs.tsx
@@ -19,6 +19,18 @@ export function EmojiBoardTabs({
         style={styles}
         as="button"
         variant="Secondary"
+        fill={tab === EmojiBoardTab.Gif ? 'Solid' : 'None'}
+        size="500"
+        onClick={() => onTabChange(EmojiBoardTab.Gif)}
+      >
+        <Text as="span" size="L400">
+          GIF
+        </Text>
+      </Badge>
+      <Badge
+        style={styles}
+        as="button"
+        variant="Secondary"
         fill={tab === EmojiBoardTab.Sticker ? 'Solid' : 'None'}
         size="500"
         onClick={() => onTabChange(EmojiBoardTab.Sticker)}

--- a/src/app/components/emoji-board/components/Tabs.tsx
+++ b/src/app/components/emoji-board/components/Tabs.tsx
@@ -1,6 +1,8 @@
 import type { CSSProperties } from 'react';
 import { Badge, Box, Text } from 'folds';
 import { EmojiBoardTab } from '$components/emoji-board/types';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
 
 const styles: CSSProperties = {
   cursor: 'pointer',
@@ -13,20 +15,23 @@ export function EmojiBoardTabs({
   tab: EmojiBoardTab;
   onTabChange: (tab: EmojiBoardTab) => void;
 }) {
+  const [showGifPicker] = useSetting(settingsAtom, 'enableGifPicker');
   return (
     <Box gap="100">
-      <Badge
-        style={styles}
-        as="button"
-        variant="Secondary"
-        fill={tab === EmojiBoardTab.Gif ? 'Solid' : 'None'}
-        size="500"
-        onClick={() => onTabChange(EmojiBoardTab.Gif)}
-      >
-        <Text as="span" size="L400">
-          GIF
-        </Text>
-      </Badge>
+      {showGifPicker && (
+        <Badge
+          style={styles}
+          as="button"
+          variant="Secondary"
+          fill={tab === EmojiBoardTab.Gif ? 'Solid' : 'None'}
+          size="500"
+          onClick={() => onTabChange(EmojiBoardTab.Gif)}
+        >
+          <Text as="span" size="L400">
+            GIF
+          </Text>
+        </Badge>
+      )}
       <Badge
         style={styles}
         as="button"

--- a/src/app/components/emoji-board/components/index.tsx
+++ b/src/app/components/emoji-board/components/index.tsx
@@ -2,6 +2,7 @@ export * from './SearchInput';
 export * from './Tabs';
 export * from './Sidebar';
 export * from './NoStickerPacks';
+export * from './NoGifResults';
 export * from './Preview';
 export * from './Item';
 export * from './Group';

--- a/src/app/components/emoji-board/components/styles.css.ts
+++ b/src/app/components/emoji-board/components/styles.css.ts
@@ -126,6 +126,21 @@ export const EmojiGroupContent = style([
   },
 ]);
 
+export const GifGroupContent = style([
+  DefaultReset,
+  {
+    columnCount: 2,
+    columnGap: config.space.S100,
+    padding: `0 ${config.space.S200}`,
+
+    '@media': {
+      'screen and (max-width: 480px)': {
+        columnCount: 1,
+      },
+    },
+  },
+]);
+
 /**
  * Item
  */
@@ -172,3 +187,44 @@ export const StickerImg = style([
     objectFit: 'contain',
   },
 ]);
+
+export const GifContainer = style({
+  columnCount: 3,
+  columnGap: toRem(8),
+  padding: toRem(16),
+
+  '@media': {
+    '(max-width: 768px)': {
+      columnCount: 2,
+    },
+    '(max-width: 480px)': {
+      columnCount: 1,
+    },
+  },
+});
+
+export const GifItem = style([
+  DefaultReset,
+  FocusOutline,
+  {
+    width: '100%',
+    marginBottom: toRem(8),
+    breakInside: 'avoid',
+    borderRadius: config.radii.R400,
+    cursor: 'pointer',
+    overflow: 'hidden',
+    display: 'block',
+    position: 'relative',
+
+    ':hover': {
+      backgroundColor: color.Surface.ContainerHover,
+    },
+  },
+]);
+
+export const GifImg = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  borderRadius: config.radii.R400,
+});

--- a/src/app/components/emoji-board/types.ts
+++ b/src/app/components/emoji-board/types.ts
@@ -1,12 +1,14 @@
 export enum EmojiBoardTab {
   Emoji = 'Emoji',
   Sticker = 'Sticker',
+  Gif = 'Gif',
 }
 
 export enum EmojiType {
   Emoji = 'emoji',
   CustomEmoji = 'customEmoji',
   Sticker = 'sticker',
+  Gif = 'gif',
 }
 
 export type EmojiItemInfo = {
@@ -14,4 +16,13 @@ export type EmojiItemInfo = {
   data: string;
   shortcode: string;
   label: string;
+};
+
+export type GifData = {
+  id: string;
+  title: string;
+  url: string;
+  preview_url?: string;
+  width?: number;
+  height?: number;
 };

--- a/src/app/components/emoji-board/types.ts
+++ b/src/app/components/emoji-board/types.ts
@@ -25,4 +25,5 @@ export type GifData = {
   preview_url?: string;
   width?: number;
   height?: number;
+  size?: number;
 };

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -430,6 +430,7 @@ export const ImageContent = as<'div', ImageContentProps>(
                                   url: url,
                                   width: imageW,
                                   height: imageH,
+                                  size: info?.size,
                                 },
                               ],
                             })

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -16,10 +16,19 @@ import {
   Tooltip,
   TooltipProvider,
   as,
+  color,
   config,
   toRem,
 } from 'folds';
-import { Eye, EyeSlash, menuIcon, sizedIcon, Image, Warning } from '$components/icons/phosphor';
+import {
+  Eye,
+  EyeSlash,
+  menuIcon,
+  sizedIcon,
+  Image,
+  Warning,
+  Star,
+} from '$components/icons/phosphor';
 import classNames from 'classnames';
 import { BlurhashCanvas } from 'react-blurhash';
 import FocusTrap from 'focus-trap-react';
@@ -35,7 +44,13 @@ import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { ModalWide } from '$styles/Modal.css';
 import { validBlurHash } from '$utils/blurHash';
 import * as css from './style.css';
-import { MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME } from '../../../../unstable/prefixes';
+import {
+  MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS,
+  MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME,
+} from '../../../../unstable/prefixes';
+import { useAccountData } from '$hooks/useAccountData';
+import { AccountDataEvents, IContent } from 'matrix-js-sdk';
+import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 
 function thumbnailDimsForMaxEdge(
   maxEdge: number,
@@ -118,6 +133,11 @@ export const ImageContent = as<'div', ImageContentProps>(
     const [viewerFullSrc, setViewerFullSrc] = useState<string | null>(null);
     const [blurred, setBlurred] = useState(markedAsSpoiler ?? false);
     const [isHovered, setIsHovered] = useState(false);
+
+    const favoritedContent = useFavoriteGifs();
+    const [favorited, setFavorited] = useState(
+      favoritedContent.gifs.find((v) => v.url == url) != undefined
+    );
 
     const [srcState, loadSrc] = useAsyncCallback(
       useCallback(async () => {
@@ -374,21 +394,66 @@ export const ImageContent = as<'div', ImageContentProps>(
         {isHovered && (
           <Box style={{ padding: config.space.S200, right: 0, position: 'absolute' }}>
             <Menu style={{ padding: config.space.S0 }}>
-              <MenuItem
-                size="300"
-                after={menuIcon(blurred ? Eye : EyeSlash)}
-                radii="300"
-                fill="Soft"
-                variant="Secondary"
-                title={blurred ? 'Reveal Image' : 'Hide Image'}
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (srcState.status === AsyncStatus.Idle) {
-                    loadSrc();
-                    setBlurred(false);
-                  } else setBlurred(!blurred);
-                }}
-              />
+              <Box>
+                <MenuItem
+                  size="300"
+                  radii="0"
+                  fill="Soft"
+                  variant="Secondary"
+                  title={blurred ? 'Reveal Image' : 'Hide Image'}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (srcState.status === AsyncStatus.Idle) {
+                      loadSrc();
+                      setBlurred(false);
+                    } else setBlurred(!blurred);
+                  }}
+                >
+                  {menuIcon(blurred ? Eye : EyeSlash)}
+                </MenuItem>
+                {info?.mimetype == 'image/gif' && (
+                  <MenuItem
+                    size="300"
+                    radii="0"
+                    fill="Soft"
+                    variant="Secondary"
+                    title={favorited ? 'Unfavorite gif' : 'Favorite gif'}
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      if (srcState.status === AsyncStatus.Success) {
+                        if (!favorited) {
+                          setFavorited(true);
+                          await mx
+                            .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
+                              gifs: [
+                                ...favoritedContent.gifs,
+                                {
+                                  title: body,
+                                  url: url,
+                                  width: imageW,
+                                  height: imageH,
+                                },
+                              ],
+                            })
+                            .catch(() => setFavorited(false));
+                        } else {
+                          setFavorited(false);
+                          await mx
+                            .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
+                              gifs: favoritedContent.gifs.filter((v) => v.url != url),
+                            })
+                            .catch(() => setFavorited(true));
+                        }
+                      }
+                    }}
+                  >
+                    {menuIcon(Star, {
+                      weight: favorited ? 'fill' : 'regular',
+                      color: favorited ? color.Warning.MainHover : color.Surface.OnContainer,
+                    })}
+                  </MenuItem>
+                )}
+              </Box>
             </Menu>
           </Box>
         )}

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -48,8 +48,6 @@ import {
   MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS,
   MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME,
 } from '../../../../unstable/prefixes';
-import { useAccountData } from '$hooks/useAccountData';
-import { AccountDataEvents, IContent } from 'matrix-js-sdk';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 
 function thumbnailDimsForMaxEdge(

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -169,8 +169,10 @@ import {
   getFileMsgContent,
   getImageMsgContent,
   getVideoMsgContent,
+  getGifMsgContent,
 } from './msgContent';
 import { outgoingMessageTransforms } from './outgoingMessageTransforms';
+import { getKlipyMxcUrl } from '$utils/klipy';
 import { CommandAutocomplete } from './CommandAutocomplete';
 import type {
   AudioMessageRecorderHandle,
@@ -274,21 +276,7 @@ interface RoomInputProps {
   onEditLastMessage?: () => void;
 }
 
-function toBase64Url(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  let binary = '';
 
-  for (const byte of bytes) {
-    binary += String.fromCodePoint(byte);
-  }
-
-  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
-}
-
-function toMatrixID(fname: string, urlPrefix: string): string {
-  const base64 = toBase64Url(fname);
-  return urlPrefix + base64;
-}
 
 export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
   ({ editor, fileDropContainerRef, roomId, room, threadRootId, onEditLastMessage }, ref) => {
@@ -590,26 +578,8 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       handleRemoveUpload(uploads.map((upload) => upload.file));
     };
 
-    const handleSendUpload = async (uploads: UploadSuccess[]) => {
+    const handleSendContents = async (contents: IContent[]) => {
       const plainText = toPlainText(editor.children).trim();
-
-      const contentsPromises = uploads.map(async (upload) => {
-        const fileItem = selectedFiles.find((f) => f.file === upload.file);
-        if (!fileItem) throw new Error('Broken upload');
-
-        if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc);
-        }
-        if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc);
-        }
-        if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc);
-        }
-        return getFileMsgContent(fileItem, upload.mxc);
-      });
-      handleCancelUpload(uploads);
-      const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));
 
       /**
        * the currently with the room associated per-message profile, if any, so that it can be included in the message content when sending.
@@ -662,11 +632,11 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           setEditingScheduledDelayId(null);
           setScheduledTime(null);
         } catch (error) {
-          debugLog.error('message', 'Failed to schedule uploaded file message', {
+          debugLog.error('message', 'Failed to schedule message', {
             roomId,
             error: error instanceof Error ? error.message : String(error),
           });
-          log.error('failed to schedule uploaded message', { roomId }, error);
+          log.error('failed to schedule message', { roomId }, error);
           throw error;
         }
       } else {
@@ -678,7 +648,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           } catch {
             debugLog.error(
               'message',
-              'Failed to cancel scheduled event before immediate file send',
+              'Failed to cancel scheduled event before immediate send',
               { roomId }
             );
           }
@@ -689,7 +659,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             mx
               .sendMessage(roomId, threadRootId ?? null, content as RoomMessageEventContent)
               .then((res: { event_id: string }) => {
-                debugLog.info('message', 'Uploaded file message sent', {
+                debugLog.info('message', 'Message sent', {
                   roomId,
                   eventId: res.event_id,
                   msgtype: content.msgtype,
@@ -697,16 +667,38 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                 return res;
               })
               .catch((error: unknown) => {
-                debugLog.error('message', 'Failed to send uploaded file message', {
+                debugLog.error('message', 'Failed to send message', {
                   roomId,
                   error: error instanceof Error ? error.message : String(error),
                 });
-                log.error('failed to send uploaded message', { roomId }, error);
+                log.error('failed to send message', { roomId }, error);
                 throw error;
               })
           )
         );
       }
+    };
+
+    const handleSendUpload = async (uploads: UploadSuccess[]) => {
+      const contentsPromises = uploads.map(async (upload) => {
+        const fileItem = selectedFiles.find((f) => f.file === upload.file);
+        if (!fileItem) throw new Error('Broken upload');
+
+        if (fileItem.file.type.startsWith('image')) {
+          return getImageMsgContent(mx, fileItem, upload.mxc);
+        }
+        if (fileItem.file.type.startsWith('video')) {
+          return getVideoMsgContent(mx, fileItem, upload.mxc);
+        }
+        if (fileItem.file.type.startsWith('audio')) {
+          return getAudioMsgContent(fileItem, upload.mxc);
+        }
+        return getFileMsgContent(fileItem, upload.mxc);
+      });
+      handleCancelUpload(uploads);
+      const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));
+
+      await handleSendContents(contents);
     };
 
     const handleCloseAutocomplete = useCallback(() => {
@@ -1324,39 +1316,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       mx.sendEvent(roomId, EventType.Sticker, content);
     };
 
-    const handleGifSelect = async (gif: GifData) => {
-      let url = gif.url.startsWith('mxc://')
-        ? gif.url
-        : `mxc://${clientConfig.gifs?.proxyUrl ?? ''}/${toMatrixID(gif.url.slice('https://static.klipy.com/ii/'.length), 'klipy_')}`;
+    const handleGifSelect = async (gif: GifData, spoiler?: boolean) => {
+      const url = getKlipyMxcUrl(gif.url, clientConfig.gifs?.proxyUrl);
 
-      const content: RoomMessageEventContent & ReplyEventContent & IContent = {
-        body: gif.title,
-        url: url,
-        msgtype: MsgType.Image,
-        info: {
-          w: gif.width,
-          h: gif.height,
-          mimetype: 'image/gif',
-        },
-      };
+      const content = await getGifMsgContent(mx, gif, url, spoiler);
 
-      // Handle replies if there's a reply draft
-      if (replyDraft) {
-        content['m.relates_to'] = {
-          'm.in_reply_to': {
-            event_id: replyDraft.eventId,
-          },
-        };
-        if (replyDraft.relation?.rel_type === RelationType.Thread) {
-          content['m.relates_to'].event_id = replyDraft.relation.event_id;
-          content['m.relates_to'].rel_type = RelationType.Thread;
-          content['m.relates_to'].is_falling_back = false;
-        }
-      }
-
-      // Send the gif as sticker event.
-      await mx.sendEvent(roomId, EventType.RoomMessage, content);
-      setReplyDraft(undefined);
+      await handleSendContents([content]);
     };
 
     return (

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -276,8 +276,6 @@ interface RoomInputProps {
   onEditLastMessage?: () => void;
 }
 
-
-
 export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
   ({ editor, fileDropContainerRef, roomId, room, threadRootId, onEditLastMessage }, ref) => {
     // When in thread mode, isolate drafts by thread root ID so thread replies
@@ -646,11 +644,9 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             invalidate();
             setEditingScheduledDelayId(null);
           } catch {
-            debugLog.error(
-              'message',
-              'Failed to cancel scheduled event before immediate send',
-              { roomId }
-            );
+            debugLog.error('message', 'Failed to cancel scheduled event before immediate send', {
+              roomId,
+            });
           }
         }
 

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -286,6 +286,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const useAuthentication = useMediaAuthentication();
     const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
     const [editorOldAddFile] = useSetting(settingsAtom, 'editorOldAddFile');
+    const [showGifPicker] = useSetting(settingsAtom, 'enableGifPicker');
 
     const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
     const [mentionInReplies] = useSetting(settingsAtom, 'mentionInReplies');
@@ -1731,17 +1732,19 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                       />
                     }
                   >
-                    <IconButton
-                      aria-pressed={emojiBoardTab === EmojiBoardTab.Gif}
-                      onClick={() => setEmojiBoardTab(EmojiBoardTab.Gif)}
-                      variant="SurfaceVariant"
-                      size="300"
-                      radii="300"
-                    >
-                      {composerIcon(GifIcon, {
-                        weight: emojiBoardTab === EmojiBoardTab.Gif ? 'fill' : 'regular',
-                      })}
-                    </IconButton>
+                    {showGifPicker && (
+                      <IconButton
+                        aria-pressed={emojiBoardTab === EmojiBoardTab.Gif}
+                        onClick={() => setEmojiBoardTab(EmojiBoardTab.Gif)}
+                        variant="SurfaceVariant"
+                        size="300"
+                        radii="300"
+                      >
+                        {composerIcon(GifIcon, {
+                          weight: emojiBoardTab === EmojiBoardTab.Gif ? 'fill' : 'regular',
+                        })}
+                      </IconButton>
+                    )}
                     {!hideStickerBtn && (
                       <IconButton
                         aria-pressed={emojiBoardTab === EmojiBoardTab.Sticker}

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -64,7 +64,8 @@ import {
   BlockType,
 } from '$components/editor';
 import { plainToEditorInput } from '$components/editor/input';
-import { EmojiBoard, EmojiBoardTab, GifData } from '$components/emoji-board';
+import type { GifData } from '$components/emoji-board';
+import { EmojiBoard, EmojiBoardTab } from '$components/emoji-board';
 import { UseStateProvider } from '$components/UseStateProvider';
 import type { TUploadContent } from '$utils/matrix';
 import { encryptFile, getImageInfo, mxcUrlToHttp, toggleReaction } from '$utils/matrix';
@@ -271,6 +272,22 @@ interface RoomInputProps {
   room: Room;
   threadRootId?: string;
   onEditLastMessage?: () => void;
+}
+
+function toBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
+}
+
+function toMatrixID(fname: string, urlPrefix: string): string {
+  const base64 = toBase64Url(fname);
+  return urlPrefix + base64;
 }
 
 export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
@@ -1308,22 +1325,6 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     };
 
     const handleGifSelect = async (gif: GifData) => {
-      function toBase64Url(value: string): string {
-        const bytes = new TextEncoder().encode(value);
-        let binary = '';
-
-        for (const byte of bytes) {
-          binary += String.fromCodePoint(byte);
-        }
-
-        return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
-      }
-
-      function toMatrixID(fname: string, prefix: string): string {
-        const base64 = toBase64Url(fname);
-        return prefix + base64;
-      }
-
       let url = gif.url.startsWith('mxc://')
         ? gif.url
         : `mxc://${clientConfig.gifs?.proxyUrl ?? ''}/${toMatrixID(gif.url.slice('https://static.klipy.com/ii/'.length), 'klipy_')}`;

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -64,7 +64,7 @@ import {
   BlockType,
 } from '$components/editor';
 import { plainToEditorInput } from '$components/editor/input';
-import { EmojiBoard, EmojiBoardTab } from '$components/emoji-board';
+import { EmojiBoard, EmojiBoardTab, GifData } from '$components/emoji-board';
 import { UseStateProvider } from '$components/UseStateProvider';
 import type { TUploadContent } from '$utils/matrix';
 import { encryptFile, getImageInfo, mxcUrlToHttp, toggleReaction } from '$utils/matrix';
@@ -179,6 +179,8 @@ import { AudioMessageRecorder } from './AudioMessageRecorder';
 import * as prefix from '$unstable/prefixes';
 import { PollDialog } from './poll-modals';
 import { LocationDialog } from './location-modal';
+import { useClientConfig } from '$hooks/useClientConfig';
+import { GifIcon } from '@phosphor-icons/react';
 
 // Returns the event ID of the most recent non-reaction/non-edit event in a thread,
 // falling back to the thread root if no replies exist yet.
@@ -277,6 +279,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     // don't clobber the main room draft (and vice versa).
     const draftKey = threadRootId ?? roomId;
     const mx = useMatrixClient();
+    const clientConfig = useClientConfig();
     const useAuthentication = useMediaAuthentication();
     const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
     const [editorOldAddFile] = useSetting(settingsAtom, 'editorOldAddFile');
@@ -1304,6 +1307,57 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       mx.sendEvent(roomId, EventType.Sticker, content);
     };
 
+    const handleGifSelect = async (gif: GifData) => {
+      function toBase64Url(value: string): string {
+        const bytes = new TextEncoder().encode(value);
+        let binary = '';
+
+        for (const byte of bytes) {
+          binary += String.fromCodePoint(byte);
+        }
+
+        return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
+      }
+
+      function toMatrixID(fname: string, prefix: string): string {
+        const base64 = toBase64Url(fname);
+        return prefix + base64;
+      }
+
+      let url = gif.url.startsWith('mxc://')
+        ? gif.url
+        : `mxc://${clientConfig.gifs?.proxyUrl ?? ''}/${toMatrixID(gif.url.slice('https://static.klipy.com/ii/'.length), 'klipy_')}`;
+
+      const content: RoomMessageEventContent & ReplyEventContent & IContent = {
+        body: gif.title,
+        url: url,
+        msgtype: MsgType.Image,
+        info: {
+          w: gif.width,
+          h: gif.height,
+          mimetype: 'image/gif',
+        },
+      };
+
+      // Handle replies if there's a reply draft
+      if (replyDraft) {
+        content['m.relates_to'] = {
+          'm.in_reply_to': {
+            event_id: replyDraft.eventId,
+          },
+        };
+        if (replyDraft.relation?.rel_type === RelationType.Thread) {
+          content['m.relates_to'].event_id = replyDraft.relation.event_id;
+          content['m.relates_to'].rel_type = RelationType.Thread;
+          content['m.relates_to'].is_falling_back = false;
+        }
+      }
+
+      // Send the gif as sticker event.
+      await mx.sendEvent(roomId, EventType.RoomMessage, content);
+      setReplyDraft(undefined);
+    };
+
     return (
       <div ref={ref}>
         {selectedFiles.length > 0 && (
@@ -1702,6 +1756,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                         onEmojiSelect={handleEmoticonSelect}
                         onCustomEmojiSelect={handleEmoticonSelect}
                         onStickerSelect={handleStickerSelect}
+                        onGifSelect={handleGifSelect}
                         requestClose={() => {
                           setEmojiBoardTab((t) => {
                             if (t) {
@@ -1714,6 +1769,17 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                       />
                     }
                   >
+                    <IconButton
+                      aria-pressed={emojiBoardTab === EmojiBoardTab.Gif}
+                      onClick={() => setEmojiBoardTab(EmojiBoardTab.Gif)}
+                      variant="SurfaceVariant"
+                      size="300"
+                      radii="300"
+                    >
+                      {composerIcon(GifIcon, {
+                        weight: emojiBoardTab === EmojiBoardTab.Gif ? 'fill' : 'regular',
+                      })}
+                    </IconButton>
                     {!hideStickerBtn && (
                       <IconButton
                         aria-pressed={emojiBoardTab === EmojiBoardTab.Sticker}
@@ -1732,7 +1798,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                     <IconButton
                       ref={emojiBtnRef}
                       aria-pressed={
-                        hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji
+                        hideStickerBtn
+                          ? emojiBoardTab === EmojiBoardTab.Emoji ||
+                            emojiBoardTab === EmojiBoardTab.Gif
+                          : emojiBoardTab === EmojiBoardTab.Emoji
                       }
                       onClick={() => setEmojiBoardTab(EmojiBoardTab.Emoji)}
                       variant="SurfaceVariant"

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -10,8 +10,9 @@ import {
   loadImageElement,
   loadVideoElement,
 } from '$utils/dom';
-import { encryptFile, getImageInfo, getThumbnailContent, getVideoInfo } from '$utils/matrix';
+import { encryptFile, getImageInfo, getThumbnailContent, getVideoInfo, mxcUrlToHttp } from '$utils/matrix';
 import type { TUploadItem } from '$state/room/roomInputDrafts';
+import type { GifData } from '$components/emoji-board/types';
 import { encodeBlurHash } from '$utils/blurHash';
 import { scaleYDimension } from '$utils/common';
 import { createLogger } from '$utils/debug';
@@ -235,5 +236,46 @@ export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
     content.format = 'org.matrix.custom.html';
     content.formatted_body = item.formatted_body;
   }
+  return content;
+};
+
+export const getGifMsgContent = async (
+  mx: MatrixClient,
+  gif: GifData,
+  mxcUrl: string,
+  spoiler?: boolean
+): Promise<IContent> => {
+  const proxyUrl = mxcUrlToHttp(mx, mxcUrl, true);
+  const [imgError, imgEl] = await to(loadImageElement(proxyUrl ?? gif.url, 'anonymous'));
+  if (imgError) {
+    log.warn('Failed to load image element anonymously for blurhash, falling back to basic metadata:', imgError);
+  }
+
+  const content: IContent = {
+    msgtype: MsgType.Image,
+    body: gif.title,
+    url: mxcUrl,
+    info: {
+      w: gif.width,
+      h: gif.height,
+      mimetype: 'image/gif',
+    },
+  };
+  
+  if (gif.size) {
+    content.info.size = gif.size;
+  }
+
+  if (spoiler) {
+    content[MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME] = true;
+  }
+
+  if (imgEl) {
+    const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
+    if (blurHash) {
+      content.info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] = blurHash;
+    }
+  }
+
   return content;
 };

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -10,7 +10,13 @@ import {
   loadImageElement,
   loadVideoElement,
 } from '$utils/dom';
-import { encryptFile, getImageInfo, getThumbnailContent, getVideoInfo, mxcUrlToHttp } from '$utils/matrix';
+import {
+  encryptFile,
+  getImageInfo,
+  getThumbnailContent,
+  getVideoInfo,
+  mxcUrlToHttp,
+} from '$utils/matrix';
 import type { TUploadItem } from '$state/room/roomInputDrafts';
 import type { GifData } from '$components/emoji-board/types';
 import { encodeBlurHash } from '$utils/blurHash';
@@ -248,7 +254,10 @@ export const getGifMsgContent = async (
   const proxyUrl = mxcUrlToHttp(mx, mxcUrl, true);
   const [imgError, imgEl] = await to(loadImageElement(proxyUrl ?? gif.url, 'anonymous'));
   if (imgError) {
-    log.warn('Failed to load image element anonymously for blurhash, falling back to basic metadata:', imgError);
+    log.warn(
+      'Failed to load image element anonymously for blurhash, falling back to basic metadata:',
+      imgError
+    );
   }
 
   const content: IContent = {
@@ -261,7 +270,7 @@ export const getGifMsgContent = async (
       mimetype: 'image/gif',
     },
   };
-  
+
   if (gif.size) {
     content.info.size = gif.size;
   }

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -1218,6 +1218,7 @@ function Embeds() {
     settingsAtom,
     'clientPreviewYoutube'
   );
+  const [enableGifPicker, setEnableGifPicker] = useSetting(settingsAtom, 'enableGifPicker');
   return (
     <Box direction="Column" gap="100">
       <Text size="L400">Embeds</Text>
@@ -1310,6 +1311,21 @@ function Embeds() {
           </SequenceCard>
         </>
       )}
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Enable Gif Picker"
+          focusId="enable-gif-picker"
+          description="Enables the gif picker in the emoji board. This reduces Privacy because it makes requests to klipy.com whenever you search for a gif."
+          after={
+            <Switch
+              variant="Primary"
+              value={enableGifPicker}
+              onChange={setEnableGifPicker}
+              title={enableGifPicker ? 'Disable Gif Picker' : 'Enable Gif Picker'}
+            />
+          }
+        />
+      </SequenceCard>
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile
           title="Show Interactive maps"

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -27,6 +27,7 @@ const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly string[]
     'disable-media-auto-load',
     'display-bundled-embeds',
     'display-multiple-embeds',
+    'enable-gif-picker',
     'embed-youtube-links',
     'emoji-selector-threshold',
     'enable-swiping',

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -7,6 +7,11 @@ export type HashRouterConfig = {
   basename?: string;
 };
 
+export type GifsConfig = {
+  klipyApiKey?: string;
+  proxyUrl?: string;
+};
+
 export type ClientConfig = {
   defaultHomeserver?: number;
   homeserverList?: string[];
@@ -42,6 +47,8 @@ export type ClientConfig = {
   };
 
   hashRouter?: HashRouterConfig;
+
+  gifs?: GifsConfig;
 
   matrixToBaseUrl?: string;
 

--- a/src/app/hooks/useFavoriteGifs.ts
+++ b/src/app/hooks/useFavoriteGifs.ts
@@ -1,0 +1,13 @@
+import { AccountDataEvents } from 'matrix-js-sdk';
+import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '../../unstable/prefixes';
+import { useAccountData } from './useAccountData';
+
+export const useFavoriteGifs =
+  (): AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] => {
+    const favoritedGifsData = useAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS);
+    const favoritedContent = favoritedGifsData?.getContent<
+      AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS]
+    >() ?? { gifs: [] };
+
+    return favoritedContent;
+  };

--- a/src/app/hooks/useFavoriteGifs.ts
+++ b/src/app/hooks/useFavoriteGifs.ts
@@ -2,14 +2,17 @@ import type { AccountDataEvents } from 'matrix-js-sdk';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '../../unstable/prefixes';
 import { useAccountData } from './useAccountData';
 
-const DEFAULT_FAVORITE_GIFS: AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] = { gifs: [] };
+const DEFAULT_FAVORITE_GIFS: AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] = {
+  gifs: [],
+};
 
 export const useFavoriteGifs =
   (): AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] => {
     const favoritedGifsData = useAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS);
-    const favoritedContent = favoritedGifsData?.getContent<
-      AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS]
-    >() ?? DEFAULT_FAVORITE_GIFS;
+    const favoritedContent =
+      favoritedGifsData?.getContent<
+        AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS]
+      >() ?? DEFAULT_FAVORITE_GIFS;
 
     return favoritedContent;
   };

--- a/src/app/hooks/useFavoriteGifs.ts
+++ b/src/app/hooks/useFavoriteGifs.ts
@@ -2,12 +2,14 @@ import type { AccountDataEvents } from 'matrix-js-sdk';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '../../unstable/prefixes';
 import { useAccountData } from './useAccountData';
 
+const DEFAULT_FAVORITE_GIFS: AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] = { gifs: [] };
+
 export const useFavoriteGifs =
   (): AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] => {
     const favoritedGifsData = useAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS);
     const favoritedContent = favoritedGifsData?.getContent<
       AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS]
-    >() ?? { gifs: [] };
+    >() ?? DEFAULT_FAVORITE_GIFS;
 
     return favoritedContent;
   };

--- a/src/app/hooks/useFavoriteGifs.ts
+++ b/src/app/hooks/useFavoriteGifs.ts
@@ -1,4 +1,4 @@
-import { AccountDataEvents } from 'matrix-js-sdk';
+import type { AccountDataEvents } from 'matrix-js-sdk';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '../../unstable/prefixes';
 import { useAccountData } from './useAccountData';
 

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -123,6 +123,7 @@ export interface Settings {
   clientUrlPreview: boolean;
   encClientUrlPreview: boolean;
   clientPreviewYoutube: boolean;
+  enableGifPicker: boolean;
   showInteractiveMap: boolean;
   showEncInteractiveMap: boolean;
 
@@ -265,6 +266,7 @@ export const defaultSettings: Settings = {
   clientUrlPreview: false,
   encClientUrlPreview: false,
   clientPreviewYoutube: false,
+  enableGifPicker: true,
   showInteractiveMap: true,
   showEncInteractiveMap: false,
   showHiddenEvents: false,

--- a/src/app/utils/blurHash.ts
+++ b/src/app/utils/blurHash.ts
@@ -14,8 +14,13 @@ export const encodeBlurHash = (
 
   if (!context) return undefined;
   context.drawImage(img, 0, 0, canvas.width, canvas.height);
-  const data = context.getImageData(0, 0, canvas.width, canvas.height);
-  return encode(data.data, data.width, data.height, 4, 4);
+  try {
+    const data = context.getImageData(0, 0, canvas.width, canvas.height);
+    return encode(data.data, data.width, data.height, 4, 4);
+  } catch (err) {
+    console.warn('Failed to encode blurhash, possibly due to cross-origin tainted canvas:', err);
+    return undefined;
+  }
 };
 
 export const validBlurHash = (hash?: string): string | undefined => {

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -99,9 +99,10 @@ export const getImageFileUrl = (fileOrBlob: File | Blob) => URL.createObjectURL(
 
 export const getVideoFileUrl = (fileOrBlob: File | Blob) => URL.createObjectURL(fileOrBlob);
 
-export const loadImageElement = (url: string): Promise<HTMLImageElement> =>
+export const loadImageElement = (url: string, crossOrigin?: string): Promise<HTMLImageElement> =>
   new Promise((resolve, reject) => {
     const img = document.createElement('img');
+    if (crossOrigin) img.crossOrigin = crossOrigin;
     img.addEventListener('load', () => resolve(img));
     img.addEventListener('error', (err) => reject(err));
     img.src = url;

--- a/src/app/utils/klipy.ts
+++ b/src/app/utils/klipy.ts
@@ -1,0 +1,25 @@
+export function toBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
+}
+
+export function toMatrixID(fname: string, urlPrefix: string): string {
+  const base64 = toBase64Url(fname);
+  return urlPrefix + base64;
+}
+
+export function getKlipyMxcUrl(url: string, proxyUrl?: string): string {
+  if (url.startsWith('mxc://')) return url;
+  if (!proxyUrl) return url;
+  if (url.startsWith('https://static.klipy.com/ii/')) {
+    const id = url.slice('https://static.klipy.com/ii/'.length);
+    return `mxc://${proxyUrl}/${toMatrixID(id, 'klipy_')}`;
+  }
+  return url;
+}

--- a/src/types/matrix-sdk-events.d.ts
+++ b/src/types/matrix-sdk-events.d.ts
@@ -6,6 +6,7 @@ import type { MemberPowerTag } from '$types/matrix/room';
 import type { RoomAbbreviationsContent } from '$utils/abbreviations';
 import type { PronounSet } from '$utils/pronouns';
 import type * as prefix from '$unstable/prefixes';
+import { GifData } from '$components/emoji-board';
 
 type PowerLevelTagsEventContent = Record<number, MemberPowerTag>;
 
@@ -57,5 +58,6 @@ declare module 'matrix-js-sdk/lib/@types/event' {
     [prefix.MATRIX_SABLE_UNSTABLE_ACCOUNT_SETTINGS_PROPERTY_NAME]: Record<string, unknown>;
     [prefix.MATRIX_SABLE_UNSTABLE_DISMISSED_INVITES]: { roomIds: string[] };
     [prefix.MATRIX_SABLE_UNSTABLE_ACCOUNT_ADDED_SERVERS_PROPERTY_NAME]: AddedServersContent;
+    [prefix.MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS]: { gifs: Omit<GifData, 'id'>[] };
   }
 }

--- a/src/types/matrix-sdk-events.d.ts
+++ b/src/types/matrix-sdk-events.d.ts
@@ -6,7 +6,7 @@ import type { MemberPowerTag } from '$types/matrix/room';
 import type { RoomAbbreviationsContent } from '$utils/abbreviations';
 import type { PronounSet } from '$utils/pronouns';
 import type * as prefix from '$unstable/prefixes';
-import { GifData } from '$components/emoji-board';
+import type { GifData } from '$components/emoji-board';
 
 type PowerLevelTagsEventContent = Record<number, MemberPowerTag>;
 

--- a/src/unstable/prefixes/sable/accountdata.ts
+++ b/src/unstable/prefixes/sable/accountdata.ts
@@ -14,3 +14,4 @@ export const MATRIX_SABLE_UNSTABLE_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME =
 
 export const MATRIX_SABLE_UNSTABLE_DISMISSED_INVITES = 'moe.sable.dismissed_invites';
 export const MATRIX_SABLE_UNSTABLE_ACCOUNT_ADDED_SERVERS_PROPERTY_NAME = 'moe.sable.added_servers';
+export const MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS = 'moe.sable.favorite_gifs';


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Based on work in #677.

Gif search functionality using klipy. Set your api token in config.json, also requires a mxc proxy. Favoriting gifs works by using account data.   

Fixes #60 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

I did not use AI for my changes. To quote the original PR:
> The changes to renderItem() to support GIFs were AI generated. It returns GIF Items and ensures they are scaled properly.

Those seem sane.
