### PR TITLE
Fix cat status not being displayed on its own

### DIFF
--- a/.changeset/fix-cat-status.md
+++ b/.changeset/fix-cat-status.md
@@ -1,5 +1,5 @@
 ---
-default: minor
+default: patch
 ---
 
 Fix cat status not being present on its own.

--- a/.changeset/fix-cat-status.md
+++ b/.changeset/fix-cat-status.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Fix cat status not being present on its own.

--- a/src/app/components/user-profile/UserRoomProfile.tsx
+++ b/src/app/components/user-profile/UserRoomProfile.tsx
@@ -253,7 +253,7 @@ function UserExtendedSection({
   );
   return (
     <Box direction="Column" gap="200" style={{ marginBottom: config.space.S100, color: textColor }}>
-      {(pronouns || localTime) && (
+      {(pronouns || localTime || catStatusText) && (
         <Box alignItems="Center" gap="300" wrap="Wrap">
           {pronouns && (
             <Box alignItems="Center" gap="100">


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fixes cat status not being displayed without either pronouns or timezone being present.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

No Ai was used. Instead I have used roughly 1.2 kilojoules of energy to generate this PR with natural stupidity.