### PR TITLE
Fix timeline sorting changing when show hidden events is enabled

### DIFF
--- a/.changeset/fix-timeline-sorting.md
+++ b/.changeset/fix-timeline-sorting.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix timeline sorting order regression when "show hidden events" is enabled.

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -169,15 +169,15 @@ const mergeDraftsAndExtras = (
 
   for (const extra of extraDrafts) {
     const extraTs = extra.mEvent.getTs();
-    while (resultIdx < resultDrafts.length && resultDrafts[resultIdx].mEvent.getTs() <= extraTs) {
-      mergedDrafts.push(resultDrafts[resultIdx]);
+    while (resultIdx < resultDrafts.length && resultDrafts[resultIdx]!.mEvent.getTs() <= extraTs) {
+      mergedDrafts.push(resultDrafts[resultIdx]!);
       resultIdx += 1;
     }
     mergedDrafts.push(extra);
   }
 
   while (resultIdx < resultDrafts.length) {
-    mergedDrafts.push(resultDrafts[resultIdx]);
+    mergedDrafts.push(resultDrafts[resultIdx]!);
     resultIdx += 1;
   }
 

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -146,6 +146,44 @@ const computeCollapseAndDividers = (
   });
 };
 
+const mergeDraftsAndExtras = (
+  result: ProcessedEvent[],
+  extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet }[]
+): ProcessedEventDraft[] => {
+  const resultDrafts = result.map(
+    ({ collapsed: _c, willRenderNewDivider: _n, willRenderDayDivider: _d, ...draft }) => draft
+  );
+
+  const extraDrafts = extras
+    .map(({ mEvent, timelineSet }) => ({
+      id: mEvent.getId()!,
+      itemIndex: -1,
+      mEvent,
+      timelineSet,
+      eventSender: mEvent.getSender() ?? null,
+    }))
+    .toSorted((a, b) => a.mEvent.getTs() - b.mEvent.getTs());
+
+  const mergedDrafts: ProcessedEventDraft[] = [];
+  let resultIdx = 0;
+
+  for (const extra of extraDrafts) {
+    const extraTs = extra.mEvent.getTs();
+    while (resultIdx < resultDrafts.length && resultDrafts[resultIdx].mEvent.getTs() <= extraTs) {
+      mergedDrafts.push(resultDrafts[resultIdx]);
+      resultIdx += 1;
+    }
+    mergedDrafts.push(extra);
+  }
+
+  while (resultIdx < resultDrafts.length) {
+    mergedDrafts.push(resultDrafts[resultIdx]);
+    resultIdx += 1;
+  }
+
+  return mergedDrafts;
+};
+
 const mergeRelationReactions = (
   result: ProcessedEvent[],
   linkedTimelines: EventTimeline[],
@@ -170,21 +208,7 @@ const mergeRelationReactions = (
 
   if (extras.length === 0) return result;
 
-  const mergedDrafts: ProcessedEventDraft[] = [
-    ...result.map(
-      ({ collapsed: _c, willRenderNewDivider: _n, willRenderDayDivider: _d, ...draft }) => draft
-    ),
-    ...extras.map(({ mEvent, timelineSet }) => {
-      const mEventId = mEvent.getId()!;
-      return {
-        id: mEventId,
-        itemIndex: -1,
-        mEvent,
-        timelineSet,
-        eventSender: mEvent.getSender() ?? null,
-      };
-    }),
-  ].toSorted((a, b) => a.mEvent.getTs() - b.mEvent.getTs());
+  const mergedDrafts = mergeDraftsAndExtras(result, extras);
 
   return computeCollapseAndDividers(mergedDrafts, mxUserId, readUptoEventId);
 };
@@ -207,21 +231,7 @@ const mergeRelationEdits = (
 
   if (extras.length === 0) return result;
 
-  const mergedDrafts: ProcessedEventDraft[] = [
-    ...result.map(
-      ({ collapsed: _c, willRenderNewDivider: _n, willRenderDayDivider: _d, ...draft }) => draft
-    ),
-    ...extras.map(({ mEvent, timelineSet }) => {
-      const mEventId = mEvent.getId()!;
-      return {
-        id: mEventId,
-        itemIndex: -1,
-        mEvent,
-        timelineSet,
-        eventSender: mEvent.getSender() ?? null,
-      };
-    }),
-  ].toSorted((a, b) => a.mEvent.getTs() - b.mEvent.getTs());
+  const mergedDrafts = mergeDraftsAndExtras(result, extras);
 
   return computeCollapseAndDividers(mergedDrafts, mxUserId, readUptoEventId);
 };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The reaction and edit events are grabbed from the parent message because sdk something or other (or idk what im doing, probably also true), so they have to be sorted, but I inadvertently sorted the whole timeline instead of just those events. This fixes that.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
