### PR TITLE
Fix encrypted thread messages not appearing

### DIFF
--- a/.changeset/fix-encrypted-thread-messages.md
+++ b/.changeset/fix-encrypted-thread-messages.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix encrypted thread messages not appearing until reopened.

--- a/src/app/features/room/ThreadBrowser.tsx
+++ b/src/app/features/room/ThreadBrowser.tsx
@@ -14,7 +14,7 @@ import {
   toRem,
 } from 'folds';
 import type { EventTimelineSet, MatrixEvent, Room, Thread } from '$types/matrix-sdk';
-import { NotificationCountType, RoomEvent, ThreadEvent } from '$types/matrix-sdk';
+import { MatrixEventEvent, NotificationCountType, RoomEvent, ThreadEvent } from '$types/matrix-sdk';
 import { useAtomValue } from 'jotai';
 import type { HTMLReactParserOptions } from 'html-react-parser';
 import type { Opts as LinkifyOpts } from 'linkifyjs';
@@ -316,9 +316,19 @@ export function ThreadBrowser({ room, onOpenThread, onClose, overlay }: ThreadBr
   // always be a no-op and left threadsReady=true prematurely.
   useEffect(() => {
     const onUpdate = () => forceUpdate((n) => n + 1);
+    const onDecrypted = (mEvent: MatrixEvent) => {
+      if (mEvent.getRoomId() !== room.roomId) return;
+      const relation = mEvent.getRelation();
+      const isThreadRelation = relation?.rel_type === 'm.thread';
+      const threadId = isThreadRelation ? relation.event_id : mEvent.getId();
+      if (threadId && room.getThread(threadId)) {
+        onUpdate();
+      }
+    };
     room.on(ThreadEvent.New, onUpdate);
     room.on(ThreadEvent.Update, onUpdate);
     room.on(ThreadEvent.NewReply, onUpdate);
+    mx.on(MatrixEventEvent.Decrypted, onDecrypted);
 
     let cancelled = false;
     const loadThreads = async () => {
@@ -381,6 +391,7 @@ export function ThreadBrowser({ room, onOpenThread, onClose, overlay }: ThreadBr
       room.off(ThreadEvent.New, onUpdate);
       room.off(ThreadEvent.Update, onUpdate);
       room.off(ThreadEvent.NewReply, onUpdate);
+      mx.off(MatrixEventEvent.Decrypted, onDecrypted);
     };
   }, [room, mx]);
 

--- a/src/app/features/room/ThreadDrawer.tsx
+++ b/src/app/features/room/ThreadDrawer.tsx
@@ -6,6 +6,7 @@ import type { IEvent, Room } from '$types/matrix-sdk';
 import {
   Direction,
   MatrixEvent,
+  MatrixEventEvent,
   PushProcessor,
   ReceiptType,
   RelationType,
@@ -389,6 +390,11 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
         forceUpdate((n) => n + 1);
       }
     };
+    const onDecrypted = (mEvent: MatrixEvent) => {
+      if (isEventInThread(mEvent)) {
+        forceUpdate((n) => n + 1);
+      }
+    };
     const onRedaction = (mEvent: MatrixEvent) => {
       // Redactions (removing reactions/messages) should also trigger updates
       if (isEventInThread(mEvent)) {
@@ -397,11 +403,13 @@ export function ThreadDrawer({ room, threadRootId, onClose, overlay }: ThreadDra
     };
     const onThreadUpdate = () => forceUpdate((n) => n + 1);
     mx.on(RoomEvent.Timeline, onTimeline);
+    mx.on(MatrixEventEvent.Decrypted, onDecrypted);
     room.on(RoomEvent.Redaction, onRedaction);
     room.on(ThreadEvent.Update, onThreadUpdate);
     room.on(ThreadEvent.NewReply, onThreadUpdate);
     return () => {
       mx.off(RoomEvent.Timeline, onTimeline);
+      mx.off(MatrixEventEvent.Decrypted, onDecrypted);
       room.removeListener(RoomEvent.Redaction, onRedaction);
       room.removeListener(ThreadEvent.Update, onThreadUpdate);
       room.removeListener(ThreadEvent.NewReply, onThreadUpdate);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Thread relation data isn't available until the message is decrypted, but nothing was listening for decryption to update threads. Now it does.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
