### PR TITLE
Fix timeline sorting again

### DIFF
--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -148,37 +148,46 @@ const computeCollapseAndDividers = (
 
 const mergeDraftsAndExtras = (
   result: ProcessedEvent[],
-  extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet }[]
+  extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet; parentTs: number }[]
 ): ProcessedEventDraft[] => {
   const resultDrafts = result.map(
     ({ collapsed: _c, willRenderNewDivider: _n, willRenderDayDivider: _d, ...draft }) => draft
   );
 
   const extraDrafts = extras
-    .map(({ mEvent, timelineSet }) => ({
-      id: mEvent.getId()!,
-      itemIndex: -1,
-      mEvent,
-      timelineSet,
-      eventSender: mEvent.getSender() ?? null,
+    .map(({ mEvent, timelineSet, parentTs }) => ({
+      draft: {
+        id: mEvent.getId()!,
+        itemIndex: -1,
+        mEvent,
+        timelineSet,
+        eventSender: mEvent.getSender() ?? null,
+      },
+      effectiveTs: Math.max(mEvent.getTs(), parentTs),
     }))
-    .toSorted((a, b) => a.mEvent.getTs() - b.mEvent.getTs());
+    .toSorted((a, b) => a.effectiveTs - b.effectiveTs);
 
-  const mergedDrafts: ProcessedEventDraft[] = [];
-  let resultIdx = 0;
+  const buckets: ProcessedEventDraft[][] = Array.from(
+    { length: resultDrafts.length + 1 },
+    () => []
+  );
 
   for (const extra of extraDrafts) {
-    const extraTs = extra.mEvent.getTs();
-    while (resultIdx < resultDrafts.length && resultDrafts[resultIdx]!.mEvent.getTs() <= extraTs) {
-      mergedDrafts.push(resultDrafts[resultIdx]!);
-      resultIdx += 1;
+    const extraTs = extra.effectiveTs;
+    let insertIdx = 0;
+    for (let i = resultDrafts.length - 1; i >= 0; i -= 1) {
+      if (resultDrafts[i]!.mEvent.getTs() <= extraTs) {
+        insertIdx = i + 1;
+        break;
+      }
     }
-    mergedDrafts.push(extra);
+    buckets[insertIdx]!.push(extra.draft);
   }
 
-  while (resultIdx < resultDrafts.length) {
-    mergedDrafts.push(resultDrafts[resultIdx]!);
-    resultIdx += 1;
+  const mergedDrafts: ProcessedEventDraft[] = [...buckets[0]!];
+  for (let i = 0; i < resultDrafts.length; i += 1) {
+    mergedDrafts.push(resultDrafts[i]!);
+    mergedDrafts.push(...buckets[i + 1]!);
   }
 
   return mergedDrafts;

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -758,10 +758,10 @@ export const collectRelationReactionEvents = (
   ignoredUsersSet: Set<string>,
   showReactions: boolean,
   showReactionTombstones: boolean
-): { mEvent: MatrixEvent; timelineSet: EventTimelineSet }[] => {
+): { mEvent: MatrixEvent; timelineSet: EventTimelineSet; parentTs: number }[] => {
   if (!showReactions && !showReactionTombstones) return [];
 
-  const extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet }[] = [];
+  const extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet; parentTs: number }[] = [];
   const seen = new Set(existingIds);
 
   for (const timeline of linkedTimelines) {
@@ -785,7 +785,7 @@ export const collectRelationReactionEvents = (
         if (redacted && !showReactionTombstones) continue;
         if (!redacted && !showReactions) continue;
 
-        extras.push({ mEvent: reaction, timelineSet });
+        extras.push({ mEvent: reaction, timelineSet, parentTs: parent.getTs() });
       }
     }
   }
@@ -798,10 +798,10 @@ export const collectRelationEditEvents = (
   existingIds: ReadonlySet<string>,
   ignoredUsersSet: Set<string>,
   showEdits: boolean
-): { mEvent: MatrixEvent; timelineSet: EventTimelineSet }[] => {
+): { mEvent: MatrixEvent; timelineSet: EventTimelineSet; parentTs: number }[] => {
   if (!showEdits) return [];
 
-  const extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet }[] = [];
+  const extras: { mEvent: MatrixEvent; timelineSet: EventTimelineSet; parentTs: number }[] = [];
   const seen = new Set(existingIds);
 
   for (const timeline of linkedTimelines) {
@@ -821,7 +821,7 @@ export const collectRelationEditEvents = (
         const sender = editEvent.getSender();
         if (sender && ignoredUsersSet.has(sender)) continue;
 
-        extras.push({ mEvent: editEvent, timelineSet });
+        extras.push({ mEvent: editEvent, timelineSet, parentTs: parent.getTs() });
       }
     }
   }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed for real this time. Inserts the reaction/edit/whatever at the origin server ts, as long as its after the original messages local timestamp, otherwise we just throw it right after. I think this is the best way to do this?

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
