### PR TITLE
Fix showing images of a member sometimes when showing room icons

### DIFF
--- a/.changeset/feat_add_setting_strict_icons.md
+++ b/.changeset/feat_add_setting_strict_icons.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add option for showing icons only when available and changed default to it

--- a/.changeset/fix_icons_showing_wrongly.md
+++ b/.changeset/fix_icons_showing_wrongly.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Collapsed mode showing the wrong icon

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -267,6 +267,7 @@ type RoomNavItemProps = {
   direct?: boolean;
   customDMCards?: boolean;
   hideText?: boolean;
+  isStrict?: boolean;
   joinCallOnSingleClick?: boolean;
 };
 
@@ -279,6 +280,7 @@ export function RoomNavItem({
   notificationMode,
   linkPath,
   hideText,
+  isStrict,
   joinCallOnSingleClick,
 }: RoomNavItemProps) {
   const mx = useMatrixClient();
@@ -315,6 +317,11 @@ export function RoomNavItem({
   const callPref = useAtomValue(useCallPreferencesAtom());
   const [isChatOpen, setChatOpen] = useAtom(callChatAtom);
   const autoDiscoveryInfo = useAutoDiscoveryInfo();
+
+  const avatarSrc =
+    ((!direct || customDMCards) && getRoomAvatarUrl(mx, room, 96, useAuthentication)) ||
+    (direct && getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)) ||
+    undefined;
 
   const isActiveCall = callEmbed?.roomId === room.roomId;
 
@@ -447,14 +454,10 @@ export function RoomNavItem({
                         radii="400"
                         style={hideTextStyling(hideText)}
                       >
-                        {showAvatar ? (
+                        {showAvatar || (avatarSrc && isStrict) ? (
                           <RoomAvatar
                             roomId={room.roomId}
-                            src={
-                              direct && !customDMCards
-                                ? getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)
-                                : getRoomAvatarUrl(mx, room, 96, useAuthentication)
-                            }
+                            src={avatarSrc}
                             uniformIcons
                             alt={roomName}
                             renderFallback={() => (
@@ -472,7 +475,7 @@ export function RoomNavItem({
                                   : config.opacity.P300,
                             }}
                             filled={selected || isActiveCall}
-                            size="200"
+                            size={isStrict && hideText ? '300' : '200'}
                             joinRule={room.getJoinRule()}
                             roomType={room.getType()}
                             withOverlay={roomIconOverlay}

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -451,9 +451,9 @@ export function RoomNavItem({
                           <RoomAvatar
                             roomId={room.roomId}
                             src={
-                              ((!direct || customDMCards) &&
-                                getRoomAvatarUrl(mx, room, 96, useAuthentication)) ||
-                              getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)
+                              direct && !customDMCards
+                                ? getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)
+                                : getRoomAvatarUrl(mx, room, 96, useAuthentication)
                             }
                             uniformIcons
                             alt={roomName}

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -893,20 +893,21 @@ export function Appearance({
 
             <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
               <SettingTile
-                title="Show Room Icons In Sidebars"
-                focusId="show-room-icons"
-                description="When do you want to show the specific room icons in the sidebar as opposed to the default room icons?"
-                after={<SelectShowRoomIcon />}
-              />
-            </SequenceCard>
-            <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-              <SettingTile
                 title="Overlay Room Privacy Icons"
                 focusId="room-icon-overlay"
                 description="When enabled, public and private rooms show a globe or lock badge over the room hash icon in the sidebar. When disabled, show the globe or lock icon alone."
                 after={
                   <Switch variant="Primary" value={roomIconOverlay} onChange={setRoomIconOverlay} />
                 }
+              />
+            </SequenceCard>
+
+            <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+              <SettingTile
+                title="Show Room Icons In Sidebars"
+                focusId="show-room-icons"
+                description="When do you want to show the specific room icons in the sidebar as opposed to the default room icons?"
+                after={<SelectShowRoomIcon />}
               />
             </SequenceCard>
             {/*THIS SHOULD BE MOVED TO A NEW SETTINGS MENU INSIDE OF THE HOME SETTINGS AS SOON AS THERE IS A REASON TO CREATE A HOME MENU SETTINGS PANEL

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -28,7 +28,8 @@ import {
 } from '$plugins/arborium';
 import { ThemeKind, useActiveTheme } from '$hooks/useTheme';
 import { useSetting } from '$state/hooks/settings';
-import type { PixelatedImageRenderingMode, ShowRoomIcon } from '$state/settings';
+import type { PixelatedImageRenderingMode } from '$state/settings';
+import { ShowRoomIcon } from '$state/settings';
 import { settingsAtom } from '$state/settings';
 import { SequenceCardStyle } from '$features/settings/styles.css';
 import { ThemeAppearanceSection } from './ThemeAppearanceSection';
@@ -809,6 +810,7 @@ export function Appearance({
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
   const [customDMCards, setCustomDMCards] = useSetting(settingsAtom, 'customDMCards');
   const [showEasterEggs, setShowEasterEggs] = useSetting(settingsAtom, 'showEasterEggs');
+  const [showRoomIcon] = useSetting(settingsAtom, 'showRoomIcon');
   const [themeBrowserOpen, setThemeBrowserOpen] = useState(false);
   const [closeFoldersByDefault, setCloseFoldersByDefault] = useSetting(
     settingsAtom,
@@ -906,7 +908,23 @@ export function Appearance({
               <SettingTile
                 title="Show Room Icons In Sidebars"
                 focusId="show-room-icons"
-                description="When do you want to show the specific room icons in the sidebar as opposed to the default room icons?"
+                description={
+                  <>
+                    <Text size="T200">
+                      When do you want to show the specific room icons in the sidebar?
+                    </Text>
+                    {(showRoomIcon === ShowRoomIcon.Always &&
+                      'Always show icons, and fallback to initials') ||
+                      (showRoomIcon === ShowRoomIcon.Strict &&
+                        'Show icons when available, but fallback to hashes') ||
+                      (showRoomIcon === ShowRoomIcon.Smart &&
+                        'Show icons only when sidebar is minimized, else icons.') ||
+                      (showRoomIcon === ShowRoomIcon.Never &&
+                        'Never show icons, always only the hashes.') ||
+                      ''}
+                    <span style={{ opacity: '50%' }}>{' (current)'}</span>
+                  </>
+                }
                 after={<SelectShowRoomIcon />}
               />
             </SequenceCard>

--- a/src/app/hooks/useShowRoomIcon.ts
+++ b/src/app/hooks/useShowRoomIcon.ts
@@ -14,8 +14,12 @@ export const useShowRoomIcon = (): MessageLayoutItem[] =>
         name: 'Always',
       },
       {
+        layout: ShowRoomIcon.Strict,
+        name: 'Sometimes',
+      },
+      {
         layout: ShowRoomIcon.Smart,
-        name: 'Smart',
+        name: 'Collapsed',
       },
       {
         layout: ShowRoomIcon.Never,
@@ -37,8 +41,12 @@ export const useShowPerRoomRoomIcon = (): MessageLayoutItem[] =>
         name: 'Always',
       },
       {
+        layout: ShowRoomIcon.Strict,
+        name: 'Sometimes',
+      },
+      {
         layout: ShowRoomIcon.Smart,
-        name: 'Smart',
+        name: 'Collapsed',
       },
       {
         layout: ShowRoomIcon.Never,

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -1037,6 +1037,7 @@ export function Space() {
                             room.roomId
                           )}
                           joinCallOnSingleClick={joinCallOnSingleClick}
+                          isStrict={showRoomIcon === ShowRoomIcon.Strict}
                         />
                       </div>
                     </VirtualTile>

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -26,6 +26,7 @@ export enum CaptionPosition {
 
 export enum ShowRoomIcon {
   Always = 'always',
+  Strict = 'strict',
   Smart = 'smart',
   Never = 'never',
 }
@@ -348,7 +349,7 @@ export const defaultSettings: Settings = {
   showPersonaSetting: false,
   closeFoldersByDefault: false,
   perRoomShowRoomIcon: [],
-  showRoomIcon: ShowRoomIcon.Smart,
+  showRoomIcon: ShowRoomIcon.Strict,
   roomIconOverlay: true,
   showRoomBanners: true,
   roomSidebarWidth: 256,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fix showing images of a member sometimes when showing room icons and add view for showing icons when available and not any other time and change default to it.

<img width="483" height="249" alt="image" src="https://github.com/user-attachments/assets/f0c524f3-5070-4300-8352-15686bd9e582" />

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #963
Fixes #962 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Written with the assistance of a kneading eraser used as a stimming tool