### PR TITLE
Add CTRL+E shortcut to editor to bring sticker menu up

### DIFF
--- a/.changeset/feat_add_sticker_shortcut.md
+++ b/.changeset/feat_add_sticker_shortcut.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add CTRL+E shortcut to editor to bring sticker menu up

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -16,7 +16,7 @@ import { atom, useAtom, useSetAtom } from 'jotai';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { IEmoji } from '$plugins/emoji';
 import { emojiGroups, emojis } from '$plugins/emoji';
-import { preventScrollWithArrowKey, stopPropagation } from '$utils/keyboard';
+import { preventScrollWithArrowKey } from '$utils/keyboard';
 import { useRelevantImagePacks } from '$hooks/useImagePacks';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useRecentEmoji } from '$hooks/useRecentEmoji';
@@ -545,7 +545,7 @@ export function EmojiBoard({
           !editableActiveElement() && isKeyHotkey(['arrowdown', 'arrowright'], evt),
         isKeyBackward: (evt: KeyboardEvent) =>
           !editableActiveElement() && isKeyHotkey(['arrowup', 'arrowleft'], evt),
-        escapeDeactivates: stopPropagation,
+        escapeDeactivates: true,
       }}
     >
       <EmojiBoardLayout

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -429,6 +429,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const setServerMaxDelayMs = useSetAtom(serverMaxDelayMsAtom);
     const [sendError, setSendError] = useState<string | undefined>();
     const isEncrypted = room.hasEncryptionStateEvent();
+    const [emojiBoardTab, setEmojiBoardTab] = useState<EmojiBoardTab | undefined>(undefined);
 
     useElementSizeObserver(
       useCallback(() => fileDropContainerRef.current, [fileDropContainerRef]),
@@ -1179,6 +1180,11 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           }
           setReplyDraft(undefined);
         }
+
+        if (isKeyHotkey('control+e', evt)) {
+          evt.preventDefault();
+          setEmojiBoardTab(EmojiBoardTab.Sticker);
+        }
       },
       [
         submit,
@@ -1190,6 +1196,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         showAudioRecorder,
         editor,
         onEditLastMessage,
+        setEmojiBoardTab,
       ]
     );
 
@@ -1671,7 +1678,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
               <MarkdownFormattingToolbarToggle variant="SurfaceVariant" />
 
               <UseStateProvider initial={undefined}>
-                {(emojiBoardTab: EmojiBoardTab | undefined, setEmojiBoardTab) => (
+                {() => (
                   <PopOut
                     offset={16}
                     alignOffset={-44}

--- a/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
+++ b/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
@@ -44,6 +44,7 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
       { keys: 'Ctrl+B / ⌘+B', description: 'Bold' },
       { keys: 'Ctrl+I / ⌘+I', description: 'Italic' },
       { keys: 'Ctrl+U / ⌘+U', description: 'Underline' },
+      { keys: 'Ctrl+E / ⌘+E', description: 'Open Sticker Picker' },
     ],
   },
 ];


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds Ctrl+E as a shortcut to bring up sticker board. As there is the autocomplete there is no new shortcut to bring emoji board up, but it can be switched to kb only by pressing shirt+tab then space then typing out the query.

Note that this addition is to editor so the editor must be focused in order to bring the sticker menu up.

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #949 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

Written with the assistance of one of those weird fidget cube that turns into spikey things and vice versa.
