### PR TITLE
Add a context menu for copying and downloading images

### DIFF
--- a/.changeset/feat_add_image_menu.md
+++ b/.changeset/feat_add_image_menu.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a context menu for copying and downloading images.

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -1,7 +1,21 @@
+import type { MouseEventHandler } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import FileSaver from 'file-saver';
 import classNames from 'classnames';
-import { Box, Chip, Header, IconButton, Text, as } from 'folds';
+import {
+  Box,
+  Chip,
+  Header,
+  IconButton,
+  Menu,
+  MenuItem,
+  PopOut,
+  type RectCords,
+  Text,
+  as,
+  config,
+  toRem,
+} from 'folds';
 import {
   ArrowLeft,
   ArrowsClockwise,
@@ -9,6 +23,7 @@ import {
   Image,
   Minus,
   Plus,
+  menuIcon,
   phosphorSizeRem,
   sizedIcon,
 } from '$components/icons/phosphor';
@@ -18,7 +33,10 @@ import { isPixelatedRendering, settingsAtom } from '$state/settings';
 import { downloadMedia } from '$utils/matrix';
 import * as css from './ImageViewer.css';
 import type { IImageInfo } from '$types/matrix/common';
-import { CheckerboardIcon } from '@phosphor-icons/react';
+import { CheckerboardIcon, CopyIcon, DownloadIcon } from '@phosphor-icons/react';
+import FocusTrap from 'focus-trap-react';
+import { stopPropagation } from '$utils/keyboard';
+import { copyImageToClipboard } from '$utils/dom';
 
 export type ImageViewerProps = {
   alt: string;
@@ -83,195 +101,263 @@ export const ImageViewer = as<'div', ImageViewerProps>(
       FileSaver.saveAs(fileContent, alt);
     };
 
+    const [menuAnchor, setMenuAnchor] = useState<RectCords>();
+
+    const handleContextMenu: MouseEventHandler<HTMLDivElement> = (evt) => {
+      if (evt.altKey || !window.getSelection()?.isCollapsed) return;
+      const tag = (evt.target as HTMLElement).tagName;
+      if (typeof tag === 'string' && tag.toLowerCase() === 'a') return;
+
+      evt.preventDefault();
+      setMenuAnchor({
+        x: evt.clientX,
+        y: evt.clientY,
+        width: 0,
+        height: 0,
+      });
+    };
+
     return (
-      <Box
-        className={classNames(css.ImageViewer, className)}
-        direction="Column"
-        {...props}
-        ref={ref}
-      >
-        <Header className={css.ImageViewerHeader} size="400">
-          <Box grow="Yes" alignItems="Center" gap="200">
-            <IconButton size="300" radii="300" onClick={requestClose}>
-              {sizedIcon(ArrowLeft, '200')}
-            </IconButton>
-            <Text size="T300" truncate>
-              {alt}
-            </Text>
-          </Box>
-          <Box shrink="No" alignItems="Center" gap="200">
-            <IconButton
-              variant="Surface"
-              size="300"
-              radii="Pill"
-              onClick={() => setIsPixelated(!isPixelated)}
-              aria-label="Toggle Pixelation"
-              title={`Turn ${isPixelated ? 'Anti-aliasing' : 'Pixelation'} on`}
+      <>
+        <PopOut
+          anchor={menuAnchor}
+          align={menuAnchor?.width === 0 ? 'Start' : 'End'}
+          offset={menuAnchor?.width === 0 ? 0 : undefined}
+          content={
+            <FocusTrap
+              focusTrapOptions={{
+                initialFocus: false,
+                onDeactivate: () => setMenuAnchor(undefined),
+                clickOutsideDeactivates: true,
+                escapeDeactivates: stopPropagation,
+              }}
             >
-              <CheckerboardIcon
-                size={phosphorSizeRem(20)}
-                weight={isPixelated ? 'duotone' : 'fill'}
-              />
-            </IconButton>
-            <IconButton
-              variant="Surface"
-              style={{
-                // Only show when the image isn't already larger than the container
-                // and isn't already at 100% zoom
-                // (Otherwise, the Reset Zoom button does the same thing)
-                display: fitRatio !== 1 && transforms.zoom !== 1 ? 'flex' : 'none',
-              }}
-              size="300"
-              radii="Pill"
-              onClick={() => {
-                setZoom(1);
-              }}
-              aria-label="View Original Size"
-              title="View Original Size"
-            >
-              {sizedIcon(Image, '200')}
-            </IconButton>
-            <IconButton
-              variant="Surface"
-              style={{
-                // Only show when the image has had any transforms applied (zoom or pan)
-                display:
-                  transforms.zoom !== fitRatio || transforms.pan.x !== 0 || transforms.pan.y !== 0
-                    ? 'flex'
-                    : 'none',
-              }}
-              size="300"
-              radii="Pill"
-              onClick={() => {
-                resetTransforms();
-                enableResizeWithWindow();
-                setZoom(fitRatio);
-              }}
-              aria-label="Reset Zoom"
-              title="Zoom to Fill Container"
-            >
-              {sizedIcon(ArrowsClockwise, '200')}
-            </IconButton>
-            <IconButton
-              variant={transforms.zoom < 1 ? 'Success' : 'SurfaceVariant'}
-              outlined={transforms.zoom < 1}
-              size="300"
-              radii="Pill"
-              onClick={zoomOut}
-              aria-label="Zoom Out"
-              title="Zoom Out"
-            >
-              {sizedIcon(Minus, '50')}
-            </IconButton>
-            <Chip
-              variant="SurfaceVariant"
-              radii="Pill"
-              style={{
-                // For zoom levels below 100%, keep the pill at the same size as it would be at 100% zoom.
-                // This prevents the Zoom Out button from moving from the pill changing size.
-                // 4em should be generous enough to fit without manually determining the width of the text.
-                minWidth: '4em',
-              }}
-              onClick={() => {
-                setZoomInput(Math.round(transforms.zoom * 100).toString());
-                setIsEditingZoom(true);
-              }}
-              title="Update Zoom"
-            >
-              <Text
-                size="B300"
-                style={{
-                  cursor: 'text',
-                  margin: 'auto',
-                }}
+              <Menu variant="Surface" style={{ maxWidth: toRem(160), width: '100vw' }}>
+                <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                  <MenuItem
+                    as="button"
+                    radii="300"
+                    size="300"
+                    after={menuIcon(CopyIcon)}
+                    onClick={async () => {
+                      setMenuAnchor(undefined);
+                      const fileContent = await downloadMedia(src);
+                      await copyImageToClipboard(fileContent);
+                    }}
+                  >
+                    <Text size="T300" style={{ flexGrow: 1 }}>
+                      Copy image
+                    </Text>
+                  </MenuItem>
+                  <MenuItem
+                    as="button"
+                    radii="300"
+                    size="300"
+                    after={menuIcon(DownloadIcon)}
+                    onClick={() => {
+                      setMenuAnchor(undefined);
+                      handleDownload();
+                    }}
+                  >
+                    <Text size="T300" style={{ flexGrow: 1 }}>
+                      Save image
+                    </Text>
+                  </MenuItem>
+                </Box>
+              </Menu>
+            </FocusTrap>
+          }
+        />
+        <Box
+          className={classNames(css.ImageViewer, className)}
+          direction="Column"
+          {...props}
+          ref={ref}
+        >
+          <Header className={css.ImageViewerHeader} size="400">
+            <Box grow="Yes" alignItems="Center" gap="200">
+              <IconButton size="300" radii="300" onClick={requestClose}>
+                {sizedIcon(ArrowLeft, '200')}
+              </IconButton>
+              <Text size="T300" truncate>
+                {alt}
+              </Text>
+            </Box>
+            <Box shrink="No" alignItems="Center" gap="200">
+              <IconButton
+                variant="Surface"
+                size="300"
+                radii="Pill"
+                onClick={() => setIsPixelated(!isPixelated)}
+                aria-label="Toggle Pixelation"
+                title={`Turn ${isPixelated ? 'Anti-aliasing' : 'Pixelation'} on`}
               >
-                {isEditingZoom ? (
-                  <span>
-                    <input
-                      className={css.ImageViewerInput}
-                      ref={zoomInputRef}
-                      type="text"
-                      aria-label="Set Zoom Level"
-                      value={zoomInput}
-                      onChange={(e) => {
-                        setZoomInput(e.target.value);
-                      }}
-                      onBlur={() => {
-                        const next = parseInt(zoomInput, 10);
-                        if (!Number.isNaN(next)) {
-                          setZoom(next / 100);
-                        }
-                        setIsEditingZoom(false);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
+                <CheckerboardIcon
+                  size={phosphorSizeRem(20)}
+                  weight={isPixelated ? 'duotone' : 'fill'}
+                />
+              </IconButton>
+              <IconButton
+                variant="Surface"
+                style={{
+                  // Only show when the image isn't already larger than the container
+                  // and isn't already at 100% zoom
+                  // (Otherwise, the Reset Zoom button does the same thing)
+                  display: fitRatio !== 1 && transforms.zoom !== 1 ? 'flex' : 'none',
+                }}
+                size="300"
+                radii="Pill"
+                onClick={() => {
+                  setZoom(1);
+                }}
+                aria-label="View Original Size"
+                title="View Original Size"
+              >
+                {sizedIcon(Image, '200')}
+              </IconButton>
+              <IconButton
+                variant="Surface"
+                style={{
+                  // Only show when the image has had any transforms applied (zoom or pan)
+                  display:
+                    transforms.zoom !== fitRatio || transforms.pan.x !== 0 || transforms.pan.y !== 0
+                      ? 'flex'
+                      : 'none',
+                }}
+                size="300"
+                radii="Pill"
+                onClick={() => {
+                  resetTransforms();
+                  enableResizeWithWindow();
+                  setZoom(fitRatio);
+                }}
+                aria-label="Reset Zoom"
+                title="Zoom to Fill Container"
+              >
+                {sizedIcon(ArrowsClockwise, '200')}
+              </IconButton>
+              <IconButton
+                variant={transforms.zoom < 1 ? 'Success' : 'SurfaceVariant'}
+                outlined={transforms.zoom < 1}
+                size="300"
+                radii="Pill"
+                onClick={zoomOut}
+                aria-label="Zoom Out"
+                title="Zoom Out"
+              >
+                {sizedIcon(Minus, '50')}
+              </IconButton>
+              <Chip
+                variant="SurfaceVariant"
+                radii="Pill"
+                style={{
+                  // For zoom levels below 100%, keep the pill at the same size as it would be at 100% zoom.
+                  // This prevents the Zoom Out button from moving from the pill changing size.
+                  // 4em should be generous enough to fit without manually determining the width of the text.
+                  minWidth: '4em',
+                }}
+                onClick={() => {
+                  setZoomInput(Math.round(transforms.zoom * 100).toString());
+                  setIsEditingZoom(true);
+                }}
+                title="Update Zoom"
+              >
+                <Text
+                  size="B300"
+                  style={{
+                    cursor: 'text',
+                    margin: 'auto',
+                  }}
+                >
+                  {isEditingZoom ? (
+                    <span>
+                      <input
+                        className={css.ImageViewerInput}
+                        ref={zoomInputRef}
+                        type="text"
+                        aria-label="Set Zoom Level"
+                        value={zoomInput}
+                        onChange={(e) => {
+                          setZoomInput(e.target.value);
+                        }}
+                        onBlur={() => {
                           const next = parseInt(zoomInput, 10);
                           if (!Number.isNaN(next)) {
                             setZoom(next / 100);
                           }
                           setIsEditingZoom(false);
-                        }
-                      }}
-                    />
-                    <span>%</span>
-                  </span>
-                ) : (
-                  `${Math.round(transforms.zoom * 100)}%`
-                )}
-              </Text>
-            </Chip>
-            <IconButton
-              variant={transforms.zoom > 1 ? 'Success' : 'SurfaceVariant'}
-              outlined={transforms.zoom > 1}
-              size="300"
-              radii="Pill"
-              onClick={zoomIn}
-              aria-label="Zoom In"
-              title="Zoom In"
-            >
-              {sizedIcon(Plus, '50')}
-            </IconButton>
-            <Chip
-              variant="Primary"
-              onClick={handleDownload}
-              radii="300"
-              before={sizedIcon(Download, '50')}
-              outlined
-            >
-              <Text size="B300">Download</Text>
-            </Chip>
-          </Box>
-        </Header>
-        <Box
-          grow="Yes"
-          ref={containerRef}
-          onWheel={handleWheel}
-          className={css.ImageViewerContent}
-          data-gestures="ignore"
-          justifyContent="Center"
-          alignItems="Center"
-          style={{ overflow: 'hidden', touchAction: 'none', cursor }}
-          onPointerDown={onPointerDown}
-        >
-          <img
-            className={classNames(css.ImageViewerImg, isPixelated && css.ImageViewerImgPixelated)}
-            draggable={false}
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            const next = parseInt(zoomInput, 10);
+                            if (!Number.isNaN(next)) {
+                              setZoom(next / 100);
+                            }
+                            setIsEditingZoom(false);
+                          }
+                        }}
+                      />
+                      <span>%</span>
+                    </span>
+                  ) : (
+                    `${Math.round(transforms.zoom * 100)}%`
+                  )}
+                </Text>
+              </Chip>
+              <IconButton
+                variant={transforms.zoom > 1 ? 'Success' : 'SurfaceVariant'}
+                outlined={transforms.zoom > 1}
+                size="300"
+                radii="Pill"
+                onClick={zoomIn}
+                aria-label="Zoom In"
+                title="Zoom In"
+              >
+                {sizedIcon(Plus, '50')}
+              </IconButton>
+              <Chip
+                variant="Primary"
+                onClick={handleDownload}
+                radii="300"
+                before={sizedIcon(Download, '50')}
+                outlined
+              >
+                <Text size="B300">Download</Text>
+              </Chip>
+            </Box>
+          </Header>
+          <Box
+            grow="Yes"
+            ref={containerRef}
+            onWheel={handleWheel}
+            className={css.ImageViewerContent}
             data-gestures="ignore"
-            style={{
-              cursor,
-              opacity: isImageReady ? 1 : 0, // Hide image until fit to container
-              transform: `translate(${transforms.pan.x}px, ${transforms.pan.y}px) scale(${transforms.zoom})`,
-            }}
-            src={src}
-            alt={alt}
+            justifyContent="Center"
+            alignItems="Center"
+            style={{ overflow: 'hidden', touchAction: 'none', cursor }}
             onPointerDown={onPointerDown}
-            onLoad={(event: React.SyntheticEvent<HTMLImageElement>) => {
-              handleImageLoad(event);
-              setIsImageReady(true);
-            }}
-          />
+            onContextMenu={handleContextMenu}
+          >
+            <img
+              className={classNames(css.ImageViewerImg, isPixelated && css.ImageViewerImgPixelated)}
+              draggable={false}
+              data-gestures="ignore"
+              style={{
+                cursor,
+                opacity: isImageReady ? 1 : 0, // Hide image until fit to container
+                transform: `translate(${transforms.pan.x}px, ${transforms.pan.y}px) scale(${transforms.zoom})`,
+              }}
+              src={src}
+              alt={alt}
+              onPointerDown={onPointerDown}
+              onLoad={(event: React.SyntheticEvent<HTMLImageElement>) => {
+                handleImageLoad(event);
+                setIsImageReady(true);
+              }}
+            />
+          </Box>
         </Box>
-      </Box>
+      </>
     );
   }
 );

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -187,16 +187,51 @@ export const scrollToBottom = (scrollEl: HTMLElement, behavior?: 'auto' | 'insta
   });
 };
 
-export const copyImageToClipboard = async (blob: Blob): Promise<boolean> => {
-  if (navigator.clipboard) {
-    try {
-      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-      return true;
-    } catch {
-      return false;
-    }
+async function getBitmap(blob: Blob): Promise<ImageBitmap> {
+  if (!blob.type.startsWith('image/svg+xml')) return createImageBitmap(blob);
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+
+    await new Promise<void>((resolve, reject) => {
+      img.addEventListener('load', () => resolve(), { once: true });
+      img.addEventListener('error', reject, { once: true });
+      img.src = url;
+    });
+
+    return await createImageBitmap(img);
+  } finally {
+    URL.revokeObjectURL(url);
   }
-  return false;
+}
+
+export const copyImageToClipboard = async (blob: Blob): Promise<boolean> => {
+  const bitmap = await getBitmap(blob);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+
+  const ctx = canvas.getContext('2d');
+  ctx?.drawImage(bitmap, 0, 0);
+
+  try {
+    const finalBlob = await new Promise<Blob>((resolve) => {
+      canvas.toBlob((result) => {
+        if (result) resolve(result);
+      }, 'image/png');
+    });
+
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        'image/png': finalBlob,
+      }),
+    ]);
+
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 export const copyToClipboard = async (text: string): Promise<boolean> => {

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -187,6 +187,18 @@ export const scrollToBottom = (scrollEl: HTMLElement, behavior?: 'auto' | 'insta
   });
 };
 
+export const copyImageToClipboard = async (blob: Blob): Promise<boolean> => {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+};
+
 export const copyToClipboard = async (text: string): Promise<boolean> => {
   if (navigator.clipboard) {
     try {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds a context menu for copying and downloading images in the `ImageViewer`. Useful for electron/tauri users.

<img width="1036" height="1086" alt="image" src="https://github.com/user-attachments/assets/e3b07381-c76c-4bbe-8b5c-e9492bb7d10c" />


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Fueled by the rage of using sable electron.