### PR TITLE
Fix other image viewer crash locations

### DIFF
--- a/src/app/features/message-search/SearchResultGroup.tsx
+++ b/src/app/features/message-search/SearchResultGroup.tsx
@@ -85,7 +85,7 @@ function renderSearchStickerImageContent(
       {...props}
       autoPlay={mediaAutoLoad}
       renderImage={LazyImage}
-      renderViewer={ImageViewer}
+      renderViewer={(p) => <ImageViewer {...p} />}
     />
   );
 }

--- a/src/app/pages/client/inbox/Notifications.tsx
+++ b/src/app/pages/client/inbox/Notifications.tsx
@@ -225,7 +225,7 @@ function renderNotificationStickerImageContent(
       {...props}
       autoPlay={mediaAutoLoad}
       renderImage={NotificationLazyImage}
-      renderViewer={ImageViewer}
+      renderViewer={(p) => <ImageViewer {...p} />}
     />
   );
 }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Same fix as #972, just applied to a couple other locations (inbox and search) where it also regressed.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
