### PR TITLE
Fix timeline items being rerendered constantly

### DIFF
--- a/.changeset/stop-silly-rerenders.md
+++ b/.changeset/stop-silly-rerenders.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed the entire timeline being rerendered every time you scroll :P

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  memo,
 } from 'react';
 import type { Editor } from 'slate';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -48,7 +49,7 @@ import { useSpaceOptionally } from '$hooks/useSpace';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { useIgnoredUsers } from '$hooks/useIgnoredUsers';
 import { useImagePackRooms } from '$hooks/useImagePackRooms';
-import { settingsAtom, MessageLayout } from '$state/settings';
+import { settingsAtom, MessageLayout, type MessageSpacing } from '$state/settings';
 import { useHiddenEventSettings, useSetting } from '$state/hooks/settings';
 import { nicknamesAtom } from '$state/nicknames';
 import { useRoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
@@ -102,6 +103,116 @@ const getDayDividerText = (ts: number) => {
   if (yesterday(ts)) return 'Yesterday';
   return timeDayMonthYear(ts);
 };
+
+const MemoizedTimelineItem = memo(function MemoizedTimelineItem({
+  eventData,
+  index,
+  showLoadingPlaceholders,
+  canPaginateBack,
+  backPaginationJSX,
+  room,
+  messageLayout,
+  messageSpacing,
+  renderMatrixEvent,
+}: {
+  eventData: ProcessedEvent | undefined;
+  index: number;
+  showLoadingPlaceholders: boolean;
+  canPaginateBack: boolean;
+  backPaginationJSX: ReactNode | undefined;
+  room: Room;
+  messageLayout: MessageLayout;
+  messageSpacing: MessageSpacing;
+  renderMatrixEvent: ReturnType<typeof useTimelineEventRenderer>;
+}) {
+  if (showLoadingPlaceholders) {
+    return (
+      <MessageBase key={`placeholder-${index}`}>
+        {messageLayout === MessageLayout.Compact ? <CompactPlaceholder /> : <DefaultPlaceholder />}
+      </MessageBase>
+    );
+  }
+
+  if (!eventData) {
+    if (index === 0 && !canPaginateBack) {
+      return (
+        <Fragment key="intro-and-first">
+          {backPaginationJSX}
+          <div
+            style={{
+              padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
+            }}
+          >
+            <RoomIntro room={room} />
+          </div>
+        </Fragment>
+      );
+    }
+    if (index === 0) return <Fragment key="first">{backPaginationJSX}</Fragment>;
+    return <Fragment key={index} />;
+  }
+
+  const renderedEvent = renderMatrixEvent(
+    eventData.mEvent.getType(),
+    typeof eventData.mEvent.getStateKey() === 'string',
+    eventData.id,
+    eventData.mEvent,
+    eventData.itemIndex,
+    eventData.timelineSet,
+    eventData.collapsed
+  );
+
+  const showDividers = renderedEvent !== null;
+
+  const dividers = showDividers ? (
+    <>
+      {eventData.willRenderDayDivider && (
+        <MessageBase space={messageSpacing}>
+          <TimelineDivider variant="Surface">
+            <Badge as="span" size="500" variant="Secondary" fill="None" radii="300">
+              <Text size="L400">{getDayDividerText(eventData.mEvent.getTs())}</Text>
+            </Badge>
+          </TimelineDivider>
+        </MessageBase>
+      )}
+      {eventData.willRenderNewDivider && (
+        <MessageBase space={messageSpacing}>
+          <TimelineDivider style={{ color: color.Success.Main }} variant="Inherit">
+            <Badge as="span" size="500" variant="Success" fill="Solid" radii="300">
+              <Text size="L400">New Messages</Text>
+            </Badge>
+          </TimelineDivider>
+        </MessageBase>
+      )}
+    </>
+  ) : null;
+
+  if (index === 0) {
+    return (
+      <Fragment key="first-item-block">
+        {!canPaginateBack && (
+          <div
+            style={{
+              padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
+            }}
+          >
+            <RoomIntro room={room} />
+          </div>
+        )}
+        {backPaginationJSX}
+        {dividers}
+        {renderedEvent}
+      </Fragment>
+    );
+  }
+
+  return (
+    <Fragment key={eventData.id}>
+      {dividers}
+      {renderedEvent}
+    </Fragment>
+  );
+});
 
 export type RoomTimelineProps = {
   room: Room;
@@ -903,99 +1014,20 @@ export function RoomTimeline({
           }}
           onScroll={handleVListScroll}
         >
-          {(eventData, index) => {
-            if (showLoadingPlaceholders) {
-              return (
-                <MessageBase key={`placeholder-${index}`}>
-                  {messageLayout === MessageLayout.Compact ? (
-                    <CompactPlaceholder />
-                  ) : (
-                    <DefaultPlaceholder />
-                  )}
-                </MessageBase>
-              );
-            }
-
-            if (!eventData) {
-              if (index === 0 && !timelineSync.canPaginateBack) {
-                return (
-                  <Fragment key="intro-and-first">
-                    {backPaginationJSX}
-                    <div
-                      style={{
-                        padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
-                      }}
-                    >
-                      <RoomIntro room={room} />
-                    </div>
-                  </Fragment>
-                );
-              }
-              if (index === 0) return <Fragment key="first">{backPaginationJSX}</Fragment>;
-              return <Fragment key={index} />;
-            }
-
-            const renderedEvent = renderMatrixEvent(
-              eventData.mEvent.getType(),
-              typeof eventData.mEvent.getStateKey() === 'string',
-              eventData.id,
-              eventData.mEvent,
-              eventData.itemIndex,
-              eventData.timelineSet,
-              eventData.collapsed
-            );
-
-            const showDividers = renderedEvent !== null;
-
-            const dividers = showDividers ? (
-              <>
-                {eventData.willRenderDayDivider && (
-                  <MessageBase space={messageSpacing}>
-                    <TimelineDivider variant="Surface">
-                      <Badge as="span" size="500" variant="Secondary" fill="None" radii="300">
-                        <Text size="L400">{getDayDividerText(eventData.mEvent.getTs())}</Text>
-                      </Badge>
-                    </TimelineDivider>
-                  </MessageBase>
-                )}
-                {eventData.willRenderNewDivider && (
-                  <MessageBase space={messageSpacing}>
-                    <TimelineDivider style={{ color: color.Success.Main }} variant="Inherit">
-                      <Badge as="span" size="500" variant="Success" fill="Solid" radii="300">
-                        <Text size="L400">New Messages</Text>
-                      </Badge>
-                    </TimelineDivider>
-                  </MessageBase>
-                )}
-              </>
-            ) : null;
-
-            if (index === 0) {
-              return (
-                <Fragment key="first-item-block">
-                  {!timelineSync.canPaginateBack && (
-                    <div
-                      style={{
-                        padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
-                      }}
-                    >
-                      <RoomIntro room={room} />
-                    </div>
-                  )}
-                  {backPaginationJSX}
-                  {dividers}
-                  {renderedEvent}
-                </Fragment>
-              );
-            }
-
-            return (
-              <Fragment key={eventData.id}>
-                {dividers}
-                {renderedEvent}
-              </Fragment>
-            );
-          }}
+          {(eventData, index) => (
+            <MemoizedTimelineItem
+              key={eventData ? eventData.id : `placeholder-${index}`}
+              eventData={eventData}
+              index={index}
+              showLoadingPlaceholders={showLoadingPlaceholders}
+              canPaginateBack={timelineSync.canPaginateBack}
+              backPaginationJSX={backPaginationJSX}
+              room={room}
+              messageLayout={messageLayout}
+              messageSpacing={messageSpacing}
+              renderMatrixEvent={renderMatrixEvent}
+            />
+          )}
         </VList>
       </div>
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

So as Niki pointed out while working on galleries (i think?) timeline items rerender a lot. I never noticed, but uh, turns out this might matter for weaker devices, and comparing them side by side I do actually notice now.

We we're memoizing the components *within* timeline items, but the timeline items themselves we're being called every single scroll tick, which reduced the efficiency of that inner memoization quite a bit. 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
