### PR TITLE
Further timeline performance improvements

### DIFF
--- a/.changeset/fix-direct-embeds-not-rendering.md
+++ b/.changeset/fix-direct-embeds-not-rendering.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix some image embeds not creating embeds.

--- a/.changeset/fix-empty-localparts.md
+++ b/.changeset/fix-empty-localparts.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Allow rooms with empty local parts to be viewed.

--- a/.changeset/some-other-performance-optimizations.md
+++ b/.changeset/some-other-performance-optimizations.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Various performance optimizations

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -177,7 +177,7 @@ function RenderMessageContentInternal({
             const { url } = item;
             if (themeToRender.includes(url)) return null;
             if (tweakCandidateUrls.includes(url)) return null;
-            
+
             if (!themeChatSableWidgets && isSableChatEmbedCandidate(url)) return null;
             if (clientUrlPreview && youtubeUrl(url)) {
               return <ClientPreview key={url} url={url} />;

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -174,18 +174,16 @@ function RenderMessageContentInternal({
             <TweakPreviewUrlCard key={`tweak:${url}`} url={url} />
           ))}
           {toRender.map((item) => {
-            const { url, type } = item;
+            const { url } = item;
             if (themeToRender.includes(url)) return null;
             if (tweakCandidateUrls.includes(url)) return null;
-            if (type) {
-              return <UrlPreviewCard urlPreview key={url} url={url} ts={ts} mediaType={type} />;
-            }
+            
             if (!themeChatSableWidgets && isSableChatEmbedCandidate(url)) return null;
             if (clientUrlPreview && youtubeUrl(url)) {
               return <ClientPreview key={url} url={url} />;
             }
             if (urlPreview) {
-              return <UrlPreviewCard urlPreview key={url} url={url} ts={ts} mediaType={type} />;
+              return <UrlPreviewCard urlPreview key={url} url={url} ts={ts} />;
             }
             return null;
           })}

--- a/src/app/components/message/PollEvent.tsx
+++ b/src/app/components/message/PollEvent.tsx
@@ -114,7 +114,7 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
   const [updateCounter, setUpdateCounter] = useState(0);
 
   useEffect(() => {
-    const handleUpdate = () => setUpdateCounter(c => c + 1);
+    const handleUpdate = () => setUpdateCounter((c) => c + 1);
     room.on(RoomEvent.Timeline, handleUpdate);
     return () => {
       room.off(RoomEvent.Timeline, handleUpdate);
@@ -127,7 +127,7 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
       ?.getUnfilteredTimelineSet()
       .relations.getAllChildEventsForEvent(eventId ?? '')
       .filter((event) => event.getRelation()?.rel_type === REFERENCE_RELATION.name);
-      
+
     let newChildEvents = latestChildEvents ? sortChildEvents(latestChildEvents) : [];
     const newEndIndex = getEndIndex(newChildEvents);
 

--- a/src/app/components/message/PollEvent.tsx
+++ b/src/app/components/message/PollEvent.tsx
@@ -20,6 +20,7 @@ import {
   M_POLL_RESPONSE,
   M_POLL_START,
   REFERENCE_RELATION,
+  RoomEvent,
   type MatrixEvent,
 } from 'matrix-js-sdk';
 import * as css from './PollEvent.css';
@@ -110,18 +111,30 @@ export function PollEvent({ content, mEvent, mx, room }: PollEventProps) {
   // manual sorting because the timeline is sometimes sent stupidly <3
   const [sortedChildEvents, setSortedChildEvents] = useState(sortChildEvents(childEvents));
   const [isEnded, setIsEnded] = useState(getEndIndex(sortedChildEvents) !== -1);
+  const [updateCounter, setUpdateCounter] = useState(0);
+
+  useEffect(() => {
+    const handleUpdate = () => setUpdateCounter(c => c + 1);
+    room.on(RoomEvent.Timeline, handleUpdate);
+    return () => {
+      room.off(RoomEvent.Timeline, handleUpdate);
+    };
+  }, [room]);
 
   // ensure a new sorted array is only generated when a new list is made
   useEffect(() => {
-    let newChildEvents = childEvents ? sortChildEvents(childEvents) : [];
+    const latestChildEvents = room
+      ?.getUnfilteredTimelineSet()
+      .relations.getAllChildEventsForEvent(eventId ?? '')
+      .filter((event) => event.getRelation()?.rel_type === REFERENCE_RELATION.name);
+      
+    let newChildEvents = latestChildEvents ? sortChildEvents(latestChildEvents) : [];
     const newEndIndex = getEndIndex(newChildEvents);
 
     setSortedChildEvents(newChildEvents);
     setIsEnded(newEndIndex !== -1);
-
-    // This is to avoid recomputation for anything but the childEvents changing
     // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
-  }, [childEvents.length, sortChildEvents, getEndIndex]);
+  }, [updateCounter, sortChildEvents, getEndIndex, room, eventId]);
 
   if (!content) return null;
   const finalArray = isEnded

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -80,19 +80,15 @@ export const UrlPreviewCard = as<
     urlPreview: boolean;
     url: string;
     ts?: number;
-    mediaType?: string | null;
     bundle?: IPreviewUrlResponse;
   }
->(({ urlPreview, url, ts, mediaType, bundle, ...props }, ref) => {
+>(({ urlPreview, url, ts, bundle, ...props }, ref) => {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
   const [linkPreviewImageMaxHeight] = useSetting(settingsAtom, 'linkPreviewImageMaxHeight');
 
-  const isDirect = !!mediaType;
-
   const [previewStatus, loadPreview] = useAsyncCallback(
     useCallback(() => {
-      if (isDirect) return Promise.resolve(null);
       if (!ts && !bundle) return Promise.resolve(null);
       if (urlPreview && ts) {
         const clientCache = getClientCache(mx);
@@ -104,7 +100,7 @@ export const UrlPreviewCard = as<
         return previewResult;
       }
       return Promise.resolve(bundle);
-    }, [isDirect, ts, bundle, urlPreview, mx, url])
+    }, [ts, bundle, urlPreview, mx, url])
   );
 
   useEffect(() => {
@@ -355,25 +351,9 @@ export const UrlPreviewCard = as<
     <UrlPreview
       {...props}
       ref={ref}
-      style={
-        isDirect
-          ? {
-              background: 'transparent',
-              border: 'none',
-              padding: 0,
-              boxShadow: 'none',
-              display: 'inline-block',
-              verticalAlign: 'middle',
-              width: 'max-content',
-              minWidth: 0,
-              maxWidth: '100%',
-              margin: 0,
-              alignSelf: 'start',
-            }
-          : {
-              alignSelf: 'start',
-            }
-      }
+      style={{
+        alignSelf: 'start',
+      }}
     >
       {previewContent}
     </UrlPreview>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -104,116 +104,153 @@ const getDayDividerText = (ts: number) => {
   return timeDayMonthYear(ts);
 };
 
-const MemoizedTimelineItem = memo(function MemoizedTimelineItem({
-  eventData,
-  index,
-  showLoadingPlaceholders,
-  canPaginateBack,
-  backPaginationJSX,
-  room,
-  messageLayout,
-  messageSpacing,
-  renderMatrixEvent,
-}: {
-  eventData: ProcessedEvent | undefined;
-  index: number;
-  showLoadingPlaceholders: boolean;
-  canPaginateBack: boolean;
-  backPaginationJSX: ReactNode | undefined;
-  room: Room;
-  messageLayout: MessageLayout;
-  messageSpacing: MessageSpacing;
-  renderMatrixEvent: ReturnType<typeof useTimelineEventRenderer>;
-}) {
-  if (showLoadingPlaceholders) {
-    return (
-      <MessageBase key={`placeholder-${index}`}>
-        {messageLayout === MessageLayout.Compact ? <CompactPlaceholder /> : <DefaultPlaceholder />}
-      </MessageBase>
-    );
-  }
-
-  if (!eventData) {
-    if (index === 0 && !canPaginateBack) {
+const MemoizedTimelineItem = memo(
+  function MemoizedTimelineItem({
+    eventData,
+    index,
+    showLoadingPlaceholders,
+    canPaginateBack,
+    backPaginationJSX,
+    room,
+    messageLayout,
+    messageSpacing,
+    renderMatrixEvent,
+  }: {
+    eventData: ProcessedEvent | undefined;
+    index: number;
+    showLoadingPlaceholders: boolean;
+    canPaginateBack: boolean;
+    backPaginationJSX: ReactNode | undefined;
+    room: Room;
+    messageLayout: MessageLayout;
+    messageSpacing: MessageSpacing;
+    renderMatrixEvent: ReturnType<typeof useTimelineEventRenderer>;
+    focusItem: unknown;
+    editId: string | undefined;
+    activeReplyId: string | undefined | null;
+    openThreadId: string | undefined;
+  }) {
+    if (showLoadingPlaceholders) {
       return (
-        <Fragment key="intro-and-first">
+        <MessageBase key={`placeholder-${index}`}>
+          {messageLayout === MessageLayout.Compact ? (
+            <CompactPlaceholder />
+          ) : (
+            <DefaultPlaceholder />
+          )}
+        </MessageBase>
+      );
+    }
+
+    if (!eventData) {
+      if (index === 0 && !canPaginateBack) {
+        return (
+          <Fragment key="intro-and-first">
+            {backPaginationJSX}
+            <div
+              style={{
+                padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
+              }}
+            >
+              <RoomIntro room={room} />
+            </div>
+          </Fragment>
+        );
+      }
+      if (index === 0) return <Fragment key="first">{backPaginationJSX}</Fragment>;
+      return <Fragment key={index} />;
+    }
+
+    const renderedEvent = renderMatrixEvent(
+      eventData.mEvent.getType(),
+      typeof eventData.mEvent.getStateKey() === 'string',
+      eventData.id,
+      eventData.mEvent,
+      eventData.itemIndex,
+      eventData.timelineSet,
+      eventData.collapsed
+    );
+
+    const showDividers = renderedEvent !== null;
+
+    const dividers = showDividers ? (
+      <>
+        {eventData.willRenderDayDivider && (
+          <MessageBase space={messageSpacing}>
+            <TimelineDivider variant="Surface">
+              <Badge as="span" size="500" variant="Secondary" fill="None" radii="300">
+                <Text size="L400">{getDayDividerText(eventData.mEvent.getTs())}</Text>
+              </Badge>
+            </TimelineDivider>
+          </MessageBase>
+        )}
+        {eventData.willRenderNewDivider && (
+          <MessageBase space={messageSpacing}>
+            <TimelineDivider style={{ color: color.Success.Main }} variant="Inherit">
+              <Badge as="span" size="500" variant="Success" fill="Solid" radii="300">
+                <Text size="L400">New Messages</Text>
+              </Badge>
+            </TimelineDivider>
+          </MessageBase>
+        )}
+      </>
+    ) : null;
+
+    if (index === 0) {
+      return (
+        <Fragment key="first-item-block">
+          {!canPaginateBack && (
+            <div
+              style={{
+                padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
+              }}
+            >
+              <RoomIntro room={room} />
+            </div>
+          )}
           {backPaginationJSX}
-          <div
-            style={{
-              padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
-            }}
-          >
-            <RoomIntro room={room} />
-          </div>
+          {dividers}
+          {renderedEvent}
         </Fragment>
       );
     }
-    if (index === 0) return <Fragment key="first">{backPaginationJSX}</Fragment>;
-    return <Fragment key={index} />;
-  }
 
-  const renderedEvent = renderMatrixEvent(
-    eventData.mEvent.getType(),
-    typeof eventData.mEvent.getStateKey() === 'string',
-    eventData.id,
-    eventData.mEvent,
-    eventData.itemIndex,
-    eventData.timelineSet,
-    eventData.collapsed
-  );
-
-  const showDividers = renderedEvent !== null;
-
-  const dividers = showDividers ? (
-    <>
-      {eventData.willRenderDayDivider && (
-        <MessageBase space={messageSpacing}>
-          <TimelineDivider variant="Surface">
-            <Badge as="span" size="500" variant="Secondary" fill="None" radii="300">
-              <Text size="L400">{getDayDividerText(eventData.mEvent.getTs())}</Text>
-            </Badge>
-          </TimelineDivider>
-        </MessageBase>
-      )}
-      {eventData.willRenderNewDivider && (
-        <MessageBase space={messageSpacing}>
-          <TimelineDivider style={{ color: color.Success.Main }} variant="Inherit">
-            <Badge as="span" size="500" variant="Success" fill="Solid" radii="300">
-              <Text size="L400">New Messages</Text>
-            </Badge>
-          </TimelineDivider>
-        </MessageBase>
-      )}
-    </>
-  ) : null;
-
-  if (index === 0) {
     return (
-      <Fragment key="first-item-block">
-        {!canPaginateBack && (
-          <div
-            style={{
-              padding: `${config.space.S700} ${config.space.S400} ${config.space.S600} ${messageLayout === MessageLayout.Compact ? config.space.S400 : toRem(64)}`,
-            }}
-          >
-            <RoomIntro room={room} />
-          </div>
-        )}
-        {backPaginationJSX}
+      <Fragment key={eventData.id}>
         {dividers}
         {renderedEvent}
       </Fragment>
     );
+  },
+  (prev, next) => {
+    if (prev.index !== next.index) return false;
+    if (prev.showLoadingPlaceholders !== next.showLoadingPlaceholders) return false;
+    if (prev.canPaginateBack !== next.canPaginateBack) return false;
+    if (prev.room !== next.room) return false;
+    if (prev.messageLayout !== next.messageLayout) return false;
+    if (prev.messageSpacing !== next.messageSpacing) return false;
+    if (prev.renderMatrixEvent !== next.renderMatrixEvent) return false;
+
+    if (prev.focusItem !== next.focusItem) return false;
+    if (prev.editId !== next.editId) return false;
+    if (prev.activeReplyId !== next.activeReplyId) return false;
+    if (prev.openThreadId !== next.openThreadId) return false;
+
+    if (prev.index === 0 && prev.backPaginationJSX !== next.backPaginationJSX) return false;
+
+    if (prev.eventData === next.eventData) return true;
+    if (!prev.eventData || !next.eventData) return false;
+
+    return (
+      prev.eventData.id === next.eventData.id &&
+      prev.eventData.collapsed === next.eventData.collapsed &&
+      prev.eventData.willRenderNewDivider === next.eventData.willRenderNewDivider &&
+      prev.eventData.willRenderDayDivider === next.eventData.willRenderDayDivider &&
+      prev.eventData.mEvent === next.eventData.mEvent &&
+      prev.eventData.eventSender === next.eventData.eventSender
+    );
   }
-
-  return (
-    <Fragment key={eventData.id}>
-      {dividers}
-      {renderedEvent}
-    </Fragment>
-  );
-});
-
+);
 export type RoomTimelineProps = {
   room: Room;
   eventId?: string;
@@ -1026,6 +1063,10 @@ export function RoomTimeline({
               messageLayout={messageLayout}
               messageSpacing={messageSpacing}
               renderMatrixEvent={renderMatrixEvent}
+              focusItem={timelineSync.focusItem}
+              editId={editId}
+              activeReplyId={activeReplyId}
+              openThreadId={openThreadId}
             />
           )}
         </VList>

--- a/src/app/hooks/useMatrixEventRenderer.ts
+++ b/src/app/hooks/useMatrixEventRenderer.ts
@@ -1,3 +1,4 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 
 export type EventRenderer<T extends unknown[]> = (...args: T) => ReactNode;
@@ -10,22 +11,28 @@ export type RenderMatrixEvent<T extends unknown[]> = (
   ...args: T
 ) => ReactNode;
 
-export const useMatrixEventRenderer =
-  <T extends unknown[]>(
-    typeToRenderer: EventRendererOpts<T>,
-    renderStateEvent?: EventRenderer<T>,
-    renderEvent?: EventRenderer<T>
-  ): RenderMatrixEvent<T> =>
-  (eventType, isStateEvent, ...args) => {
-    const renderer = typeToRenderer[eventType];
+export const useMatrixEventRenderer = <T extends unknown[]>(
+  typeToRenderer: EventRendererOpts<T>,
+  renderStateEvent?: EventRenderer<T>,
+  renderEvent?: EventRenderer<T>
+): RenderMatrixEvent<T> => {
+  const latestRef = useRef({ typeToRenderer, renderStateEvent, renderEvent });
+
+  useLayoutEffect(() => {
+    latestRef.current = { typeToRenderer, renderStateEvent, renderEvent };
+  });
+
+  return useCallback((eventType: string, isStateEvent: boolean, ...args: T) => {
+    const renderer = latestRef.current.typeToRenderer[eventType];
     if (renderer) return renderer(...args);
 
-    if (isStateEvent && renderStateEvent) {
-      return renderStateEvent(...args);
+    if (isStateEvent && latestRef.current.renderStateEvent) {
+      return latestRef.current.renderStateEvent(...args);
     }
 
-    if (!isStateEvent && renderEvent) {
-      return renderEvent(...args);
+    if (!isStateEvent && latestRef.current.renderEvent) {
+      return latestRef.current.renderEvent(...args);
     }
     return null;
-  };
+  }, []);
+};

--- a/src/app/utils/mxIdHelper.ts
+++ b/src/app/utils/mxIdHelper.ts
@@ -1,4 +1,4 @@
 export const matchMxId = (id: string): RegExpMatchArray | null =>
-  id.match(/^([@$+#])([^\s:]+):(\S+)$/);
+  id.match(/^([@$+#])([^\s:]*):(\S+)$/);
 export const validMxId = (id: string): boolean => !!matchMxId(id);
 export const getMxIdServer = (userId: string): string | undefined => matchMxId(userId)?.[3];

--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -283,8 +283,8 @@ const pruneInvalidEmptyElements = (
   });
 };
 
-let purifyInstance: DOMPurify.DOMPurifyI | undefined;
-function getPurify(): DOMPurify.DOMPurifyI {
+let purifyInstance: ReturnType<typeof DOMPurify> | undefined;
+function getPurify(): ReturnType<typeof DOMPurify> {
   if (!purifyInstance) {
     purifyInstance = DOMPurify(window);
   }

--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -283,13 +283,22 @@ const pruneInvalidEmptyElements = (
   });
 };
 
+let purifyInstance: DOMPurify.DOMPurifyI | undefined;
+function getPurify(): DOMPurify.DOMPurifyI {
+  if (!purifyInstance) {
+    purifyInstance = DOMPurify(window);
+  }
+  return purifyInstance;
+}
+
 export const sanitizeCustomHtml = (customHtml: string): string => {
   if (typeof window === 'undefined') {
     return sanitizeText(customHtml);
   }
 
   const { protectedHtml, protectedSources } = protectImageSources(customHtml);
-  const purify = DOMPurify(window);
+  const purify = getPurify();
+  purify.removeAllHooks();
   const allowedHtmlAttributes = [...permittedHtmlAttributes, INTERNAL_IMG_SRC_ATTR];
 
   purify.addHook('uponSanitizeAttribute', (currentNode, hookEvent) => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Smarter memoization of timeline events to prevent complete rerenders when new messages come in/reactions/etc
Avoids creating multiple dom purify instances
Allows rooms without local parts to be viewed, e.g. #:maunium.net
Removed a legacy direct media render path for bigger images that's no longer used, and was inadvertently filtering out many urls

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
