### PR TITLE
Hide register link when registration is disabled

### DIFF
--- a/.changeset/hide-register-when-disabled.md
+++ b/.changeset/hide-register-when-disabled.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Hide the "Register" link on the login page when the homeserver has registration disabled and offers no SSO to register through, so you are no longer sent to a dead-end registration page.

--- a/src/app/pages/auth/login/Login.tsx
+++ b/src/app/pages/auth/login/Login.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Box, Text, color } from 'folds';
 import { Link, useSearchParams } from 'react-router-dom';
 import { SSOAction } from '$types/matrix-sdk';
-import { useAuthFlows } from '$hooks/useAuthFlows';
+import { RegisterFlowStatus, useAuthFlows } from '$hooks/useAuthFlows';
 import { useAuthServer } from '$hooks/useAuthServer';
 import { useParsedLoginFlows } from '$hooks/useParsedLoginFlows';
 import { getLoginPath, getRegisterPath, withSearchParam } from '$pages/pathUtils';
@@ -38,7 +38,7 @@ export function Login() {
   const server = useAuthServer();
   const { hashRouter } = useClientConfig();
   const { hideUsernamePasswordFields } = useClientConfig();
-  const { loginFlows } = useAuthFlows();
+  const { loginFlows, registerFlows } = useAuthFlows();
   const [searchParams] = useSearchParams();
   const loginSearchParams = useLoginSearchParams(searchParams);
   const ssoRedirectUrl = usePathWithOrigin(getLoginPath(server));
@@ -60,6 +60,9 @@ export function Login() {
   const registerUrl = isAddingAccount
     ? withSearchParam(getRegisterPath(server), { addAccount: '1' })
     : getRegisterPath(server);
+
+  const registrationUnavailable =
+    registerFlows.status === RegisterFlowStatus.RegistrationDisabled && !parsedFlows.sso;
 
   return (
     <Box direction="Column" gap="500">
@@ -98,9 +101,11 @@ export function Login() {
           <span data-spacing-node />
         </>
       )}
-      <Text align="Center">
-        Do not have an account? <Link to={registerUrl}>Register</Link>
-      </Text>
+      {!registrationUnavailable && (
+        <Text align="Center">
+          Do not have an account? <Link to={registerUrl}>Register</Link>
+        </Text>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
### Description

When a homeserver has registration disabled, the Login page still showed a "Do not have an account? Register" prompt that led to a dead-end Register page (which only renders "Registration has been disabled on this homeserver."). This hides that prompt when registration is genuinely unavailable, the server reports registration disabled (403 `M_FORBIDDEN`) and offers no SSO flow to register through. Password and SSO login are unaffected, and the Register page keeps its message as a fallback for direct navigation.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- fmt:check, lint, typecheck, knip and test:run all pass locally. -->

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

code completion and 2nd review
