### PR TITLE
fix: allow joining spaces with sliding sync enabled

### DIFF
--- a/.changeset/fix-space-join-sliding-sync.md
+++ b/.changeset/fix-space-join-sliding-sync.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix joining spaces with sliding sync enabled.

--- a/src/app/features/join-before-navigate/JoinBeforeNavigate.tsx
+++ b/src/app/features/join-before-navigate/JoinBeforeNavigate.tsx
@@ -1,6 +1,7 @@
 import { Box, IconButton, Scroll, Text, toRem } from 'folds';
 import { ArrowLeft, composerIcon } from '$components/icons/phosphor';
 import { useAtomValue } from 'jotai';
+import { RoomType } from '$types/matrix-sdk';
 import { RoomCard } from '$components/room-card';
 import { RoomTopicViewer } from '$components/room-topic-viewer';
 import { Page, PageHeader } from '$components/page';
@@ -22,8 +23,8 @@ export function JoinBeforeNavigate({
   const { navigateRoom, navigateSpace } = useRoomNavigate();
   const screenSize = useScreenSizeContext();
 
-  const handleView = (roomId: string) => {
-    if (mx.getRoom(roomId)?.isSpaceRoom()) {
+  const handleView = (roomId: string, roomType?: string) => {
+    if (mx.getRoom(roomId)?.isSpaceRoom() || roomType === RoomType.Space) {
       navigateSpace(roomId);
       return;
     }
@@ -67,7 +68,7 @@ export function JoinBeforeNavigate({
                   renderTopicViewer={(name, topic, requestClose) => (
                     <RoomTopicViewer name={name} topic={topic} requestClose={requestClose} />
                   )}
-                  onView={handleView}
+                  onView={(roomId) => handleView(roomId, summary?.room_type)}
                 />
               )}
             </RoomSummaryLoader>

--- a/src/app/pages/client/space/SpaceProvider.tsx
+++ b/src/app/pages/client/space/SpaceProvider.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import { useSpaces } from '$state/hooks/roomList';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useSelectedSpace } from '$hooks/router/useSelectedSpace';
 import { SpaceProvider } from '$hooks/useSpace';
@@ -13,7 +13,7 @@ type RouteSpaceProviderProps = {
 };
 export function RouteSpaceProvider({ children }: RouteSpaceProviderProps) {
   const mx = useMatrixClient();
-  const joinedSpaces = useSpaces(mx, allRoomsAtom);
+  const allRooms = useAtomValue(allRoomsAtom);
 
   const { spaceIdOrAlias: encodedSpaceIdOrAlias } = useParams();
   const spaceIdOrAlias = encodedSpaceIdOrAlias && decodeURIComponent(encodedSpaceIdOrAlias);
@@ -22,7 +22,7 @@ export function RouteSpaceProvider({ children }: RouteSpaceProviderProps) {
   const selectedSpaceId = useSelectedSpace();
   const space = mx.getRoom(selectedSpaceId);
 
-  if (!space || !joinedSpaces.includes(space.roomId)) {
+  if (!space || !allRooms.includes(space.roomId)) {
     return <JoinBeforeNavigate roomIdOrAlias={spaceIdOrAlias ?? ''} viaServers={viaServers} />;
   }
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

With sliding sync enabled, joining a space was impossible. The root cause was a navigation dead-end: when a room's m.room.create event wasn't yet in the client store (common with sliding sync's delivery model), isSpaceRoom() returned false, causing spaces to be misrouted.

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
