### PR TITLE
fix: render redacted messages as deleted instead of unsupported

### DIFF
--- a/.changeset/fix-redacted-message-display.md
+++ b/.changeset/fix-redacted-message-display.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix redacted messages rendering as "Unsupported message (no body)" instead of "Message deleted" with sliding sync.

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -562,6 +562,7 @@ export function useTimelineEventRenderer({
         const baseContent = mEvent.getContent() || {};
         const safeContent =
           Object.keys(baseContent).length > 0 ? baseContent : mEvent.getOriginalContent();
+        const isContentEmpty = Object.keys(safeContent).length === 0;
 
         const getContent = (() => editedNewContent ?? safeContent) as GetContentCallback;
 
@@ -669,7 +670,7 @@ export function useTimelineEventRenderer({
             hour24Clock={hour24Clock}
             dateFormatString={dateFormatString}
           >
-            {mEvent.isRedacted() ? (
+            {mEvent.isRedacted() || isContentEmpty ? (
               <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
             ) : (
               <RenderMessageContent
@@ -1039,6 +1040,7 @@ export function useTimelineEventRenderer({
         const baseContent = mEvent.getContent() || {};
         const safeContent =
           Object.keys(baseContent).length > 0 ? baseContent : mEvent.getOriginalContent();
+        const isContentEmpty = Object.keys(safeContent).length === 0;
 
         const getContent = (() => editedNewContent ?? safeContent) as GetContentCallback;
 
@@ -1146,7 +1148,7 @@ export function useTimelineEventRenderer({
             hour24Clock={hour24Clock}
             dateFormatString={dateFormatString}
           >
-            {mEvent.isRedacted() ? (
+            {mEvent.isRedacted() || isContentEmpty ? (
               <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
             ) : (
               <RenderMessageContent


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When sliding sync delivers a message that has been redacted, the redaction event may not be in the client's timeline. In this case, mEvent.isRedacted() returns false even though the event content has already been stripped to {}.


Sable's timeline renderer only checked isRedacted(), so these messages fell through to the fallback renderer and displayed as "Unsupported message (no body)".
This adds an isContentEmpty check (Object.keys(safeContent).length === 0) so that m.room.message events with empty content render as "Message deleted" instead.

<img width="321" height="73" alt="Screenshot 2026-07-15 at 22 57 30" src="https://github.com/user-attachments/assets/82cae806-1a14-473d-b45c-045de6032b81" />


```json
{
"content": {},
"origin_server_ts": 1784136316933
},
...
{
   "content": {
                "redacts": "$3xt7_zZiHMYPEdrDXaEFvu5cPtv-flc-oijPuv9elbU"
            },
            "origin_server_ts": 1784136364105,
```

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
