### PR TITLE
fix: render redacted state events as deleted instead of hiding them

### DIFF
--- a/.changeset/fix-redacted-state-events.md
+++ b/.changeset/fix-redacted-state-events.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Display redacted state events (membership, room name/topic/avatar, pins and other state events) as a "deleted" tombstone in the timeline instead of rendering them with empty/redacted content or hiding them, so the reply-to of a redaction highlights the redacted event.

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -1178,9 +1178,10 @@ export function useTimelineEventRenderer({
         if (membershipChanged && hideMembershipEvents) return null;
         if (!membershipChanged && hideNickAvatarEvents) return null;
 
+        const isRedacted = mEvent.isRedacted();
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const marked = activeReplyId === mEventId && !suppressMark;
-        const parsed = parseMemberEvent(mEvent);
+        const parsed = isRedacted ? null : parseMemberEvent(mEvent);
 
         const timeJSX = (
           <Time
@@ -1259,19 +1260,24 @@ export function useTimelineEventRenderer({
             <EventContent
               messageLayout={messageLayout}
               time={timeJSX}
-              icon={parsed.icon}
+              icon={parsed?.icon ?? timelineIcon(Trash)}
               content={
-                <Text size="T300" priority="300">
-                  <Box direction="Row" style={{ flexWrap: 'wrap', columnGap: toRem(6) }}>
-                    {parsed.body}
-                  </Box>
-                </Text>
+                isRedacted ? (
+                  <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+                ) : (
+                  <Text size="T300" priority="300">
+                    <Box direction="Row" style={{ flexWrap: 'wrap', columnGap: toRem(6) }}>
+                      {parsed?.body}
+                    </Box>
+                  </Text>
+                )
               }
             />
           </Message>
         );
       },
       [EventType.RoomName]: (mEventId, mEvent, item, timelineSet, collapse) => {
+        const isRedacted = mEvent.isRedacted();
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
@@ -1353,20 +1359,25 @@ export function useTimelineEventRenderer({
             <EventContent
               messageLayout={messageLayout}
               time={timeJSX}
-              icon={timelineIcon(Hash)}
+              icon={isRedacted ? timelineIcon(Trash) : timelineIcon(Hash)}
               content={
-                <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
-                    <DecoratedUser userId={senderId} userName={senderName} room={room} />
-                    {t('Organisms.RoomCommon.changed_room_name')}
-                  </Text>
-                </Box>
+                isRedacted ? (
+                  <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+                ) : (
+                  <Box grow="Yes" direction="Column">
+                    <Text size="T300" priority="300">
+                      <DecoratedUser userId={senderId} userName={senderName} room={room} />
+                      {t('Organisms.RoomCommon.changed_room_name')}
+                    </Text>
+                  </Box>
+                )
               }
             />
           </Message>
         );
       },
       [EventType.RoomTopic]: (mEventId, mEvent, item, timelineSet, collapse) => {
+        const isRedacted = mEvent.isRedacted();
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
@@ -1449,20 +1460,25 @@ export function useTimelineEventRenderer({
             <EventContent
               messageLayout={messageLayout}
               time={timeJSX}
-              icon={timelineIcon(Hash)}
+              icon={isRedacted ? timelineIcon(Trash) : timelineIcon(Hash)}
               content={
-                <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
-                    <DecoratedUser userId={senderId} userName={senderName} room={room} />
-                    {' changed room topic'}
-                  </Text>
-                </Box>
+                isRedacted ? (
+                  <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+                ) : (
+                  <Box grow="Yes" direction="Column">
+                    <Text size="T300" priority="300">
+                      <DecoratedUser userId={senderId} userName={senderName} room={room} />
+                      {' changed room topic'}
+                    </Text>
+                  </Box>
+                )
               }
             />
           </Message>
         );
       },
       [EventType.RoomAvatar]: (mEventId, mEvent, item, timelineSet, collapse) => {
+        const isRedacted = mEvent.isRedacted();
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
@@ -1545,20 +1561,25 @@ export function useTimelineEventRenderer({
             <EventContent
               messageLayout={messageLayout}
               time={timeJSX}
-              icon={timelineIcon(Hash)}
+              icon={isRedacted ? timelineIcon(Trash) : timelineIcon(Hash)}
               content={
-                <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
-                    <DecoratedUser userId={senderId} userName={senderName} room={room} />
-                    {' changed room avatar'}
-                  </Text>
-                </Box>
+                isRedacted ? (
+                  <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+                ) : (
+                  <Box grow="Yes" direction="Column">
+                    <Text size="T300" priority="300">
+                      <DecoratedUser userId={senderId} userName={senderName} room={room} />
+                      {' changed room avatar'}
+                    </Text>
+                  </Box>
+                )
               }
             />
           </Message>
         );
       },
       [EventType.GroupCallMemberPrefix]: (mEventId, mEvent, item, timelineSet, collapse) => {
+        const isRedacted = mEvent.isRedacted();
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
@@ -1648,14 +1669,24 @@ export function useTimelineEventRenderer({
             <EventContent
               messageLayout={messageLayout}
               time={timeJSX}
-              icon={callJoined ? timelineIcon(Phone) : timelineIcon(PhoneDisconnect)}
+              icon={
+                isRedacted
+                  ? timelineIcon(Trash)
+                  : callJoined
+                    ? timelineIcon(Phone)
+                    : timelineIcon(PhoneDisconnect)
+              }
               content={
-                <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
-                    <DecoratedUser userId={senderId} userName={senderName} room={room} />
-                    {callJoined ? ' joined the call' : ' ended the call'}
-                  </Text>
-                </Box>
+                isRedacted ? (
+                  <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+                ) : (
+                  <Box grow="Yes" direction="Column">
+                    <Text size="T300" priority="300">
+                      <DecoratedUser userId={senderId} userName={senderName} room={room} />
+                      {callJoined ? ' joined the call' : ' ended the call'}
+                    </Text>
+                  </Box>
+                )
               }
             />
           </Message>
@@ -1990,6 +2021,7 @@ export function useTimelineEventRenderer({
       },
       [EventType.RoomPinnedEvents]: (mEventId, mEvent, item, timelineSet, collapse) => {
         if (!hiddenEventOther) return null;
+        const isRedacted = mEvent.isRedacted();
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const marked = activeReplyId === mEventId && !suppressMark;
         const senderId = mEvent.getSender() ?? '';
@@ -2083,39 +2115,43 @@ export function useTimelineEventRenderer({
             <EventContent
               messageLayout={messageLayout}
               time={timeJSX}
-              icon={timelineIcon(PushPin)}
+              icon={isRedacted ? timelineIcon(Trash) : timelineIcon(PushPin)}
               content={
-                <Box grow="Yes" direction="Column">
-                  <Text size="T300" priority="300">
-                    <DecoratedUser userId={senderId} userName={senderName} room={room} />
-                    {(pinsAdded?.length > 0 &&
-                      `pinned ${pinsAdded.length} message${pinsAdded.length > 1 ? 's' : ''}`) ||
-                      ''}
-                    {(pinsAdded?.length > 0 && pinsRemoved?.length > 0 && ` and `) || ''}
-                    {(pinsRemoved?.length > 0 &&
-                      `unpinned ${pinsRemoved.length} message${
-                        pinsRemoved.length > 1 ? 's' : ''
-                      }`) ||
-                      ''}
-                    {((!pinsAdded || pinsAdded.length <= 0) &&
-                      (!pinsRemoved || pinsRemoved.length <= 0) &&
-                      `has not changed the pins`) ||
-                      `:`}
-                  </Text>
-                  {pinPreviewIds.length > 0 &&
-                    pinPreviewIds
-                      .slice(0, 4)
-                      .map((x: string) => (
-                        <Reply
-                          key={x}
-                          style={{ opacity: '80%' }}
-                          room={room}
-                          replyEventId={x}
-                          onClick={handleOpenReply}
-                          replyIcon={<>{menuIcon(pinnedSet.has(x) ? PushPin : PushPinSlash)}</>}
-                        />
-                      ))}
-                </Box>
+                isRedacted ? (
+                  <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+                ) : (
+                  <Box grow="Yes" direction="Column">
+                    <Text size="T300" priority="300">
+                      <DecoratedUser userId={senderId} userName={senderName} room={room} />
+                      {(pinsAdded?.length > 0 &&
+                        `pinned ${pinsAdded.length} message${pinsAdded.length > 1 ? 's' : ''}`) ||
+                        ''}
+                      {(pinsAdded?.length > 0 && pinsRemoved?.length > 0 && ` and `) || ''}
+                      {(pinsRemoved?.length > 0 &&
+                        `unpinned ${pinsRemoved.length} message${
+                          pinsRemoved.length > 1 ? 's' : ''
+                        }`) ||
+                        ''}
+                      {((!pinsAdded || pinsAdded.length <= 0) &&
+                        (!pinsRemoved || pinsRemoved.length <= 0) &&
+                        `has not changed the pins`) ||
+                        `:`}
+                    </Text>
+                    {pinPreviewIds.length > 0 &&
+                      pinPreviewIds
+                        .slice(0, 4)
+                        .map((x: string) => (
+                          <Reply
+                            key={x}
+                            style={{ opacity: '80%' }}
+                            room={room}
+                            replyEventId={x}
+                            onClick={handleOpenReply}
+                            replyIcon={<>{menuIcon(pinnedSet.has(x) ? PushPin : PushPinSlash)}</>}
+                          />
+                        ))}
+                  </Box>
+                )
               }
             />
           </Message>
@@ -2124,6 +2160,7 @@ export function useTimelineEventRenderer({
     },
     (mEventId, mEvent, item, timelineSet, collapse) => {
       if (!hiddenEventOther) return null;
+      const isRedacted = mEvent.isRedacted();
       const highlighted = focusItem?.index === item && focusItem.highlight;
       const marked = activeReplyId === mEventId && !suppressMark;
       const senderId = mEvent.getSender() ?? '';
@@ -2205,16 +2242,20 @@ export function useTimelineEventRenderer({
           <EventContent
             messageLayout={messageLayout}
             time={timeJSX}
-            icon={timelineIcon(Code)}
+            icon={isRedacted ? timelineIcon(Trash) : timelineIcon(Code)}
             content={
-              <Box grow="Yes" direction="Column">
-                <Text size="T300" priority="300">
-                  <DecoratedUser userId={senderId} userName={senderName} room={room} />
-                  {' sent '}
-                  <code className={customHtmlCss.Code}>{mEvent.getType()}</code>
-                  {' state event'}
-                </Text>
-              </Box>
+              isRedacted ? (
+                <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+              ) : (
+                <Box grow="Yes" direction="Column">
+                  <Text size="T300" priority="300">
+                    <DecoratedUser userId={senderId} userName={senderName} room={room} />
+                    {' sent '}
+                    <code className={customHtmlCss.Code}>{mEvent.getType()}</code>
+                    {' state event'}
+                  </Text>
+                </Box>
+              )
             }
           />
         </Message>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

When a state event (room name, topic, avatar, membership, pins, etc.) is redacted, Sable either:
- renders it with empty/garbage content (e.g. "changed room name" with no name), or
- hides it entirely (the fallback handler returns null on empty content)

Fixes #988 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
