### PR TITLE
feat: show unread count in page title

### DIFF
--- a/.changeset/page-title-unread-count.md
+++ b/.changeset/page-title-unread-count.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Show the unread mention count in the page title.

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -39,7 +39,7 @@ import {
   isDMRoom,
   isNotificationEvent,
 } from '$utils/room';
-import { NotificationType } from '$types/matrix/room';
+import { NotificationType, type RoomToUnread } from '$types/matrix/room';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
 import { useSelectedRoom } from '$hooks/router/useSelectedRoom';
 import { useInboxNotificationsSelected } from '$hooks/router/useInbox';
@@ -107,6 +107,40 @@ function PageZoomFeature() {
   return null;
 }
 
+// Sum only leaf rooms (from === null); space entries aggregate their children
+// and would double-count.
+function getUnreadTotals(roomToUnread: RoomToUnread) {
+  let total = 0;
+  let highlightTotal = 0;
+  let notification = false;
+  let highlight = false;
+  roomToUnread.forEach((unread) => {
+    if (unread.from === null) {
+      total += unread.total;
+      highlightTotal += unread.highlight;
+    }
+    if (unread.total > 0) {
+      notification = true;
+    }
+    if (unread.highlight > 0) {
+      highlight = true;
+    }
+  });
+  return { total, highlightTotal, notification, highlight };
+}
+
+// Show the mention count in the tab title.
+function PageTitleUpdater() {
+  const roomToUnread = useAtomValue(roomToUnreadAtom);
+
+  useEffect(() => {
+    const { highlightTotal } = getUnreadTotals(roomToUnread);
+    document.title = highlightTotal > 0 ? `(${highlightTotal}) Sable Client` : 'Sable Client';
+  }, [roomToUnread]);
+
+  return null;
+}
+
 function FaviconUpdater() {
   const roomToUnread = useAtomValue(roomToUnreadAtom);
   const [usePushNotifications] = useSetting(settingsAtom, 'usePushNotifications');
@@ -114,22 +148,7 @@ function FaviconUpdater() {
   const registration = useAtomValue(registrationAtom);
 
   useEffect(() => {
-    let notification = false;
-    let highlight = false;
-    let total = 0;
-    let highlightTotal = 0;
-    roomToUnread.forEach((unread) => {
-      if (unread.from === null) {
-        total += unread.total;
-        highlightTotal += unread.highlight;
-      }
-      if (unread.total > 0) {
-        notification = true;
-      }
-      if (unread.highlight > 0) {
-        highlight = true;
-      }
-    });
+    const { total, highlightTotal, notification, highlight } = getUnreadTotals(roomToUnread);
 
     if (highlight) {
       setFavicon(LogoHighlightSVG);
@@ -904,6 +923,7 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <PageZoomFeature />
       <PrivacyBlurFeature />
       <FaviconUpdater />
+      <PageTitleUpdater />
       <InviteNotifications />
       <MessageNotifications />
       <BackgroundNotifications />


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds an unread indicator to the browser tab <title> so a backgrounded Sable window shows new-message state at a glance. A new PageTitleUpdater component watches the unread atom and sets document.title to (N) Sable Client when there are unread mentions, reverting to Sable Client when there are none.

<img width="171" height="34" alt="image" src="https://github.com/user-attachments/assets/f9ab0428-8de6-4254-820d-2462a130a47c" />

Fixes #1082

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
