### PR TITLE
fix: stop presence sync from resetting user status to online

### DIFF
--- a/.changeset/fix-presence-reset.md
+++ b/.changeset/fix-presence-reset.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix presence status resetting to "online".

--- a/src/app/utils/presence.ts
+++ b/src/app/utils/presence.ts
@@ -1,5 +1,6 @@
 import type { MatrixClient } from 'matrix-js-sdk';
 import { SetPresence } from 'matrix-js-sdk';
+import { getPresenceSyncManager } from '$client/initMatrix';
 import { Presence } from '../hooks/useUserPresence';
 
 const PRESENCE_TO_SET_PRESENCE: Record<Presence, SetPresence> = {
@@ -16,8 +17,10 @@ export const setUserPresence = async (
   presence: Presence,
   statusMsg?: string
 ): Promise<void> => {
-  Promise.all([
-    mx.setSyncPresence(presenceToSetPresence(presence)),
+  const setPresence = presenceToSetPresence(presence);
+  getPresenceSyncManager(mx)?.setDesiredPresence(setPresence);
+  await Promise.all([
+    mx.setSyncPresence(setPresence),
     mx.setPresence({
       presence,
       status_msg: statusMsg,

--- a/src/client/presenceSync.ts
+++ b/src/client/presenceSync.ts
@@ -1,5 +1,12 @@
 import type { CryptoBackend, IDeviceLists, IToDeviceEvent, MatrixClient } from '$types/matrix-sdk';
-import { ClientEvent, Filter, Method, processToDeviceMessages, User } from '$types/matrix-sdk';
+import {
+  ClientEvent,
+  Filter,
+  Method,
+  processToDeviceMessages,
+  SetPresence,
+  User,
+} from '$types/matrix-sdk';
 import { createDebugLogger } from '$utils/debugLogger';
 
 const debugLog = createDebugLogger('presenceSync');
@@ -18,6 +25,8 @@ export class PresenceSyncManager {
   private disposed = false;
 
   private enabled = true;
+
+  private desiredSetPresence = SetPresence.Online;
 
   private activeRequest: Promise<void> | null = null;
 
@@ -47,6 +56,10 @@ export class PresenceSyncManager {
     }
 
     if (!this.activeRequest && !this.disposed) this.poll();
+  }
+
+  public setDesiredPresence(presence: SetPresence): void {
+    this.desiredSetPresence = presence;
   }
 
   public start(): void {
@@ -135,7 +148,7 @@ export class PresenceSyncManager {
             filter: filterId,
             since: this.syncToken,
             timeout: this.pollTimeoutMs,
-            set_presence: 'online',
+            set_presence: this.desiredSetPresence,
           },
           undefined,
           { abortSignal: signal }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description


When using sliding sync, the background presence sync poll hardcodes set_presence: 'online' on every /sync request


<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes  #1091

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
