### PR TITLE
fix: re-anchor new messages divider at last read when tabbing out

### DIFF
--- a/.changeset/fix-new-messages-divider-refocus.md
+++ b/.changeset/fix-new-messages-divider-refocus.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the new messages divider staying at the room-open position instead of re-anchoring at the last read when the window loses focus.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -830,9 +830,17 @@ export function RoomTimeline({
   useDocumentFocusChange(
     useCallback(
       (inFocus) => {
-        if (inFocus && atBottomState) tryAutoMarkAsRead();
+        if (inFocus) {
+          if (atBottomState) tryAutoMarkAsRead();
+          return;
+        }
+        // Re-anchor the divider at the last read when tabbing out while caught up.
+        if (atBottomState && timelineSync.liveTimelineLinked) {
+          readUptoEventIdRef.current = undefined;
+          setUnreadInfo(undefined);
+        }
       },
-      [tryAutoMarkAsRead, atBottomState]
+      [tryAutoMarkAsRead, atBottomState, timelineSync.liveTimelineLinked, setUnreadInfo]
     )
   );
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
The "New Messages" divider was anchored to the read position captured when the room was first opened (unreadInfo is computed once on mount and never refreshed while the room stays open). So if you kept a room open, tabbed away, and messages streamed in, the timeline auto-scrolled but the divider stayed stuck at the open-time position instead of marking where you actually left off.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
