### PR TITLE
fix: improve timeline reliablity to follow new message

### DIFF
--- a/.changeset/fix-timeline-auto-follow.md
+++ b/.changeset/fix-timeline-auto-follow.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the timeline not reliably following new messages when pinned to the bottom, and stop the browser's scroll anchoring from fighting the virtualized message list.

--- a/src/app/features/room/RoomTimeline.css.ts
+++ b/src/app/features/room/RoomTimeline.css.ts
@@ -36,6 +36,7 @@ export type TimelineFloatVariants = RecipeVariants<typeof TimelineFloat>;
 export const messageList = style({
   overflowY: 'scroll',
   scrollbarGutter: 'stable',
+  overflowAnchor: 'none',
 
   '@supports': {
     'not selector(::-webkit-scrollbar)': {

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -445,12 +445,18 @@ export function RoomTimeline({
   const processedEventsRef = useRef<ProcessedEvent[]>([]);
   const timelineSyncRef = useRef<typeof timelineSync>(null as unknown as typeof timelineSync);
 
-  const scrollToBottom = useCallback(() => {
-    if (!vListRef.current) return;
-    const lastIndex = processedEventsRef.current.length - 1;
-    if (lastIndex < 0) return;
-    vListRef.current.scrollTo(vListRef.current.scrollSize);
-  }, []);
+  const scrollToBottom = useCallback(
+    (behavior: 'instant' | 'smooth' = 'instant') => {
+      if (!vListRef.current) return;
+      const lastIndex = processedEventsRef.current.length - 1;
+      if (lastIndex < 0) return;
+      vListRef.current.scrollToIndex(lastIndex, {
+        align: 'end',
+        smooth: behavior === 'smooth' && !reducedMotion,
+      });
+    },
+    [reducedMotion]
+  );
 
   const timelineSync = useTimelineSync({
     room,
@@ -665,7 +671,10 @@ export function RoomTimeline({
       const shrank = newHeight < prev;
 
       if (shrank && atBottom) {
-        vListRef.current?.scrollTo(vListRef.current.scrollSize);
+        const lastIndex = processedEventsRef.current.length - 1;
+        if (lastIndex >= 0) {
+          vListRef.current?.scrollToIndex(lastIndex, { align: 'end' });
+        }
       }
       prevViewportHeightRef.current = newHeight;
     });

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Room } from '$types/matrix-sdk';
 import { RoomEvent } from '$types/matrix-sdk';
 import { useTimelineSync } from './useTimelineSync';
+import { getRoomUnreadInfo } from '$utils/timeline';
+import type * as TimelineUtils from '$utils/timeline';
 
 vi.mock('@sentry/react', () => ({
   default: {},
@@ -14,6 +16,14 @@ vi.mock('@sentry/react', () => ({
     distribution: vi.fn<() => void>(),
   },
 }));
+
+vi.mock('$utils/timeline', async (importOriginal) => {
+  const actual = await importOriginal<typeof TimelineUtils>();
+  return {
+    ...actual,
+    getRoomUnreadInfo: vi.fn<typeof TimelineUtils.getRoomUnreadInfo>(),
+  };
+});
 
 type FakeTimeline = {
   getEvents: () => unknown[];
@@ -48,6 +58,7 @@ function createRoom(
   room: FakeRoom;
   timelineSet: FakeTimelineSet;
   events: unknown[];
+  timeline: FakeTimeline;
 } {
   const timeline = {
     ...createTimeline(events),
@@ -66,12 +77,40 @@ function createRoom(
     getUnfilteredTimelineSet: () => timelineSet as never,
     getEventReadUpTo: () => null,
     getThread: () => null,
+    getLiveTimeline: () => timeline,
+    getUnreadNotificationCount: () => 0,
+    getMyMembership: () => 'join',
+    getMember: () => null,
+    hasEncryptionStateEvent: () => false,
     client: {
       getUserId: () => '@alice:test',
     },
   } as unknown as FakeRoom;
 
-  return { room, timelineSet, events };
+  return { room, timelineSet, events, timeline };
+}
+
+function makeEvent(sender: string, roomId: string) {
+  return {
+    threadRootId: undefined,
+    getSender: () => sender,
+    getRoomId: () => roomId,
+    getTs: () => Date.now(),
+    getRelation: () => undefined,
+  };
+}
+
+function emitLiveTimelineEvent(
+  room: FakeRoom,
+  timeline: FakeTimeline,
+  events: unknown[],
+  sender: string
+) {
+  events.push({});
+  room.emit(RoomEvent.Timeline, makeEvent(sender, room.roomId), room, false, false, {
+    liveEvent: true,
+    timeline,
+  });
 }
 
 describe('useTimelineSync', () => {
@@ -237,5 +276,184 @@ describe('useTimelineSync', () => {
     });
 
     expect(result.current.timeline.linkedTimelines[0]).toBe(roomOne.timelineSet.getLiveTimeline());
+  });
+
+  describe('auto-follow on live message', () => {
+    it('scrolls to bottom with smooth behavior for an incoming message from another user', async () => {
+      const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      const { room, timeline, events } = createRoom();
+      const scrollToBottom = vi.fn<(behavior?: 'instant' | 'smooth') => void>();
+
+      renderHook(() =>
+        useTimelineSync({
+          room: room as Room,
+          mx: { getUserId: () => '@alice:test' } as never,
+          isAtBottom: true,
+          isAtBottomRef: { current: true },
+          scrollToBottom,
+          unreadInfo: undefined,
+          setUnreadInfo: vi.fn<() => void>(),
+          hideReadsRef: { current: false },
+          readUptoEventIdRef: { current: undefined },
+        })
+      );
+
+      await act(async () => {
+        emitLiveTimelineEvent(room, timeline, events, '@bob:test');
+        await Promise.resolve();
+      });
+
+      expect(scrollToBottom).toHaveBeenCalledWith('smooth');
+      hasFocus.mockRestore();
+    });
+
+    it('scrolls to bottom with instant behavior for an own message', async () => {
+      const { room, timeline, events } = createRoom();
+      const scrollToBottom = vi.fn<(behavior?: 'instant' | 'smooth') => void>();
+
+      renderHook(() =>
+        useTimelineSync({
+          room: room as Room,
+          mx: { getUserId: () => '@alice:test' } as never,
+          isAtBottom: true,
+          isAtBottomRef: { current: true },
+          scrollToBottom,
+          unreadInfo: undefined,
+          setUnreadInfo: vi.fn<() => void>(),
+          hideReadsRef: { current: false },
+          readUptoEventIdRef: { current: undefined },
+        })
+      );
+
+      await act(async () => {
+        emitLiveTimelineEvent(room, timeline, events, '@alice:test');
+        await Promise.resolve();
+      });
+
+      expect(scrollToBottom).toHaveBeenCalledWith('instant');
+    });
+
+    it('keeps following instantly and re-anchors the unread divider while unfocused', async () => {
+      const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+      const unread = { readUptoEventId: '$read:test', inLiveTimeline: true, scrollTo: false };
+      vi.mocked(getRoomUnreadInfo).mockReturnValueOnce(unread);
+      const { room, timeline, events } = createRoom();
+      const scrollToBottom = vi.fn<(behavior?: 'instant' | 'smooth') => void>();
+      const setUnreadInfo = vi.fn<() => void>();
+
+      renderHook(() =>
+        useTimelineSync({
+          room: room as Room,
+          mx: { getUserId: () => '@alice:test' } as never,
+          isAtBottom: true,
+          isAtBottomRef: { current: true },
+          scrollToBottom,
+          unreadInfo: undefined,
+          setUnreadInfo,
+          hideReadsRef: { current: false },
+          readUptoEventIdRef: { current: undefined },
+        })
+      );
+
+      await act(async () => {
+        emitLiveTimelineEvent(room, timeline, events, '@bob:test');
+        await Promise.resolve();
+      });
+
+      expect(setUnreadInfo).toHaveBeenCalledWith(unread);
+      expect(scrollToBottom).toHaveBeenCalledWith('instant');
+      hasFocus.mockRestore();
+    });
+
+    it('does not scroll when the user is not at the bottom', async () => {
+      const { room, timeline, events } = createRoom();
+      const scrollToBottom = vi.fn<() => void>();
+
+      renderHook(() =>
+        useTimelineSync({
+          room: room as Room,
+          mx: { getUserId: () => '@alice:test' } as never,
+          isAtBottom: false,
+          isAtBottomRef: { current: false },
+          scrollToBottom,
+          unreadInfo: undefined,
+          setUnreadInfo: vi.fn<() => void>(),
+          hideReadsRef: { current: false },
+          readUptoEventIdRef: { current: undefined },
+        })
+      );
+
+      await act(async () => {
+        emitLiveTimelineEvent(room, timeline, events, '@bob:test');
+        await Promise.resolve();
+      });
+
+      expect(scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-live (historical) timeline events', async () => {
+      const { room, timeline } = createRoom();
+      const scrollToBottom = vi.fn<() => void>();
+
+      renderHook(() =>
+        useTimelineSync({
+          room: room as Room,
+          mx: { getUserId: () => '@alice:test' } as never,
+          isAtBottom: true,
+          isAtBottomRef: { current: true },
+          scrollToBottom,
+          unreadInfo: undefined,
+          setUnreadInfo: vi.fn<() => void>(),
+          hideReadsRef: { current: false },
+          readUptoEventIdRef: { current: undefined },
+        })
+      );
+
+      const mEvent = makeEvent('@bob:test', room.roomId);
+      await act(async () => {
+        room.emit(RoomEvent.Timeline, mEvent, room, true, false, {
+          liveEvent: false,
+          timeline,
+        });
+        await Promise.resolve();
+      });
+
+      expect(scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    it('ignores thread reply events', async () => {
+      const { room, timeline } = createRoom();
+      const scrollToBottom = vi.fn<() => void>();
+
+      renderHook(() =>
+        useTimelineSync({
+          room: room as Room,
+          mx: { getUserId: () => '@alice:test' } as never,
+          isAtBottom: true,
+          isAtBottomRef: { current: true },
+          scrollToBottom,
+          unreadInfo: undefined,
+          setUnreadInfo: vi.fn<() => void>(),
+          hideReadsRef: { current: false },
+          readUptoEventIdRef: { current: undefined },
+        })
+      );
+
+      const mEvent = {
+        threadRootId: '$thread-root:test',
+        getSender: () => '@bob:test',
+        getRoomId: () => room.roomId,
+        getTs: () => Date.now(),
+      };
+      await act(async () => {
+        room.emit(RoomEvent.Timeline, mEvent, room, false, false, {
+          liveEvent: true,
+          timeline,
+        });
+        await Promise.resolve();
+      });
+
+      expect(scrollToBottom).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -399,6 +399,7 @@ export function useTimelineSync({
   >();
 
   const resetAutoScrollPendingRef = useRef(false);
+  const pendingAutoScrollBehaviorRef = useRef<'instant' | 'smooth' | undefined>(undefined);
 
   const eventsLength = getTimelinesEventsCount(timeline.linkedTimelines);
   const liveTimelineLinked = timeline.linkedTimelines.at(-1) === getLiveTimeline(room);
@@ -501,8 +502,10 @@ export function useTimelineSync({
             setUnreadInfo(getRoomUnreadInfo(room));
           }
 
-          scrollToBottom(mEvt.getSender() === mx.getUserId() ? 'instant' : 'smooth');
-          lastScrolledAtEventsLengthRef.current = eventsLengthRef.current + 1;
+          // Own messages should feel immediate, and unfocused windows throttle
+          // scroll animations, which can leave the view stuck mid-scroll.
+          pendingAutoScrollBehaviorRef.current =
+            mEvt.getSender() === mx.getUserId() || !document.hasFocus() ? 'instant' : 'smooth';
 
           setTimeline((ct) => ({ ...ct }));
           return;
@@ -513,7 +516,7 @@ export function useTimelineSync({
           setUnreadInfo(getRoomUnreadInfo(room));
         }
       },
-      [mx, room, isAtBottomRef, unreadInfo, scrollToBottom, setUnreadInfo, hideReadsRef]
+      [mx, room, isAtBottomRef, unreadInfo, setUnreadInfo, hideReadsRef]
     )
   );
 
@@ -562,6 +565,9 @@ export function useTimelineSync({
     const resetAutoScrollPending = resetAutoScrollPendingRef.current;
     if (resetAutoScrollPending) resetAutoScrollPendingRef.current = false;
 
+    const behavior = pendingAutoScrollBehaviorRef.current ?? 'instant';
+    pendingAutoScrollBehaviorRef.current = undefined;
+
     // liveTimelineLinked can be transiently false after TimelineReset: the SDK
     // fires the event before React commits the new linkedTimelines, so the stored
     // chain still references the old detached timeline. When auto-scroll recovery
@@ -576,7 +582,7 @@ export function useTimelineSync({
     if (eventsLength <= lastScrolledAtEventsLengthRef.current && !resetAutoScrollPending) return;
 
     lastScrolledAtEventsLengthRef.current = eventsLength;
-    scrollToBottom('instant');
+    scrollToBottom(behavior);
   }, [isAtBottom, liveTimelineLinked, eventsLength, scrollToBottom]);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix the timeline not reliably following new messages when pinned to the bottom, and stop the browser's scroll anchoring from fighting the virtualized message list.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
