### PR TITLE
Fix typing indicator padding

### DIFF
--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -157,7 +157,9 @@ export function RoomView({ eventId }: { eventId?: string }) {
                 onEditorReset={handleResetEditor}
                 onEditLastMessageRef={editLastMessageRef}
               />
-              <RoomViewTyping room={room} />
+              <div style={{ position: 'relative', flexShrink: 0 }}>
+                <RoomViewTyping room={room} />
+              </div>
               <GlobalModalManager />
             </Box>
             <Box shrink="No" direction="Column">

--- a/src/app/features/room/RoomViewTyping.css.ts
+++ b/src/app/features/room/RoomViewTyping.css.ts
@@ -17,6 +17,8 @@ export const RoomViewTyping = style([
     width: '100%',
     backgroundColor: color.Surface.Container,
     color: color.Surface.OnContainer,
+    position: 'absolute',
+    bottom: 0,
     animation: `${SlideUpAnime} 100ms ease-in-out`,
   },
 ]);

--- a/src/app/features/room/RoomViewTyping.tsx
+++ b/src/app/features/room/RoomViewTyping.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Text, as } from 'folds';
+import { Box, IconButton, Text, as, toRem } from 'folds';
 import { chipIcon, X } from '$components/icons/phosphor';
 import type { Room } from '$types/matrix-sdk';
 import classNames from 'classnames';
@@ -114,7 +114,13 @@ export const RoomViewTyping = as<'div', RoomViewTypingProps>(
             </>
           )}
         </Text>
-        <IconButton title="Drop Typing Status" size="300" radii="Pill" onClick={handleDropAll}>
+        <IconButton
+          title="Drop Typing Status"
+          size="300"
+          radii="Pill"
+          onClick={handleDropAll}
+          style={{ padding: toRem(2) }}
+        >
           {chipIcon(X)}
         </IconButton>
       </Box>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Only affects dev, sort of. Layout shift caused by a different pr, i adjusted padding to make it fit the gap before the first message better

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
