### PR TITLE
fix: wait for room list to be loaded before fetching pack info

### DIFF
--- a/.changeset/fix-sliding-sync-subspaces.md
+++ b/.changeset/fix-sliding-sync-subspaces.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix a regression making subspaces with emote packs being listed as separate spaces on sliding-sync.

--- a/src/client/slidingSync.test.ts
+++ b/src/client/slidingSync.test.ts
@@ -333,6 +333,7 @@ describe('SlidingSyncManager room subscription coordination', () => {
   it('uses the active subscription while a room is also an image-pack room', () => {
     const manager = makeManager(makeMockMx());
     const roomId = '!pack:example.com';
+    (manager as unknown as { listsFullyLoaded: boolean }).listsFullyLoaded = true;
 
     manager.setImagePackSubscriptions([roomId]);
     manager.subscribeToRoom(roomId);
@@ -346,6 +347,7 @@ describe('SlidingSyncManager room subscription coordination', () => {
   it('restores the image-pack subscription when the room is no longer active', () => {
     const manager = makeManager(makeMockMx());
     const roomId = '!pack:example.com';
+    (manager as unknown as { listsFullyLoaded: boolean }).listsFullyLoaded = true;
 
     manager.setImagePackSubscriptions([roomId]);
     manager.subscribeToRoom(roomId);
@@ -400,12 +402,33 @@ describe('SlidingSyncManager room subscription coordination', () => {
 
   it('removes image-pack subscriptions which are no longer configured', () => {
     const manager = makeManager(makeMockMx());
+    (manager as unknown as { listsFullyLoaded: boolean }).listsFullyLoaded = true;
 
     manager.setImagePackSubscriptions(['!old:example.com', '!current:example.com']);
     manager.setImagePackSubscriptions(['!current:example.com']);
 
     expect(mocks.slidingSyncInstance.modifyRoomSubscriptions).toHaveBeenLastCalledWith(
       new Set(['!current:example.com'])
+    );
+  });
+
+  it('defers image-pack subscriptions until lists are loaded so pack spaces get the composite key', () => {
+    const manager = makeManager(makeMockMx());
+    const roomId = '!spacepack:example.com';
+
+    manager.setImagePackSubscriptions([roomId]);
+    expect(mocks.slidingSyncInstance.modifyRoomSubscriptions).not.toHaveBeenCalled();
+
+    manager.setSpaceSubscriptions([roomId]);
+    (manager as unknown as { listsFullyLoaded: boolean }).listsFullyLoaded = true;
+    (manager as unknown as { flushDeferredSubscriptions: () => void }).flushDeferredSubscriptions();
+
+    expect(mocks.slidingSyncInstance.useCustomSubscription).toHaveBeenLastCalledWith(
+      roomId,
+      'space_image_packs'
+    );
+    expect(mocks.slidingSyncInstance.modifyRoomSubscriptions).toHaveBeenLastCalledWith(
+      new Set([roomId])
     );
   });
 

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -240,6 +240,8 @@ export class SlidingSyncManager {
 
   private readonly imagePackRoomSubscriptions = new Set<string>();
 
+  private deferredImagePackSubscriptions: Set<string> | null = null;
+
   private roomSubscriptionSyncQueued = false;
 
   private readonly roomTimelineLimit: number;
@@ -998,6 +1000,10 @@ export class SlidingSyncManager {
     const spaces = this.deferredSpaceSubscriptions;
     this.deferredSpaceSubscriptions = new Set();
     this.setSpaceSubscriptions(spaces);
+
+    const imagePacks = this.deferredImagePackSubscriptions;
+    this.deferredImagePackSubscriptions = null;
+    if (imagePacks) this.setImagePackSubscriptions(imagePacks);
   }
 
   private queueRoomSubscriptionSync(): void {
@@ -1053,6 +1059,10 @@ export class SlidingSyncManager {
   public setImagePackSubscriptions(roomIds: Iterable<string>): void {
     if (this.disposed) return;
     const next = new Set(roomIds);
+    if (!this.listsFullyLoaded) {
+      this.deferredImagePackSubscriptions = next;
+      return;
+    }
     const unchanged =
       next.size === this.imagePackRoomSubscriptions.size &&
       [...next].every((roomId) => this.imagePackRoomSubscriptions.has(roomId));


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fixes a regression in #1112 where every subspace of a space with an emoji pack was shown separately in the server list with sliding sync. We now wait until the room list is loaded before fetching an emoji pack.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
