### PR TITLE
fix(shortcuts): Remove keybind conflict with text-editor bold text

### DIFF
--- a/.changeset/fix_overlapping_bookmarks_and_bold_text_shortcut.md
+++ b/.changeset/fix_overlapping_bookmarks_and_bold_text_shortcut.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix overlapping Bookmarks and Bold Text shortcut

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -165,7 +165,7 @@ export function GlobalKeyboardShortcuts() {
 
   const handleBookmarkKeyDown = useCallback(
     (evt: KeyboardEvent) => {
-      if (!isKeyHotkey('mod+b', evt)) return;
+      if (!isKeyHotkey('mod+shift+b', evt)) return;
       evt.preventDefault();
 
       navigate(getInboxBookmarksPath());


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This fixes #1061 by removing the conflicting `mod+b` keybind that was previously on both the bold-text shortcut and bookmarks page shortcuts.

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->