### PR TITLE
Add account switcher to "homeserver down" screen

### DIFF
--- a/.changeset/show-account-switcher-hs-down.md
+++ b/.changeset/show-account-switcher-hs-down.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add account switcher to "homeserver down" screen to prevent being locked out from all accounts at once

--- a/src/app/pages/client/SpecVersions.tsx
+++ b/src/app/pages/client/SpecVersions.tsx
@@ -6,6 +6,7 @@ import { SpecVersionsProvider } from '$hooks/useSpecVersions';
 import { SplashScreen } from '$components/splash-screen';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import type { SpecVersions } from '../../cs-api';
+import { AccountMenuOption } from './sidebar/UserMenuTab';
 
 const EMPTY_VERSIONS: SpecVersions = { versions: [] };
 
@@ -25,6 +26,9 @@ function HomeserverOfflineError({ baseUrl, onRetry }: HomeserverOfflineErrorProp
                 We can&apos;t reach <strong>{baseUrl}</strong>. The homeserver may be down, or you
                 may have a connection issue. Please try again.
               </Text>
+              <div style={{ position: 'relative' }}>
+                <AccountMenuOption isMobile={true} showSeparator={false} />
+              </div>
             </Box>
             <Button variant="Critical" onClick={onRetry} fill="Soft">
               <Text as="span" size="B400">

--- a/src/app/pages/client/sidebar/UserMenuTab.tsx
+++ b/src/app/pages/client/sidebar/UserMenuTab.tsx
@@ -161,7 +161,15 @@ function AccountRow({
   );
 }
 
-export function AccountMenuOption({ isMobile, isRight }: { isMobile: boolean; isRight?: boolean }) {
+export function AccountMenuOption({
+  isMobile,
+  isRight,
+  showSeparator,
+}: {
+  isMobile: boolean;
+  isRight?: boolean;
+  showSeparator?: boolean;
+}) {
   const mx = useMatrixClient();
   const navigate = useNavigate();
   const sessions = useAtomValue(sessionsAtom);
@@ -265,7 +273,7 @@ export function AccountMenuOption({ isMobile, isRight }: { isMobile: boolean; is
 
   return (
     <>
-      <Line variant="Surface" size="300" />
+      {(showSeparator ?? true) && <Line variant="Surface" size="300" />}
       <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
         <MenuItem
           size="300"


### PR DESCRIPTION
### Description

Add account switcher to "homeserver down"  screen to prevent being locked out from all accounts at once.  
The implementation is quite ugly, but this serves as a starting point, it honestly just needs some styling changes. Feel free to edit my pull request or suggest changes.  

Before this pull request, the "Homeserver Down" screen would not let you navigate past it, effectively locking you out of every account, not just the one of which the homeserver is down. I had this happen in the wild, my screenshots show a reproduction by emulating the hs being down, by temporarily ip-blocking myself.

Before this change:
<img width="449" height="264" alt="image" src="https://github.com/user-attachments/assets/773c1efc-efad-45f6-953f-e9a23ef87312" />
After this change:
<img width="411" height="294" alt="image" src="https://github.com/user-attachments/assets/bb226cf2-9e6b-4a59-8787-03b1981efaae" />

(please don't mind the difference in theme)

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:
No AI here
