### PR TITLE
fix(tauri): prevent android media loading stalls and object-url leaks

### DIFF
--- a/.changeset/fix-android-media-loading-stall.md
+++ b/.changeset/fix-android-media-loading-stall.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix media loading stalling on Android after browsing through message history.

--- a/src-tauri/src/network/loopback_http.rs
+++ b/src-tauri/src/network/loopback_http.rs
@@ -1,17 +1,27 @@
 use std::{
     collections::HashMap,
     sync::{LazyLock, Mutex},
+    time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
 use tauri_plugin_http::reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    ClientBuilder, Method, Url,
+    Client, ClientBuilder, Method, Url,
 };
 use tokio::sync::watch;
 
 static LOOPBACK_ABORT_SENDERS: LazyLock<Mutex<HashMap<String, watch::Sender<bool>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static LOOPBACK_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    ClientBuilder::new()
+        .no_proxy()
+        .timeout(Duration::from_secs(30))
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .expect("failed to build loopback client")
+});
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -110,12 +120,7 @@ pub async fn loopback_fetch(
     let result = async {
         let method = Method::from_bytes(request.method.as_bytes()).map_err(|err| err.to_string())?;
         let headers = build_headers(request.headers)?;
-        let mut req = ClientBuilder::new()
-            .no_proxy()
-            .build()
-            .map_err(|err| err.to_string())?
-            .request(method, url)
-            .headers(headers);
+        let mut req = LOOPBACK_CLIENT.request(method, url).headers(headers);
 
         if let Some(body) = request.body {
             req = req.body(body);

--- a/src-tauri/src/network/media_protocol.rs
+++ b/src-tauri/src/network/media_protocol.rs
@@ -2,6 +2,7 @@ use std::{
     fs,
     path::PathBuf,
     sync::{OnceLock, RwLock},
+    time::Duration,
 };
 
 use sha2::{Digest, Sha256};
@@ -13,22 +14,44 @@ use tauri_plugin_http::reqwest::{
     header::{AUTHORIZATION, CONTENT_TYPE},
     Client, Url,
 };
+use tokio::sync::Semaphore;
 
 pub const MEDIA_URI_SCHEME: &str = "sable-media";
 
 const MEDIA_PATH_PREFIXES: [&str; 2] = ["/_matrix/media/", "/_matrix/client/v1/media/"];
 const CACHE_SUBDIR: &str = "sable-media";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_CONCURRENT_REQUESTS: usize = 8;
 
-#[derive(Default)]
 pub struct MediaSessionState {
     inner: RwLock<Option<MediaSession>>,
     client: OnceLock<Client>,
+    semaphore: Semaphore,
+}
+
+impl Default for MediaSessionState {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(None),
+            client: OnceLock::new(),
+            semaphore: Semaphore::new(MAX_CONCURRENT_REQUESTS),
+        }
+    }
 }
 
 impl MediaSessionState {
     // Shared across requests so the connection pool and TLS sessions stay warm.
     fn client(&self) -> Client {
-        self.client.get_or_init(Client::new).clone()
+        self.client
+            .get_or_init(|| {
+                Client::builder()
+                    .timeout(REQUEST_TIMEOUT)
+                    .connect_timeout(CONNECT_TIMEOUT)
+                    .build()
+                    .unwrap_or_else(|_| Client::new())
+            })
+            .clone()
     }
 }
 
@@ -122,14 +145,21 @@ async fn handle_request<R: Runtime>(
     let body_path = dir.join(&key);
     let content_type_path = dir.join(format!("{key}.ct"));
 
-    if let (Ok(body), Ok(content_type)) =
-        (fs::read(&body_path), fs::read_to_string(&content_type_path))
+    let state = app.state::<MediaSessionState>();
+    let _permit = state
+        .semaphore
+        .acquire()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if let Some((body, content_type)) =
+        read_cache(body_path.clone(), content_type_path.clone()).await
     {
         return Ok(ok_response(body, &content_type));
     }
 
-    let client = app.state::<MediaSessionState>().client();
-    let upstream = client
+    let upstream = state
+        .client()
         .get(media_url)
         .header(AUTHORIZATION, format!("Bearer {}", session.token))
         .send()
@@ -154,12 +184,43 @@ async fn handle_request<R: Runtime>(
         .map_err(|_| StatusCode::BAD_GATEWAY)?
         .to_vec();
 
-    if fs::create_dir_all(&dir).is_ok() {
-        let _ = fs::write(&body_path, &body);
-        let _ = fs::write(&content_type_path, &content_type);
-    }
+    write_cache(
+        dir,
+        body_path,
+        content_type_path,
+        body.clone(),
+        content_type.clone(),
+    )
+    .await;
 
     Ok(ok_response(body, &content_type))
+}
+
+async fn read_cache(body_path: PathBuf, content_type_path: PathBuf) -> Option<(Vec<u8>, String)> {
+    tokio::task::spawn_blocking(move || {
+        match (fs::read(&body_path), fs::read_to_string(&content_type_path)) {
+            (Ok(body), Ok(content_type)) => Some((body, content_type)),
+            _ => None,
+        }
+    })
+    .await
+    .unwrap_or(None)
+}
+
+async fn write_cache(
+    dir: PathBuf,
+    body_path: PathBuf,
+    content_type_path: PathBuf,
+    body: Vec<u8>,
+    content_type: String,
+) {
+    let _ = tokio::task::spawn_blocking(move || {
+        if fs::create_dir_all(&dir).is_ok() {
+            let _ = fs::write(&body_path, &body);
+            let _ = fs::write(&content_type_path, &content_type);
+        }
+    })
+    .await;
 }
 
 fn ok_response(body: Vec<u8>, content_type: &str) -> Response<Vec<u8>> {

--- a/src/app/components/message/FileHeader.tsx
+++ b/src/app/components/message/FileHeader.tsx
@@ -30,9 +30,7 @@ export function FileDownloadButton({ filename, url, mimeType, encInfo }: FileDow
         ? await downloadEncryptedMedia(mediaUrl, (encBuf) => decryptFile(encBuf, mimeType, encInfo))
         : await downloadMedia(mediaUrl);
 
-      const fileURL = URL.createObjectURL(fileContent);
       await saveFileToDevice(fileContent, getDownloadFilename(filename), mimeType);
-      return fileURL;
     }, [mx, url, useAuthentication, mimeType, encInfo, filename])
   );
 

--- a/src/app/components/message/content/AudioContent.tsx
+++ b/src/app/components/message/content/AudioContent.tsx
@@ -20,6 +20,7 @@ import { useThrottle } from '$hooks/useThrottle';
 import { secondsToMinutesAndSeconds } from '$utils/common';
 import { decryptFile, downloadEncryptedMedia, downloadMedia, mxcUrlToHttp } from '$utils/matrix';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import { useRevokeObjectURL } from '$hooks/useObjectURL';
 import { MEDIA_VOLUME_KEY } from '$components/media';
 
 const PLAY_TIME_THROTTLE_OPS = {
@@ -60,6 +61,8 @@ export function AudioContent({
       return URL.createObjectURL(fileContent);
     }, [mx, url, useAuthentication, mimeType, encInfo])
   );
+
+  useRevokeObjectURL(srcState.status === AsyncStatus.Success ? srcState.data : undefined);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
 

--- a/src/app/components/message/content/FileContent.tsx
+++ b/src/app/components/message/content/FileContent.tsx
@@ -29,6 +29,7 @@ import {
 import { stopPropagation } from '$utils/keyboard';
 import { decryptFile, downloadEncryptedMedia, downloadMedia, mxcUrlToHttp } from '$utils/matrix';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import { useRevokeObjectURL } from '$hooks/useObjectURL';
 import { ModalWide } from '$styles/Modal.css';
 import { getDownloadFilename, saveFileToDevice } from '$utils/download';
 
@@ -182,6 +183,8 @@ export function ReadPdfFile({ body, mimeType, url, encInfo, renderViewer }: Read
     }, [mx, url, useAuthentication, mimeType, encInfo])
   );
 
+  useRevokeObjectURL(pdfState.status === AsyncStatus.Success ? pdfState.data : undefined);
+
   return (
     <>
       {pdfState.status === AsyncStatus.Success && (
@@ -261,6 +264,8 @@ export function DownloadFile({ body, mimeType, url, info, encInfo }: DownloadFil
       return fileURL;
     }, [mx, url, useAuthentication, mimeType, encInfo, body])
   );
+
+  useRevokeObjectURL(downloadState.status === AsyncStatus.Success ? downloadState.data : undefined);
 
   return downloadState.status === AsyncStatus.Error ? (
     renderErrorButton(download, `Retry Download (${bytesToSize(info.size ?? 0)})`)

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -50,6 +50,7 @@ import {
 } from '../../../../unstable/prefixes';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 import { useRenderableMediaUrl } from '$hooks/useRenderableMediaUrl';
+import { useRevokeObjectURL } from '$hooks/useObjectURL';
 
 export function checkIfGif(url: string, mimetype?: string, body?: string) {
   return (
@@ -204,6 +205,10 @@ export const ImageContent = as<'div', ImageContentProps>(
     useEffect(() => {
       if (autoPlay) loadSrc();
     }, [autoPlay, loadSrc]);
+
+    useRevokeObjectURL(
+      encInfo && srcState.status === AsyncStatus.Success ? srcState.data : undefined
+    );
 
     const imageW = info?.w;
     const imageH = info?.h;

--- a/src/app/components/message/content/ThumbnailContent.tsx
+++ b/src/app/components/message/content/ThumbnailContent.tsx
@@ -6,6 +6,7 @@ import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { decryptFile, downloadEncryptedMedia, mxcUrlToHttp } from '$utils/matrix';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import { useRenderableMediaUrl } from '$hooks/useRenderableMediaUrl';
+import { useRevokeObjectURL } from '$hooks/useObjectURL';
 import { FALLBACK_MIMETYPE } from '$utils/mimeTypes';
 
 export type ThumbnailContentProps = {
@@ -46,6 +47,10 @@ export function ThumbnailContent({ info, renderImage }: ThumbnailContentProps) {
   useEffect(() => {
     loadThumbSrc();
   }, [loadThumbSrc]);
+
+  useRevokeObjectURL(
+    encInfo && thumbSrcState.status === AsyncStatus.Success ? thumbSrcState.data : undefined
+  );
 
   return thumbSrcState.status === AsyncStatus.Success ? renderImage(thumbSrcState.data) : null;
 }

--- a/src/app/components/message/content/VideoContent.tsx
+++ b/src/app/components/message/content/VideoContent.tsx
@@ -24,6 +24,7 @@ import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { bytesToSize, millisecondsToMinutesAndSeconds } from '$utils/common';
 import { decryptFile, downloadEncryptedMedia, downloadMedia, mxcUrlToHttp } from '$utils/matrix';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
+import { useRevokeObjectURL } from '$hooks/useObjectURL';
 import { validBlurHash } from '$utils/blurHash';
 import * as css from './style.css';
 import { MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME } from '../../../../unstable/prefixes';
@@ -120,6 +121,8 @@ export const VideoContent = as<'div', VideoContentProps>(
     useEffect(() => {
       if (autoPlay) loadSrc();
     }, [autoPlay, loadSrc]);
+
+    useRevokeObjectURL(srcState.status === AsyncStatus.Success ? srcState.data : undefined);
 
     return (
       <Box

--- a/src/app/hooks/useObjectURL.ts
+++ b/src/app/hooks/useObjectURL.ts
@@ -15,3 +15,12 @@ export const useObjectURL = (object?: Blob): string | undefined => {
 
   return url;
 };
+
+export const useRevokeObjectURL = (url?: string): void => {
+  useEffect(
+    () => () => {
+      if (url?.startsWith('blob:')) URL.revokeObjectURL(url);
+    },
+    [url]
+  );
+};

--- a/src/app/utils/mediaTransport.ts
+++ b/src/app/utils/mediaTransport.ts
@@ -19,6 +19,8 @@ export type MediaTransportOptions = {
 
 const inflightRequests = new Map<string, Promise<Blob>>();
 
+const MEDIA_FETCH_TIMEOUT_MS = 30_000;
+
 const MATRIX_SESSIONS_KEY = 'matrixSessions';
 const ACTIVE_SESSION_KEY = 'matrixActiveSession';
 const FALLBACK_ACCESS_TOKEN_KEY = 'cinny_access_token';
@@ -214,6 +216,7 @@ async function fetchMediaResponse(
   const init: RequestInit = {
     method: 'GET',
     cache: getFetchCacheMode(cacheMode),
+    signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS),
     ...(Object.keys(headers).length > 0 ? { headers } : {}),
   };
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fix media loading stalling on Android/desktop after paginating through history: move the native media cache's file I/O off the async runtime, cap concurrent media fetches, add request timeouts, and revoke leaked object URLs for encrypted media.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
