### PR TITLE
fix(mobile): keep edit field focused so the keyboard doesn't flicker shut

### DIFF
--- a/.changeset/fix-mobile-edit-keyboard.md
+++ b/.changeset/fix-mobile-edit-keyboard.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix editing messages on mobile where tapping the edit field flickered the keyboard shut.

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -440,9 +440,12 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                 onPaste={onPaste}
                 // Defer to OS capitalization setting (respects iOS sentence-case toggle).
                 autoCapitalize="sentences"
-                // keeps focus after pressing send.
-                onBlur={() => {
-                  if (mobileOrTablet()) ReactEditor.focus(editor);
+                // keeps focus after pressing send, but yields to another editor.
+                onBlur={(evt) => {
+                  if (!mobileOrTablet()) return;
+                  const next = evt.relatedTarget as HTMLElement | null;
+                  if (next && next !== editableRef.current && next.isContentEditable) return;
+                  ReactEditor.focus(editor);
                 }}
                 style={{ boxShadow: 'none' }}
               />


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

On Android, tapping the inline message edit field opened the soft keyboard and instantly closed it. The always-mounted  composer and the message editor both refocus themselves on blur (mobile only), so they fought over focus and the  WebView dropped the keyboard. Each editor now yields focus when it's moving to another content-editable.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
