### PR TITLE
fix(tauri): open system browser for SSO device removal and cross-signing reset

### DIFF
--- a/.changeset/fix-tauri-sso-device-removal.md
+++ b/.changeset/fix-tauri-sso-device-removal.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix OIDC device removal, sessions dashboard, and cross-signing reset not opening a browser on Tauri mobile.

--- a/src/app/components/uia-stages/SSOStage.tsx
+++ b/src/app/components/uia-stages/SSOStage.tsx
@@ -1,7 +1,10 @@
 import { Box, Button, color, config, Dialog, Header, IconButton, Text } from 'folds';
 import { Warning, composerIcon, sizedIcon, X } from '$components/icons/phosphor';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
 import type { StageComponentProps } from './types';
+
+const POLL_COOLDOWN_MS = 1500;
 
 export function SSOStage({
   ssoRedirectURL,
@@ -13,6 +16,8 @@ export function SSOStage({
 }) {
   const { errorCode, error, session } = stageData;
   const [ssoWindow, setSSOWindow] = useState<Window>();
+  const [polling, setPolling] = useState(false);
+  const lastPollRef = useRef(0);
 
   const handleSubmit = useCallback(() => {
     submitAuthDict({
@@ -21,9 +26,27 @@ export function SSOStage({
   }, [submitAuthDict, session]);
 
   const handleContinue = () => {
+    if (isTauri()) {
+      import('@tauri-apps/plugin-opener')
+        .then(({ openUrl }) => openUrl(ssoRedirectURL))
+        .then(() => setPolling(true))
+        .catch(() => {
+          const w = window.open(ssoRedirectURL, '_blank');
+          setSSOWindow(w ?? undefined);
+        });
+      return;
+    }
     const w = window.open(ssoRedirectURL, '_blank');
     setSSOWindow(w ?? undefined);
   };
+
+  const triggerPoll = useCallback(() => {
+    if (!polling) return;
+    const now = Date.now();
+    if (now - lastPollRef.current < POLL_COOLDOWN_MS) return;
+    lastPollRef.current = now;
+    handleSubmit();
+  }, [polling, handleSubmit]);
 
   useEffect(() => {
     const handleMessage = (evt: MessageEvent) => {
@@ -35,6 +58,7 @@ export function SSOStage({
       ) {
         ssoWindow.close();
         setSSOWindow(undefined);
+        setPolling(false);
         handleSubmit();
       }
     };
@@ -44,6 +68,22 @@ export function SSOStage({
       window.removeEventListener('message', handleMessage);
     };
   }, [ssoWindow, handleSubmit, ssoRedirectURL]);
+
+  useEffect(() => {
+    if (!polling) return undefined;
+    const onFocus = () => triggerPoll();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') triggerPoll();
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [polling, triggerPoll]);
+
+  const showContinueButton = ssoWindow || polling;
 
   return (
     <Dialog>
@@ -77,8 +117,14 @@ export function SSOStage({
             </Text>
           </Box>
         )}
+        {polling && (
+          <Text size="T200">
+            Complete SSO in your browser, then return to the app. Your action will resume
+            automatically.
+          </Text>
+        )}
 
-        {ssoWindow ? (
+        {showContinueButton ? (
           <Button variant="Primary" onClick={handleSubmit}>
             <Text as="span" size="B400">
               Continue

--- a/src/app/features/settings/devices/OtherDevices.tsx
+++ b/src/app/features/settings/devices/OtherDevices.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
 import { Box, Button, config, Menu, Spinner, Text } from 'folds';
 import type { AuthDict, IAuthData, IMyDevice, MatrixError, UIAFlow } from '$types/matrix-sdk';
 import { SequenceCard } from '$components/sequence-card';
@@ -65,12 +66,16 @@ export function OtherDevices({ devices, refreshDeviceList, showVerification }: O
     const authUrl = authMetadata?.account_management_uri ?? authMetadata?.issuer;
     if (!authUrl) return;
 
-    window.open(
-      withSearchParam(authUrl, {
-        action: accountManagementActions.sessionsList,
-      }),
-      '_blank'
-    );
+    const url = withSearchParam(authUrl, {
+      action: accountManagementActions.sessionsList,
+    });
+    if (isTauri()) {
+      import('@tauri-apps/plugin-opener')
+        .then(({ openUrl }) => openUrl(url))
+        .catch(() => window.open(url, '_blank'));
+      return;
+    }
+    window.open(url, '_blank');
   }, [authMetadata, accountManagementActions]);
 
   const handleDeleteOIDC = useCallback(
@@ -78,13 +83,17 @@ export function OtherDevices({ devices, refreshDeviceList, showVerification }: O
       const authUrl = authMetadata?.account_management_uri ?? authMetadata?.issuer;
       if (!authUrl) return;
 
-      window.open(
-        withSearchParam(authUrl, {
-          action: accountManagementActions.sessionEnd,
-          device_id: deviceId,
-        }),
-        '_blank'
-      );
+      const url = withSearchParam(authUrl, {
+        action: accountManagementActions.sessionEnd,
+        device_id: deviceId,
+      });
+      if (isTauri()) {
+        import('@tauri-apps/plugin-opener')
+          .then(({ openUrl }) => openUrl(url))
+          .catch(() => window.open(url, '_blank'));
+        return;
+      }
+      window.open(url, '_blank');
     },
     [authMetadata, accountManagementActions]
   );

--- a/src/app/features/settings/devices/Verification.tsx
+++ b/src/app/features/settings/devices/Verification.tsx
@@ -1,5 +1,6 @@
 import type { MouseEventHandler } from 'react';
 import { useCallback, useState } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
 import type { RectCords } from 'folds';
 import {
   Badge,
@@ -274,12 +275,16 @@ export function DeviceVerificationOptions() {
 
     if (authMetadata) {
       const authUrl = authMetadata.account_management_uri ?? authMetadata.issuer;
-      window.open(
-        withSearchParam(authUrl, {
-          action: accountManagementActions.crossSigningReset,
-        }),
-        '_blank'
-      );
+      const url = withSearchParam(authUrl, {
+        action: accountManagementActions.crossSigningReset,
+      });
+      if (isTauri()) {
+        import('@tauri-apps/plugin-opener')
+          .then(({ openUrl }) => openUrl(url))
+          .catch(() => window.open(url, '_blank'));
+        return;
+      }
+      window.open(url, '_blank');
       return;
     }
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix OIDC device removal, sessions dashboard, and cross-signing reset not opening a browser on Tauri mobile.


Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
