### PR TITLE
fix(pwa): restore ios safe area regression

### DIFF
--- a/src/app/components/app-shell/SystemBarShell.test.tsx
+++ b/src/app/components/app-shell/SystemBarShell.test.tsx
@@ -40,4 +40,19 @@ describe('SystemBarShell', () => {
     });
     expect(container.querySelector('[data-system-bar-position="bottom"]')).not.toBeInTheDocument();
   });
+
+  it('ignores the bottom safe area on iOS while preserving the keyboard offset', () => {
+    mockIsTauri.mockReturnValue(true);
+    mockOsType.mockReturnValue('ios');
+
+    const { container } = render(
+      <SystemBarShell onPortalContainerChange={vi.fn<(node: HTMLDivElement | null) => void>()}>
+        <div>Content</div>
+      </SystemBarShell>
+    );
+
+    expect(container.querySelector('[data-system-bar-position="bottom"]')).toHaveStyle({
+      height: 'var(--keyboard-height, 0px)',
+    });
+  });
 });

--- a/src/app/components/app-shell/SystemBarShell.test.tsx
+++ b/src/app/components/app-shell/SystemBarShell.test.tsx
@@ -40,19 +40,4 @@ describe('SystemBarShell', () => {
     });
     expect(container.querySelector('[data-system-bar-position="bottom"]')).not.toBeInTheDocument();
   });
-
-  it('ignores the bottom safe area on iOS while preserving the keyboard offset', () => {
-    mockIsTauri.mockReturnValue(true);
-    mockOsType.mockReturnValue('ios');
-
-    const { container } = render(
-      <SystemBarShell onPortalContainerChange={vi.fn<(node: HTMLDivElement | null) => void>()}>
-        <div>Content</div>
-      </SystemBarShell>
-    );
-
-    expect(container.querySelector('[data-system-bar-position="bottom"]')).toHaveStyle({
-      height: 'var(--keyboard-height, 0px)',
-    });
-  });
 });

--- a/src/app/components/app-shell/SystemBarShell.test.tsx
+++ b/src/app/components/app-shell/SystemBarShell.test.tsx
@@ -27,7 +27,7 @@ describe('SystemBarShell', () => {
     const mutationObserver = vi.fn<() => void>();
     vi.stubGlobal('MutationObserver', mutationObserver);
 
-    render(
+    const { container } = render(
       <SystemBarShell onPortalContainerChange={vi.fn<(node: HTMLDivElement | null) => void>()}>
         <div>Content</div>
       </SystemBarShell>
@@ -35,5 +35,9 @@ describe('SystemBarShell', () => {
 
     expect(mockOsType).not.toHaveBeenCalled();
     expect(mutationObserver).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-system-bar-position="top"]')).toHaveStyle({
+      height: 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))',
+    });
+    expect(container.querySelector('[data-system-bar-position="bottom"]')).not.toBeInTheDocument();
   });
 });

--- a/src/app/components/app-shell/SystemBarShell.tsx
+++ b/src/app/components/app-shell/SystemBarShell.tsx
@@ -99,16 +99,19 @@ function useBarColor(
 }
 
 type SystemBarStripProps = {
+  edge: 'top' | 'bottom';
   size: string;
   background: string;
   stripRef?: RefObject<HTMLDivElement>;
   transition?: string;
 };
 
-function SystemBarStrip({ size, background, stripRef, transition }: SystemBarStripProps) {
+function SystemBarStrip({ edge, size, background, stripRef, transition }: SystemBarStripProps) {
   return (
     <div
       ref={stripRef}
+      aria-hidden="true"
+      data-system-bar-position={edge}
       style={{
         height: size,
         flexShrink: 0,
@@ -143,13 +146,12 @@ export function SystemBarShell({ children, onPortalContainerChange }: SystemBarS
 
   return (
     <>
-      {enabled && (
-        <SystemBarStrip
-          size={safeAreaTop}
-          background={topColor ?? 'var(--sable-bg-container)'}
-          stripRef={topStripRef}
-        />
-      )}
+      <SystemBarStrip
+        edge="top"
+        size={safeAreaTop}
+        background={topColor ?? 'var(--sable-bg-container)'}
+        stripRef={topStripRef}
+      />
 
       <div
         style={{
@@ -180,6 +182,7 @@ export function SystemBarShell({ children, onPortalContainerChange }: SystemBarS
 
       {enabled && (
         <SystemBarStrip
+          edge="bottom"
           size={tauriOs === 'ios' ? iosBottomInset : safeAreaBottom}
           background={bottomColor ?? 'var(--sable-surface-container)'}
           stripRef={bottomStripRef}

--- a/src/app/components/app-shell/SystemBarShell.tsx
+++ b/src/app/components/app-shell/SystemBarShell.tsx
@@ -5,7 +5,7 @@ import { updateThemeColorMeta } from '../../theme/themeColorMeta';
 
 const safeAreaTop = 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))';
 const safeAreaBottom = 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))';
-const iosBottomInset = 'var(--keyboard-height, 0px)';
+const iosBottomInset = `max(${safeAreaBottom}, var(--keyboard-height, 0px))`;
 const safeAreaLeft = 'var(--safe-area-inset-left, env(safe-area-inset-left, 0px))';
 const safeAreaRight = 'var(--safe-area-inset-right, env(safe-area-inset-right, 0px))';
 

--- a/src/app/components/app-shell/SystemBarShell.tsx
+++ b/src/app/components/app-shell/SystemBarShell.tsx
@@ -5,7 +5,7 @@ import { updateThemeColorMeta } from '../../theme/themeColorMeta';
 
 const safeAreaTop = 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))';
 const safeAreaBottom = 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))';
-const iosBottomInset = `max(${safeAreaBottom}, var(--keyboard-height, 0px))`;
+const iosBottomInset = 'var(--keyboard-height, 0px)';
 const safeAreaLeft = 'var(--safe-area-inset-left, env(safe-area-inset-left, 0px))';
 const safeAreaRight = 'var(--safe-area-inset-right, env(safe-area-inset-right, 0px))';
 

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -55,12 +55,19 @@ describe('android edge-to-edge inset contract', () => {
     expect(systemBarShell).toContain(
       'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))'
     );
-    expect(systemBarShell).toContain("const iosBottomInset = 'var(--keyboard-height, 0px)'");
     expect(systemBarShell).toContain('<SystemBarStrip\n        edge="top"');
     expect(systemBarShell).toContain(
       '{enabled && (\n        <SystemBarStrip\n          edge="bottom"'
     );
     expect(mobileCapability).toContain('"edge-to-edge:default"');
+  });
+
+  it('extends only standalone iOS PWAs to the dynamic viewport bottom', () => {
+    const indexCss = readWorkspaceFile('src/index.css');
+
+    expect(indexCss).toContain('@media (display-mode: standalone)');
+    expect(indexCss).toContain('@supports (-webkit-touch-callout: none)');
+    expect(indexCss).toContain('height: 100dvh');
   });
 
   it('removes the scattered safe-area css consumers', () => {

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -73,7 +73,7 @@ describe('android edge-to-edge inset contract', () => {
     expect(indexTsx).toContain('installIosPwaViewportHeight();');
     expect(iosPwaViewport).toContain("window.matchMedia('(display-mode: standalone)').matches");
     expect(iosPwaViewport).toContain('viewport.height + viewport.offsetTop');
-    expect(iosPwaViewport).toContain("window.setTimeout(updateHeight, 350)");
+    expect(iosPwaViewport).toContain('window.setTimeout(updateHeight, 350)');
   });
 
   it('removes the scattered safe-area css consumers', () => {

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -72,7 +72,9 @@ describe('android edge-to-edge inset contract', () => {
     expect(indexCss).toContain('var(--sable-ios-pwa-viewport-height, 100dvh)');
     expect(indexTsx).toContain('installIosPwaViewportHeight();');
     expect(iosPwaViewport).toContain("window.matchMedia('(display-mode: standalone)').matches");
-    expect(iosPwaViewport).toContain('viewport.height + viewport.offsetTop');
+    expect(iosPwaViewport).toContain('const MIN_KEYBOARD_HEIGHT = 100');
+    expect(iosPwaViewport).toContain('const keyboardOpen = fullHeight - visibleHeight');
+    expect(iosPwaViewport).toContain('const height = keyboardOpen ? visibleBottom : fullHeight');
     expect(iosPwaViewport).toContain('window.setTimeout(updateHeight, 350)');
   });
 

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -55,6 +55,7 @@ describe('android edge-to-edge inset contract', () => {
     expect(systemBarShell).toContain(
       'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))'
     );
+    expect(systemBarShell).toContain("const iosBottomInset = 'var(--keyboard-height, 0px)'");
     expect(systemBarShell).toContain('<SystemBarStrip\n        edge="top"');
     expect(systemBarShell).toContain(
       '{enabled && (\n        <SystemBarStrip\n          edge="bottom"'

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -55,6 +55,8 @@ describe('android edge-to-edge inset contract', () => {
     expect(systemBarShell).toContain(
       'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))'
     );
+    expect(systemBarShell).toContain('<SystemBarStrip\n        edge="top"');
+    expect(systemBarShell).toContain('{enabled && (\n        <SystemBarStrip\n          edge="bottom"');
     expect(mobileCapability).toContain('"edge-to-edge:default"');
   });
 

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -64,10 +64,16 @@ describe('android edge-to-edge inset contract', () => {
 
   it('extends only standalone iOS PWAs to the dynamic viewport bottom', () => {
     const indexCss = readWorkspaceFile('src/index.css');
+    const indexTsx = readWorkspaceFile('src/index.tsx');
+    const iosPwaViewport = readWorkspaceFile('src/app/utils/iosPwaViewport.ts');
 
     expect(indexCss).toContain('@media (display-mode: standalone)');
     expect(indexCss).toContain('@supports (-webkit-touch-callout: none)');
-    expect(indexCss).toContain('height: 100dvh');
+    expect(indexCss).toContain('var(--sable-ios-pwa-viewport-height, 100dvh)');
+    expect(indexTsx).toContain('installIosPwaViewportHeight();');
+    expect(iosPwaViewport).toContain("window.matchMedia('(display-mode: standalone)').matches");
+    expect(iosPwaViewport).toContain('viewport.height + viewport.offsetTop');
+    expect(iosPwaViewport).toContain("window.setTimeout(updateHeight, 350)");
   });
 
   it('removes the scattered safe-area css consumers', () => {

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -56,7 +56,9 @@ describe('android edge-to-edge inset contract', () => {
       'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))'
     );
     expect(systemBarShell).toContain('<SystemBarStrip\n        edge="top"');
-    expect(systemBarShell).toContain('{enabled && (\n        <SystemBarStrip\n          edge="bottom"');
+    expect(systemBarShell).toContain(
+      '{enabled && (\n        <SystemBarStrip\n          edge="bottom"'
+    );
     expect(mobileCapability).toContain('"edge-to-edge:default"');
   });
 

--- a/src/app/utils/iosPwaViewport.ts
+++ b/src/app/utils/iosPwaViewport.ts
@@ -1,4 +1,5 @@
 const IOS_PWA_VIEWPORT_HEIGHT = '--sable-ios-pwa-viewport-height';
+const MIN_KEYBOARD_HEIGHT = 100;
 
 const isStandaloneIosPwa = (): boolean =>
   window.matchMedia('(display-mode: standalone)').matches &&
@@ -9,11 +10,24 @@ export function installIosPwaViewportHeight(): void {
 
   let frame = 0;
   let settleTimer = 0;
+  let fullHeight = 0;
+  let viewportWidth = window.innerWidth;
 
   const updateHeight = () => {
     frame = 0;
     const viewport = window.visualViewport;
-    const height = viewport ? viewport.height + viewport.offsetTop : window.innerHeight;
+    const visibleHeight = viewport?.height ?? window.innerHeight;
+    const visibleBottom = visibleHeight + (viewport?.offsetTop ?? 0);
+
+    if (window.innerWidth !== viewportWidth) {
+      viewportWidth = window.innerWidth;
+      fullHeight = visibleBottom;
+    }
+
+    const keyboardOpen = fullHeight - visibleHeight > MIN_KEYBOARD_HEIGHT;
+    if (!keyboardOpen) fullHeight = Math.max(fullHeight, visibleBottom);
+
+    const height = keyboardOpen ? visibleBottom : fullHeight;
     document.documentElement.style.setProperty(IOS_PWA_VIEWPORT_HEIGHT, `${Math.round(height)}px`);
   };
 

--- a/src/app/utils/iosPwaViewport.ts
+++ b/src/app/utils/iosPwaViewport.ts
@@ -1,0 +1,35 @@
+const IOS_PWA_VIEWPORT_HEIGHT = '--sable-ios-pwa-viewport-height';
+
+const isStandaloneIosPwa = (): boolean =>
+  window.matchMedia('(display-mode: standalone)').matches &&
+  CSS.supports('-webkit-touch-callout: none');
+
+export function installIosPwaViewportHeight(): void {
+  if (!isStandaloneIosPwa()) return;
+
+  let frame = 0;
+  let settleTimer = 0;
+
+  const updateHeight = () => {
+    frame = 0;
+    const viewport = window.visualViewport;
+    const height = viewport ? viewport.height + viewport.offsetTop : window.innerHeight;
+    document.documentElement.style.setProperty(IOS_PWA_VIEWPORT_HEIGHT, `${Math.round(height)}px`);
+  };
+
+  const scheduleUpdate = () => {
+    if (frame) cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(updateHeight);
+
+    window.clearTimeout(settleTimer);
+    settleTimer = window.setTimeout(updateHeight, 350);
+  };
+
+  updateHeight();
+  window.addEventListener('resize', scheduleUpdate);
+  window.addEventListener('orientationchange', scheduleUpdate);
+  window.visualViewport?.addEventListener('resize', scheduleUpdate);
+  window.visualViewport?.addEventListener('scroll', scheduleUpdate);
+  document.addEventListener('focusin', scheduleUpdate);
+  document.addEventListener('focusout', scheduleUpdate);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,16 @@ body {
   flex-direction: column;
 }
 
+@media (display-mode: standalone) {
+  @supports (-webkit-touch-callout: none) {
+    html,
+    body,
+    #root {
+      height: 100dvh;
+    }
+  }
+}
+
 *,
 *::before,
 *::after {

--- a/src/index.css
+++ b/src/index.css
@@ -63,7 +63,7 @@ body {
     html,
     body,
     #root {
-      height: 100dvh;
+      height: var(--sable-ios-pwa-viewport-height, 100dvh);
     }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ import { registerMatrixUriProtocol } from './app/plugins/matrix-uri';
 import { initTauriMediaSession } from './app/utils/tauriMediaAuth';
 import { registerAppServiceWorker } from './serviceWorkerBootstrap';
 import { hasServiceWorker } from './app/utils/platform';
+import { installIosPwaViewportHeight } from './app/utils/iosPwaViewport';
 
 enableMapSet();
 installConsolePasteScamWarning();
@@ -30,6 +31,7 @@ registerMatrixUriProtocol();
 const log = createLogger('index');
 
 document.body.classList.add(configClass, varsClass);
+installIosPwaViewportHeight();
 
 registerAppServiceWorker();
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

After the tauri, the ios pwa bottom safe area became empty, and the top went into the safe area instead of stopping below it. This hopefully fixes that.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
