### PR TITLE
feat(settings): hide desktop section on tauri mobile and web

### DIFF
--- a/.changeset/hide-desktop-settings-tauri-mobile.md
+++ b/.changeset/hide-desktop-settings-tauri-mobile.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Hide the desktop settings section on Tauri mobile and web.

--- a/src/app/features/settings/Settings.tsx
+++ b/src/app/features/settings/Settings.tsx
@@ -62,6 +62,7 @@ import { useSettingsFocus } from './useSettingsFocus';
 import { SettingsLinkProvider } from './SettingsLinkContext';
 import { useSettingsLinkBaseUrl } from './useSettingsLinkBaseUrl';
 import { Desktop } from './desktop';
+import { isDesktopTauri } from '$utils/platform';
 
 export enum SettingsPages {
   GeneralPage,
@@ -192,12 +193,16 @@ export function Settings({
     : undefined;
 
   const [showPersona] = useSetting(settingsAtom, 'showPersonaSetting');
+  const isDesktop = isDesktopTauri();
   const settingsLinkBaseUrl = useSettingsLinkBaseUrl();
   const screenSize = useScreenSizeContext();
   const isControlled = activeSection !== undefined;
 
   const [legacyActivePage, setLegacyActivePage] = useState<SettingsPages | undefined>(() => {
     if (initialPage === SettingsPages.PerMessageProfilesPage && !showPersona) {
+      return SettingsPages.GeneralPage;
+    }
+    if (initialPage === SettingsPages.DesktopPage && !isDesktop) {
       return SettingsPages.GeneralPage;
     }
     if (initialPage) return initialPage;
@@ -215,18 +220,24 @@ export function Settings({
     if (section === 'persona' && !showPersona) {
       return 'general';
     }
+    if (section === 'desktop' && !isDesktop) {
+      return 'general';
+    }
     return section;
-  }, [activeSection, isControlled, legacyActivePage, showPersona]);
+  }, [activeSection, isControlled, legacyActivePage, showPersona, isDesktop]);
 
   const menuItems = useMemo<SettingsMenuItem[]>(
     () =>
       settingsSections
-        .filter((section) => showPersona || section.id !== 'persona')
+        .filter(
+          (section) =>
+            (showPersona || section.id !== 'persona') && (isDesktop || section.id !== 'desktop')
+        )
         .map((section) => {
           const icon = settingsMenuIcons[section.id];
           return { id: section.id, name: section.label, ...icon };
         }),
-    [showPersona]
+    [showPersona, isDesktop]
   );
 
   const handleSelectSection = (section: SettingsSectionId) => {

--- a/src/app/features/settings/SettingsRoute.tsx
+++ b/src/app/features/settings/SettingsRoute.tsx
@@ -4,6 +4,7 @@ import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 import { getSettingsPath } from '$pages/pathUtils';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
+import { isDesktopTauri } from '$utils/platform';
 import { trimTrailingSlash } from '$utils/common';
 import { getSettingsCloseTarget, type SettingsRouteState } from './navigation';
 import { Settings } from './Settings';
@@ -12,7 +13,8 @@ import { isSettingsSectionId, type SettingsSectionId } from './routes';
 function resolveSettingsSection(
   section: string | undefined,
   screenSize: ScreenSize,
-  showPersona: boolean
+  showPersona: boolean,
+  showDesktop: boolean
 ): SettingsSectionId | null {
   if (section === undefined) {
     return screenSize === ScreenSize.Mobile ? null : 'general';
@@ -23,6 +25,10 @@ function resolveSettingsSection(
   }
 
   if (section === 'persona' && !showPersona) {
+    return null;
+  }
+
+  if (section === 'desktop' && !showDesktop) {
     return null;
   }
 
@@ -40,6 +46,7 @@ export function SettingsRoute({ routeSection }: SettingsRouteProps) {
   const location = useLocation();
   const screenSize = useScreenSizeContext();
   const [showPersona] = useSetting(settingsAtom, 'showPersonaSetting');
+  const showDesktop = isDesktopTauri();
   const routeState = location.state as SettingsRouteState | null;
   const shallowBackgroundState =
     screenSize !== ScreenSize.Mobile && Boolean(routeState?.backgroundLocation);
@@ -55,7 +62,7 @@ export function SettingsRoute({ routeSection }: SettingsRouteProps) {
     (typeof browserHistoryIndex === 'number' && browserHistoryIndex > 0) ||
     location.key !== 'default';
 
-  const activeSection = resolveSettingsSection(section, screenSize, showPersona);
+  const activeSection = resolveSettingsSection(section, screenSize, showPersona, showDesktop);
   const shouldRedirectToGeneral = section === undefined && screenSize !== ScreenSize.Mobile;
   const shouldRedirectToIndex = section !== undefined && activeSection === null;
 

--- a/src/app/pages/client/profile/Profile.tsx
+++ b/src/app/pages/client/profile/Profile.tsx
@@ -34,6 +34,7 @@ import { useUserPresence } from '$hooks/useUserPresence';
 import { useUserProfile } from '$hooks/useUserProfile';
 import type { SettingsMenuItem } from '$features/settings';
 import { settingsMenuIcons, settingsSections, useOpenSettings } from '$features/settings';
+import { isDesktopTauri } from '$utils/platform';
 import { UserQuickTools } from '../sidebar/UserQuickTools';
 import {
   CaretDownIcon,
@@ -82,15 +83,19 @@ export function ProfileMobile() {
   const hideText = curWidth <= 80 && !isMobile;
 
   const [showPersona] = useSetting(settingsAtom, 'showPersonaSetting');
+  const isDesktop = isDesktopTauri();
   const menuItems = useMemo<SettingsMenuItem[]>(
     () =>
       settingsSections
-        .filter((section) => showPersona || section.id !== 'persona')
+        .filter(
+          (section) =>
+            (showPersona || section.id !== 'persona') && (isDesktop || section.id !== 'desktop')
+        )
         .map((section) => {
           const icon = settingsMenuIcons[section.id];
           return { id: section.id, name: section.label, ...icon };
         }),
-    [showPersona]
+    [showPersona, isDesktop]
   );
 
   return (

--- a/src/app/utils/platform.ts
+++ b/src/app/utils/platform.ts
@@ -1,8 +1,15 @@
 import { isTauri } from '@tauri-apps/api/core';
+import { type as osType } from '@tauri-apps/plugin-os';
 
 export function hasServiceWorker(): boolean {
   // Android WebViews (Tauri) do not support service workers.
   return 'serviceWorker' in navigator && !isTauri();
+}
+
+const DESKTOP_TAURI_OS = new Set(['linux', 'macos', 'windows']);
+
+export function isDesktopTauri(): boolean {
+  return isTauri() && DESKTOP_TAURI_OS.has(osType());
 }
 
 export function hasControllingServiceWorker(): boolean {


### PR DESCRIPTION


<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Desktop settings only apply on tauri desktop (linux/macos/windows). Filter the section from the settings menu and profile menu, and redirect direct /settings/desktop routes to the index on other platforms. Mirrors the existing persona-section guard.
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
