### PR TITLE
fix(notifications): sync background push toggle when OS permission denied

### DIFF
--- a/src/app/features/settings/notifications/NativePushNotifications.ts
+++ b/src/app/features/settings/notifications/NativePushNotifications.ts
@@ -69,7 +69,7 @@ function getPushGatewayUrl(clientConfig: ClientConfig): string {
   return pushGatewayUrl;
 }
 
-export async function isNativePushPermissionGranted(): Promise<boolean> {
+export async function isNativePushPermissionGranted(): Promise<boolean | null> {
   const api = await getNativePushNotificationsApi();
   return api.isPermissionGranted();
 }

--- a/src/app/features/settings/notifications/NativePushNotificationsApiClient.ts
+++ b/src/app/features/settings/notifications/NativePushNotificationsApiClient.ts
@@ -7,7 +7,7 @@ export type NativePushRegistration = {
 };
 
 export type NativePushNotificationsApi = {
-  isPermissionGranted: () => Promise<boolean>;
+  isPermissionGranted: () => Promise<boolean | null>;
   requestPermission: () => Promise<NotificationPermission>;
   registerForPushNotifications: (vapid?: string) => Promise<NativePushRegistration>;
   unregisterForPushNotifications: () => Promise<void>;

--- a/src/app/features/settings/notifications/NotificationTransportRuntimeFeature.tsx
+++ b/src/app/features/settings/notifications/NotificationTransportRuntimeFeature.tsx
@@ -7,18 +7,28 @@ import { useClientConfig } from '$hooks/useClientConfig';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { enableUnifiedPush } from './UnifiedPushNotifications';
-import { enableNativePush } from './NativePushNotifications';
+import { enableNativePush, isNativePushPermissionGranted } from './NativePushNotifications';
+import { isUnifiedPushPermissionGranted } from './UnifiedPushTransport';
 import {
   NotificationTransportRuntime,
   type NotificationTransportRuntimeContext,
 } from './NotificationTransportRuntime';
 import {
   type NotificationTransportPlatform,
+  type NotificationTransportProvider,
   normalizeNotificationTransportMode,
   resolvePreferredNotificationTransportProvider,
 } from './NotificationTransport';
 
 const log = createLogger('NotificationTransportRuntimeFeature');
+
+async function checkPushPermission(
+  provider: NotificationTransportProvider | null
+): Promise<boolean | null> {
+  if (provider === 'unifiedpush') return isUnifiedPushPermissionGranted();
+  if (provider === 'native') return isNativePushPermissionGranted();
+  return null;
+}
 
 function currentPlatform(): NotificationTransportPlatform {
   if (!isTauri()) return 'web';
@@ -31,8 +41,14 @@ function currentPlatform(): NotificationTransportPlatform {
 export function NotificationTransportRuntimeFeature() {
   const mx = useMatrixClient();
   const clientConfig = useClientConfig();
-  const [backgroundPushEnabled] = useSetting(settingsAtom, 'backgroundPushEnabled');
-  const [backgroundPushProvider] = useSetting(settingsAtom, 'backgroundPushProvider');
+  const [backgroundPushEnabled, setBackgroundPushEnabled] = useSetting(
+    settingsAtom,
+    'backgroundPushEnabled'
+  );
+  const [backgroundPushProvider, setBackgroundPushProvider] = useSetting(
+    settingsAtom,
+    'backgroundPushProvider'
+  );
   const [pushTransportMode] = useSetting(settingsAtom, 'pushTransportMode');
   const [pushTransportOverride] = useSetting(settingsAtom, 'pushTransportOverride');
   const [useInAppNotifications] = useSetting(settingsAtom, 'useInAppNotifications');
@@ -107,26 +123,33 @@ export function NotificationTransportRuntimeFeature() {
   useEffect(() => {
     if (!mx) return undefined;
 
-    if (provider === 'unifiedpush') {
-      enableUnifiedPush(mx, upConfigRef.current)
-        .then((result) => {
+    void (async () => {
+      const granted = await checkPushPermission(provider);
+      if (granted === false) {
+        setBackgroundPushEnabled(false);
+        setBackgroundPushProvider(null);
+        return;
+      }
+
+      try {
+        if (provider === 'unifiedpush') {
+          const result = await enableUnifiedPush(mx, upConfigRef.current);
           lastEndpointRef.current = result.endpoint;
-        })
-        .catch((error) => {
-          log.warn('UnifiedPush pusher registration failed at startup', error);
-        });
-    } else if (provider === 'native') {
-      enableNativePush(mx, clientConfigRef.current)
-        .then((token) => {
+        } else if (provider === 'native') {
+          const token = await enableNativePush(mx, clientConfigRef.current);
           lastEndpointRef.current = token;
-        })
-        .catch((error) => {
-          log.warn('Native push pusher registration failed at startup', error);
-        });
-    }
+        }
+      } catch (error) {
+        log.warn('Pusher registration failed at startup', error);
+        if ((await checkPushPermission(provider)) === false) {
+          setBackgroundPushEnabled(false);
+          setBackgroundPushProvider(null);
+        }
+      }
+    })();
 
     return () => {};
-  }, [provider, mx]);
+  }, [provider, mx, setBackgroundPushEnabled, setBackgroundPushProvider]);
 
   useEffect(
     () => () => {

--- a/src/app/features/settings/notifications/UnifiedPushTransport.ts
+++ b/src/app/features/settings/notifications/UnifiedPushTransport.ts
@@ -110,6 +110,11 @@ async function getUnifiedPushPermissionState(): Promise<UnifiedPushPermissionSta
   return permission === 'granted' ? 'granted' : permission;
 }
 
+export async function isUnifiedPushPermissionGranted(): Promise<boolean | null> {
+  const api = await getUnifiedPushTransportApi();
+  return api.isPermissionGranted();
+}
+
 export async function getUnifiedPushDistributors(): Promise<string[]> {
   const api = await getUnifiedPushTransportApi();
   return api.listDistributors();

--- a/src/app/features/settings/notifications/UnifiedPushTransportApiClient.ts
+++ b/src/app/features/settings/notifications/UnifiedPushTransportApiClient.ts
@@ -7,7 +7,7 @@ export type UnifiedPushRegistration = {
 };
 
 export type UnifiedPushTransportApi = {
-  isPermissionGranted: () => Promise<boolean>;
+  isPermissionGranted: () => Promise<boolean | null>;
   requestPermission: () => Promise<NotificationPermission>;
   registerForPushNotifications: (vapid?: string) => Promise<UnifiedPushRegistration>;
   unregisterForPushNotifications: () => Promise<void>;

--- a/src/types/tauri-plugin-notifications-api.d.ts
+++ b/src/types/tauri-plugin-notifications-api.d.ts
@@ -62,7 +62,7 @@ declare module '@choochmeque/tauri-plugin-notifications-api' {
     unregister: () => Promise<void> | void;
   };
 
-  export function isPermissionGranted(): Promise<boolean>;
+  export function isPermissionGranted(): Promise<boolean | null>;
   export function requestPermission(): Promise<NotificationPermission>;
   export function sendNotification(options: NotificationOptions | string): Promise<void>;
   export function registerForPushNotifications(): Promise<string>;


### PR DESCRIPTION

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On mobile, backgroundPushEnabled defaults to true. Startup auto-registration threw on permission denial but only logged a warning, leaving the toggle ON even though push was non-functional. Now syncs backgroundPushEnabled to false and clears the provider when registration fails due to denied/dismissed permission. Transient errors are left alone.


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
