### PR TITLE
fix(tauri): don't leak wry into CEF builds + don't gate updater manifest on android

### DIFF
--- a/.changeset/fix-cef-wry-leak.md
+++ b/.changeset/fix-cef-wry-leak.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Stop leaking `wry`/`tauri-runtime-wry` into CEF builds via `tauri-plugin-notifications` and `tauri-plugin-devtools`. CEF builds (`--no-default-features --features cef`) no longer pull `wry` or `tauri-runtime-wry`; `webkit2gtk` still comes in via `tauri-runtime` (upstream). Also removes the broken `not(feature = "cef")` target-cfg gate that produced a cargo warning.

--- a/.changeset/fix-cef-wry-leak.md
+++ b/.changeset/fix-cef-wry-leak.md
@@ -1,5 +1,0 @@
----
-default: patch
----
-
-Stop leaking `wry`/`tauri-runtime-wry` into CEF builds via `tauri-plugin-notifications` and `tauri-plugin-devtools`. CEF builds (`--no-default-features --features cef`) no longer pull `wry` or `tauri-runtime-wry`; `webkit2gtk` still comes in via `tauri-runtime` (upstream). Also removes the broken `not(feature = "cef")` target-cfg gate that produced a cargo warning.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -457,7 +457,7 @@ jobs:
 
   updater-manifest:
     name: Publish updater manifest
-    needs: [setup-release, build, android]
+    needs: [setup-release, build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5259,6 +5259,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "ts-rs",
+ "webkit2gtk",
  "windows",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5259,7 +5259,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "ts-rs",
- "webkit2gtk",
  "windows",
 ]
 
@@ -6441,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notifications"
 version = "0.5.0-rc.11"
-source = "git+https://github.com/SableClient/tauri-plugin-notifications.git?rev=4ea297bdeffaba6a8e2e4386a18fbd4dd59fa0f0#4ea297bdeffaba6a8e2e4386a18fbd4dd59fa0f0"
+source = "git+https://github.com/SableClient/tauri-plugin-notifications.git?rev=0ca647a8d762cbba2ecfbefed7ff13565ec46229#0ca647a8d762cbba2ecfbefed7ff13565ec46229"
 dependencies = [
  "log",
  "notify-rust",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -86,12 +86,9 @@ tauri-plugin-window-state = "2.4.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 gtk = "0.18"
-
-# WebKitGTK is the wry runtime on Linux, pulled transitively via
-# tauri-runtime-wry when Sable's `wry` feature is on. Not declared directly
-# here because cargo cannot gate target-cfg deps on cargo features
-# (`not(feature = "cef")` is silently ignored), and it's redundant with the
-# transitive dep from tauri-runtime-wry.
+# Used directly in lib.rs for WebKitGTK permission handling (wry only).
+# Optional + gated via the `wry` feature so CEF builds don't pull it.
+webkit2gtk = { version = "2.0", optional = true }
 
 # CEF (Chromium) runtime — Linux only; other platforms use wry.
 # Repackage of tauri's unreleased feat/cef branch. Switch to the official
@@ -117,7 +114,7 @@ jni = "0.21"
 [features]
 default = ["wry", "updater"]
 custom-protocol = ["tauri/custom-protocol"]
-wry = ["tauri/wry"]
+wry = ["tauri/wry", "dep:webkit2gtk"]
 # Tauri auto-updater. Disable with --no-default-features --features wry,cef.
 updater = ["dep:tauri-plugin-updater"]
 # CEF (Chromium) runtime. Build with --no-default-features --features cef.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,11 @@ tauri-plugin-clipboard-manager = "2.3.2"
 
 # Debug-only in practice: only initialized under #[cfg(debug_assertions)] in
 # lib.rs, so the release build never calls into it.
-tauri-plugin-devtools = "2.0.0"
+# default-features = false drops the plugin's `wry` feature (which enables
+# `tauri/wry`); Sable's own `wry` feature already enables `tauri/wry` for wry
+# builds, and CEF builds (--no-default-features --features cef) must not pull
+# wry/tauri-runtime-wry/webkit2gtk.
+tauri-plugin-devtools = { version = "2.0.0", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 enigo = "0.5.0"
@@ -67,12 +71,12 @@ windows = { version = "0.61", features = [
 tauri-plugin-single-instance = { version = "2.4.3", features = ["deep-link"] }
 
 [target.'cfg(any(windows, target_os = "linux"))'.dependencies]
-tauri-plugin-notifications = { git = "https://github.com/SableClient/tauri-plugin-notifications.git", rev = "4ea297bdeffaba6a8e2e4386a18fbd4dd59fa0f0" }
+tauri-plugin-notifications = { git = "https://github.com/SableClient/tauri-plugin-notifications.git", rev = "0ca647a8d762cbba2ecfbefed7ff13565ec46229" }
 
 # default-features = false drops notify-rust so macOS uses the native
 # UNUserNotificationCenter backend (needs a signed .app to deliver).
 [target.'cfg(target_os = "macos")'.dependencies]
-tauri-plugin-notifications = { git = "https://github.com/SableClient/tauri-plugin-notifications.git", rev = "4ea297bdeffaba6a8e2e4386a18fbd4dd59fa0f0", default-features = false }
+tauri-plugin-notifications = { git = "https://github.com/SableClient/tauri-plugin-notifications.git", rev = "0ca647a8d762cbba2ecfbefed7ff13565ec46229", default-features = false }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = { version = "2", optional = true }
@@ -83,9 +87,11 @@ tauri-plugin-window-state = "2.4.1"
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 gtk = "0.18"
 
-# WebKitGTK is the wry runtime; not needed under CEF.
-[target.'cfg(all(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"), not(feature = "cef")))'.dependencies]
-webkit2gtk = "2.0"
+# WebKitGTK is the wry runtime on Linux, pulled transitively via
+# tauri-runtime-wry when Sable's `wry` feature is on. Not declared directly
+# here because cargo cannot gate target-cfg deps on cargo features
+# (`not(feature = "cef")` is silently ignored), and it's redundant with the
+# transitive dep from tauri-runtime-wry.
 
 # CEF (Chromium) runtime — Linux only; other platforms use wry.
 # Repackage of tauri's unreleased feat/cef branch. Switch to the official
@@ -96,7 +102,7 @@ cef = { version = "=148.0.0", optional = true }
 libloading = "0.8"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-tauri-plugin-notifications = { git = "https://github.com/SableClient/tauri-plugin-notifications.git", rev = "4ea297bdeffaba6a8e2e4386a18fbd4dd59fa0f0", features = [
+tauri-plugin-notifications = { git = "https://github.com/SableClient/tauri-plugin-notifications.git", rev = "0ca647a8d762cbba2ecfbefed7ff13565ec46229", features = [
   "push-notifications",
 ] }
 tauri-plugin-edge-to-edge = { git = "https://github.com/SableClient/tauri-plugin-edge-to-edge.git", rev = "33c6116c27be28c06df5a9d02231ecc5fdeb93c5" }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

fix packaging to not including wry in cef build + don't wait 45 minutes to release the desktop auto update json

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
