### PR TITLE
fix: tauri settings links and copying to clipboard instead of share

### DIFF
--- a/src/app/components/setting-tile/SettingTile.tsx
+++ b/src/app/components/setting-tile/SettingTile.tsx
@@ -3,7 +3,7 @@ import { Box, IconButton, Text } from 'folds';
 import { Check, Link, sizedIcon } from '$components/icons/phosphor';
 import { BreakWord } from '$styles/Text.css';
 import { buildSettingsLink } from '$features/settings/settingsLink';
-import { shareText } from '$utils/share';
+import { copyToClipboard } from '$utils/dom';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 import { useTimeoutToggle } from '$hooks/useTimeoutToggle';
 import { useSettingsLinkContext } from '$features/settings/SettingsLinkContext';
@@ -52,7 +52,7 @@ function SettingTileSettingLinkAction({
           : settingTileSettingLinkActionMobileVisible,
       ].join(' ')}
       onClick={async () => {
-        if (await shareText(copyPath)) setCopied();
+        if (await copyToClipboard(copyPath)) setCopied();
       }}
       size="300"
       variant="Surface"

--- a/src/app/utils/platform.test.ts
+++ b/src/app/utils/platform.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { getAppOrigin } from './platform';
+import { isTauri } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: vi.fn<() => boolean>(),
+}));
+
+vi.mock('@tauri-apps/plugin-os', () => ({
+  type: vi.fn<() => string>(() => 'windows'),
+}));
+
+describe('getAppOrigin', () => {
+  beforeEach(() => {
+    vi.mocked(isTauri).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns https://app.sable.moe when running inside Tauri', () => {
+    vi.mocked(isTauri).mockReturnValue(true);
+    expect(getAppOrigin()).toBe('https://app.sable.moe');
+  });
+
+  it('returns https://app.sable.moe when hostname is tauri.localhost', () => {
+    vi.stubGlobal('location', {
+      origin: 'http://tauri.localhost',
+      hostname: 'tauri.localhost',
+      protocol: 'http:',
+      host: 'tauri.localhost',
+    });
+    expect(getAppOrigin()).toBe('https://app.sable.moe');
+  });
+
+  it('returns window.location.origin in normal web environment', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://app.sable.moe',
+      hostname: 'app.sable.moe',
+      protocol: 'https:',
+      host: 'app.sable.moe',
+    });
+    expect(getAppOrigin()).toBe('https://app.sable.moe');
+  });
+});

--- a/src/app/utils/platform.ts
+++ b/src/app/utils/platform.ts
@@ -18,6 +18,12 @@ export function hasControllingServiceWorker(): boolean {
 
 // window.location.origin is "null" on Tauri (tauri:// is opaque per WHATWG).
 export function getAppOrigin(): string {
+  if (
+    isTauri() ||
+    (typeof window !== 'undefined' && window.location.hostname === 'tauri.localhost')
+  ) {
+    return 'https://app.sable.moe';
+  }
   return window.location.origin === 'null'
     ? `${window.location.protocol}//${window.location.host}`
     : window.location.origin;


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Defaults tauri app settings links to app.sable.moe instead of the tauri.localhost thing, and makes the settings link copy buttons use the clipboard instead of os native shares

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
