### PR TITLE
feat: add always inline editor option for multiline messages

### DIFF
--- a/.changeset/keep-composer-inline.md
+++ b/.changeset/keep-composer-inline.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+The message composer no longer moves the input box above the send/emoji buttons when writing multiple lines. The box now grows in place and the buttons stay bottom-aligned beside it.

--- a/src/app/components/editor/Editor.css.ts
+++ b/src/app/components/editor/Editor.css.ts
@@ -15,7 +15,7 @@ export const Editor = style([
 
 export const EditorRow = style({
   gridTemplateColumns: 'auto 1fr auto',
-  alignItems: 'center',
+  alignItems: 'end',
 });
 
 export const EditorRowMultiline = style({
@@ -79,6 +79,10 @@ export const EditorTextarea = style([
     },
   },
 ]);
+
+export const EditorTextareaInline = style({
+  paddingBottom: toRem(13),
+});
 
 export const EditorResponsiveAfterMultiline = style([
   EditorOptions,

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -132,7 +132,8 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
     const hasBefore = Boolean(before);
     const hasAfter = Boolean(after);
     const hasResponsiveAfter = Boolean(responsiveAfter);
-    const layoutIsMultiline = isMultiline || forceMultilineLayout;
+    const [alwaysInlineEditor] = useSetting(settingsAtom, 'alwaysInlineEditor');
+    const layoutIsMultiline = !alwaysInlineEditor && (isMultiline || forceMultilineLayout);
     const showResponsiveAfterInFooter = hasResponsiveAfter && layoutIsMultiline;
     const showResponsiveAfterInline = hasResponsiveAfter && !showResponsiveAfterInFooter;
 
@@ -449,7 +450,7 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
               <Editable
                 ref={editableRef}
                 data-editable-name={editableName}
-                className={css.EditorTextarea}
+                className={`${css.EditorTextarea} ${alwaysInlineEditor ? css.EditorTextareaInline : ''}`}
                 placeholder={placeholder}
                 renderPlaceholder={renderPlaceholder}
                 renderElement={renderElement}

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -421,6 +421,10 @@ function DateAndTime() {
 function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
   const [enterForNewline, setEnterForNewline] = useSetting(settingsAtom, 'enterForNewline');
   const [editorToolbar, setEditorToolbar] = useSetting(settingsAtom, 'editorToolbar');
+  const [alwaysInlineEditor, setAlwaysInlineEditor] = useSetting(
+    settingsAtom,
+    'alwaysInlineEditor'
+  );
   const [editorOldAddFile, setEditorOldAddFile] = useSetting(settingsAtom, 'editorOldAddFile');
   const [hideActivity, setHideActivity] = useSetting(settingsAtom, 'hideActivity');
   const [hideReads, setHideReads] = useSetting(settingsAtom, 'hideReads');
@@ -450,6 +454,20 @@ function Editor({ isMobile }: Readonly<{ isMobile: boolean }>) {
               value={enterForNewline}
               onChange={setEnterForNewline}
               disabled={isMobile}
+            />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Always Inline Editor"
+          focusId="always-inline-editor"
+          description="Always keep the last line of the text editor inline with UI buttons"
+          after={
+            <Switch
+              variant="Primary"
+              value={alwaysInlineEditor}
+              onChange={setAlwaysInlineEditor}
             />
           }
         />

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -117,6 +117,7 @@ export interface Settings {
   editorToolbar: boolean;
   editorOldAddFile: boolean;
   composerToolbarOpen: boolean;
+  alwaysInlineEditor: boolean;
   messageLayout: MessageLayout;
   messageSpacing: MessageSpacing;
   hideMembershipEvents: boolean;
@@ -288,6 +289,7 @@ export const defaultSettings: Settings = {
   editorToolbar: false,
   editorOldAddFile: false,
   composerToolbarOpen: false,
+  alwaysInlineEditor: false,
   messageLayout: 0,
   messageSpacing: '400',
   hideMembershipEvents: false,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1181
Add an option to force the text editor to stay inline with the buttons. See corresponding issue.
Keep current editor style as default, as it's unique. 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

I used Opus 4.8 for generating the settings boilerplate. I manually reviewed and edited all generated output.