### PR TITLE
Fix synced local tweaks

### DIFF
--- a/.changeset/fix-synced-local-tweaks.md
+++ b/.changeset/fix-synced-local-tweaks.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Restore locally imported CSS tweaks when syncing settings between devices.

--- a/src/app/components/message/content/UploadedSableCssContent.tsx
+++ b/src/app/components/message/content/UploadedSableCssContent.tsx
@@ -66,7 +66,13 @@ function UploadedTweakCard({ data }: { data: Extract<SuccessfulUpload, { role: '
       const existing = favorites.find((favorite) => favorite.fullUrl === data.fullUrl);
       if (existing) {
         return favorites.map((favorite) =>
-          favorite.fullUrl === data.fullUrl && pinned ? { ...favorite, pinned: true } : favorite
+          favorite.fullUrl === data.fullUrl
+            ? {
+                ...favorite,
+                pinned: pinned ? true : favorite.pinned,
+                cssText: favorite.cssText ?? data.cssText,
+              }
+            : favorite
         );
       }
       return [
@@ -77,6 +83,7 @@ function UploadedTweakCard({ data }: { data: Extract<SuccessfulUpload, { role: '
           basename: data.basename,
           pinned,
           importedLocal: true,
+          cssText: data.cssText,
         },
       ];
     },

--- a/src/app/features/settings/cosmetics/ThemeCatalogSettings.test.tsx
+++ b/src/app/features/settings/cosmetics/ThemeCatalogSettings.test.tsx
@@ -37,7 +37,10 @@ const settings = {
 };
 
 vi.mock('$state/hooks/settings', () => ({
-  useSetting: (_atom: unknown, key: keyof typeof settings) => [settings[key], vi.fn()],
+  useSetting: (_atom: unknown, key: keyof typeof settings) => [
+    settings[key],
+    vi.fn<(value: unknown) => void>(),
+  ],
 }));
 vi.mock('$state/settings', () => ({
   settingsAtom: {},
@@ -49,7 +52,9 @@ vi.mock('$state/settings', () => ({
   }),
 }));
 vi.mock('$hooks/useClientConfig', () => ({ useClientConfig: () => ({}) }));
-vi.mock('$utils/share', () => ({ shareText: vi.fn() }));
+vi.mock('$utils/share', () => ({
+  shareText: vi.fn<(text: string) => Promise<boolean>>().mockResolvedValue(false),
+}));
 vi.mock('../../../theme/cache', () => ({
   getCachedThemeCss,
   putCachedThemeCss,

--- a/src/app/features/settings/cosmetics/ThemeCatalogSettings.test.tsx
+++ b/src/app/features/settings/cosmetics/ThemeCatalogSettings.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getCachedThemeCss, putCachedThemeCss } = vi.hoisted(() => ({
+  getCachedThemeCss: vi.fn<() => Promise<string | undefined>>(),
+  putCachedThemeCss: vi.fn<() => Promise<void>>(),
+}));
+
+type TweakFavorite = {
+  fullUrl: string;
+  displayName: string;
+  basename: string;
+  importedLocal: boolean;
+  cssText?: string;
+};
+
+const settings = {
+  themeRemoteFavorites: [],
+  themeRemoteTweakFavorites: [
+    {
+      fullUrl: 'sable-import://tweak/restored/full.sable.css',
+      displayName: 'Fallback name',
+      basename: 'restored',
+      importedLocal: true,
+      cssText: '/*\n@sable-tweak\nname: Restored tweak\n*/\n.restored {}',
+    },
+  ] as TweakFavorite[],
+  themeRemoteEnabledTweakFullUrls: [],
+  useSystemTheme: false,
+  themeRemoteManualFullUrl: undefined,
+  themeRemoteLightFullUrl: undefined,
+  themeRemoteDarkFullUrl: undefined,
+  themeChatSableWidgetsEnabled: false,
+  themeChatAutoPreviewApprovedUrls: [],
+  themeChatAutoPreviewAnyUrl: false,
+};
+
+vi.mock('$state/hooks/settings', () => ({
+  useSetting: (_atom: unknown, key: keyof typeof settings) => [settings[key], vi.fn()],
+}));
+vi.mock('$state/settings', () => ({
+  settingsAtom: {},
+  getSettings: () => ({
+    iconCompactSizePx: 16,
+    iconInlineSizePx: 20,
+    iconToolbarSizePx: 24,
+    iconEmptySizePx: 32,
+  }),
+}));
+vi.mock('$hooks/useClientConfig', () => ({ useClientConfig: () => ({}) }));
+vi.mock('$utils/share', () => ({ shareText: vi.fn() }));
+vi.mock('../../../theme/cache', () => ({
+  getCachedThemeCss,
+  putCachedThemeCss,
+}));
+
+import { ThemeCatalogSettings } from './ThemeCatalogSettings';
+
+describe('ThemeCatalogSettings saved tweaks', () => {
+  beforeEach(() => {
+    getCachedThemeCss.mockRejectedValue(new Error('no cache'));
+    putCachedThemeCss.mockRejectedValue(new Error('no cache'));
+  });
+
+  afterEach(() => {
+    settings.themeRemoteTweakFavorites = [
+      {
+        fullUrl: 'sable-import://tweak/restored/full.sable.css',
+        displayName: 'Fallback name',
+        basename: 'restored',
+        importedLocal: true,
+        cssText: '/*\n@sable-tweak\nname: Restored tweak\n*/\n.restored {}',
+      },
+    ];
+    getCachedThemeCss.mockReset().mockRejectedValue(new Error('no cache'));
+    putCachedThemeCss.mockReset().mockRejectedValue(new Error('no cache'));
+  });
+
+  it('lists restored embedded local CSS when the cache is unavailable', async () => {
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <ThemeCatalogSettings mode="local" />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByText('Tweaks (1)'));
+    expect(await screen.findByText('Restored tweak')).toBeInTheDocument();
+  });
+
+  it('shows zero and migration guidance for a fresh body-less legacy tweak', async () => {
+    settings.themeRemoteTweakFavorites = [
+      {
+        fullUrl: 'sable-import://tweak/legacy/full.sable.css',
+        displayName: 'Legacy',
+        basename: 'legacy',
+        importedLocal: true,
+      },
+    ];
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <ThemeCatalogSettings mode="local" />
+      </QueryClientProvider>
+    );
+    expect(screen.getByText('Tweaks (0)')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Tweaks (0)'));
+    expect(await screen.findByText(/waiting to migrate/)).toBeInTheDocument();
+  });
+
+  it('counts a cache-resolved legacy tweak without migration guidance', async () => {
+    settings.themeRemoteTweakFavorites = [
+      {
+        fullUrl: 'sable-import://tweak/legacy/full.sable.css',
+        displayName: 'Legacy',
+        basename: 'legacy',
+        importedLocal: true,
+      },
+    ];
+    getCachedThemeCss.mockResolvedValue('/*\n@sable-tweak\nname: Cached legacy\n*/\n.cached {}');
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <ThemeCatalogSettings mode="local" />
+      </QueryClientProvider>
+    );
+    fireEvent.click(screen.getByText('Tweaks (0)'));
+    expect(await screen.findByText('Cached legacy')).toBeInTheDocument();
+    expect(screen.getByText('Tweaks (1)')).toBeInTheDocument();
+    expect(screen.queryByText(/waiting to migrate/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/features/settings/cosmetics/ThemeCatalogSettings.tsx
+++ b/src/app/features/settings/cosmetics/ThemeCatalogSettings.tsx
@@ -39,7 +39,12 @@ import {
   type ThemePair,
   type TweakCatalogEntry,
 } from '../../../theme/catalog';
-import { isLocalImportBundledUrl, isLocalImportThemeUrl } from '../../../theme/localImportUrls';
+import {
+  isLocalImportBundledUrl,
+  isLocalImportThemeUrl,
+  isLocalImportTweakUrl,
+} from '../../../theme/localImportUrls';
+import { resolveSavedTweakCss } from '../../../theme/syncedTweakCss';
 import { isThirdPartyThemeUrl } from '../../../theme/themeApproval';
 import { themeCatalogListingBaseUrl } from '../../../theme/catalogDefaults';
 import {
@@ -579,14 +584,17 @@ export function ThemeCatalogSettings({
   });
 
   const localTweaksQuery = useQuery({
-    queryKey: ['theme-local-tweaks', tweakFavorites.map((f) => f.fullUrl).join('|')],
+    queryKey: [
+      'theme-local-tweaks',
+      tweakFavorites.map((f) => `${f.fullUrl}:${f.cssText ?? ''}`).join('|'),
+    ],
     enabled: showSavedLibrary && tweakFavorites.length > 0,
     staleTime: 10 * 60_000,
     queryFn: async (): Promise<LocalTweakRow[]> => {
       const rows = await Promise.all(
         tweakFavorites.map(async (fav) => {
           try {
-            let text = (await getCachedThemeCss(fav.fullUrl)) ?? '';
+            let text = await resolveSavedTweakCss(fav);
             if (!isLocalImportBundledUrl(fav.fullUrl)) {
               try {
                 const res = await fetch(fav.fullUrl, { mode: 'cors' });
@@ -616,6 +624,23 @@ export function ThemeCatalogSettings({
       return rows.filter((r): r is LocalTweakRow => Boolean(r));
     },
   });
+  const resolvedTweakUrls = new Set(
+    localTweaksQuery.isSuccess ? localTweaksQuery.data.map((row) => row.fullUrl) : []
+  );
+  const provisionalTweakCount = tweakFavorites.filter(
+    (favorite) => !isLocalImportTweakUrl(favorite.fullUrl) || Boolean(favorite.cssText)
+  ).length;
+  const savedTweakCount = localTweaksQuery.isSuccess
+    ? resolvedTweakUrls.size
+    : provisionalTweakCount;
+  const unresolvedLegacyTweakCount = localTweaksQuery.isSuccess
+    ? tweakFavorites.filter(
+        (favorite) =>
+          isLocalImportTweakUrl(favorite.fullUrl) &&
+          !favorite.cssText &&
+          !resolvedTweakUrls.has(favorite.fullUrl)
+      ).length
+    : 0;
 
   const removeFavorite = useCallback(
     (fullUrl: string) => {
@@ -1103,7 +1128,7 @@ export function ThemeCatalogSettings({
                   radii="Pill"
                   onClick={() => setSavedSection('tweaks')}
                 >
-                  <Text size="B300">Tweaks ({tweakFavorites.length})</Text>
+                  <Text size="B300">Tweaks ({savedTweakCount})</Text>
                 </Chip>
               </Box>
               <Box direction="Row" gap="100" alignItems="Center">
@@ -1263,9 +1288,17 @@ export function ThemeCatalogSettings({
                       paddingRight: toRem(4),
                     }}
                   >
+                    {localTweaksQuery.data.length > 0 && unresolvedLegacyTweakCount > 0 && (
+                      <Text size="T300" priority="300">
+                        {unresolvedLegacyTweakCount} saved local tweak
+                        {unresolvedLegacyTweakCount === 1 ? ' is' : 's are'} waiting to migrate.
+                      </Text>
+                    )}
                     {localTweaksQuery.data.length === 0 ? (
                       <Text size="T300" priority="300">
-                        Could not load tweak CSS. Check the URL or your connection.
+                        {unresolvedLegacyTweakCount === tweakFavorites.length
+                          ? 'Some saved local tweaks are waiting to migrate. Open Sable on a device that still has them to finish syncing.'
+                          : 'Could not load tweak CSS. Check the URL or your connection.'}
                       </Text>
                     ) : (
                       localTweaksQuery.data.map((row) => {

--- a/src/app/features/settings/cosmetics/ThemeImportModal.tsx
+++ b/src/app/features/settings/cosmetics/ThemeImportModal.tsx
@@ -96,6 +96,7 @@ export function ThemeImportModal({ open, onClose }: ThemeImportModalProps) {
           basename: r.basename,
           pinned: true,
           importedLocal: r.importedLocal,
+          cssText: r.cssText,
         };
         const nextEnabled = enabledTweakFullUrls.includes(r.fullUrl)
           ? [...enabledTweakFullUrls]

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -1424,6 +1424,7 @@ function Sync() {
       ? `Last synced at ${dayjs(lastSynced).format('HH:mm:ss')}`
       : 'Not yet synced this session',
     syncing: 'Syncing…',
+    partial: 'Settings synced, but some local tweaks were too large to sync.',
     error: 'Sync failed — will retry on next change',
   };
 
@@ -1456,7 +1457,7 @@ function Sync() {
         <SettingTile
           title="Sync settings across devices"
           focusId="sync-across-devices"
-          description="Store your settings in your Matrix account so they follow you to any Sable instance. Notification and zoom preferences are kept per-device."
+          description="Store your settings in your Matrix account so they follow you to any Sable instance. Locally imported tweak CSS is uploaded as unencrypted account data readable by your homeserver. Notification and zoom preferences are kept per-device."
           after={<Switch variant="Primary" value={syncEnabled} onChange={setSyncEnabled} />}
         />
         {syncEnabled && (

--- a/src/app/hooks/useSettingsSync.test.tsx
+++ b/src/app/hooks/useSettingsSync.test.tsx
@@ -275,7 +275,7 @@ describe('useSettingsSyncEffect — debounced upload', () => {
   });
 
   it('cancels a stale deferred backfill when settings change', async () => {
-    let resolveCache: (css: string | undefined) => void = () => undefined;
+    let resolveCache: ((css: string | undefined) => void) | undefined;
     getCachedThemeCss.mockImplementationOnce(
       () => new Promise<string | undefined>((resolve) => (resolveCache = resolve))
     );
@@ -292,13 +292,13 @@ describe('useSettingsSyncEffect — debounced upload', () => {
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
     act(() => vi.advanceTimersByTime(2000));
     act(() => store.set(settingsAtom, { ...store.get(settingsAtom), twitterEmoji: false }));
-    resolveCache('body {}');
+    resolveCache?.('body {}');
     await act(async () => await Promise.resolve());
     expect(mockMx.setAccountData).not.toHaveBeenCalled();
   });
 
   it('cancels a deferred backfill when settings sync is disabled', async () => {
-    let resolveCache: (css: string | undefined) => void = () => undefined;
+    let resolveCache: ((css: string | undefined) => void) | undefined;
     getCachedThemeCss.mockImplementationOnce(
       () => new Promise<string | undefined>((resolve) => (resolveCache = resolve))
     );
@@ -315,7 +315,7 @@ describe('useSettingsSyncEffect — debounced upload', () => {
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
     act(() => vi.advanceTimersByTime(2000));
     act(() => store.set(settingsAtom, { ...store.get(settingsAtom), settingsSyncEnabled: false }));
-    resolveCache('body {}');
+    resolveCache?.('body {}');
     await act(async () => await Promise.resolve());
     expect(mockMx.setAccountData).not.toHaveBeenCalled();
   });
@@ -347,7 +347,7 @@ describe('useSettingsSyncEffect — debounced upload', () => {
   });
 
   it('keeps idle state after disabling sync during an in-flight request and ignores its late failure', async () => {
-    let rejectUpload: (error: Error) => void = () => undefined;
+    let rejectUpload: ((error: Error) => void) | undefined;
     mockMx.setAccountData.mockImplementationOnce(
       () => new Promise<void>((_resolve, reject) => (rejectUpload = reject))
     );
@@ -360,7 +360,7 @@ describe('useSettingsSyncEffect — debounced upload', () => {
     expect(store.get(settingsSyncStatusAtom)).toBe('syncing');
     act(() => store.set(settingsAtom, { ...store.get(settingsAtom), settingsSyncEnabled: false }));
     expect(store.get(settingsSyncStatusAtom)).toBe('idle');
-    rejectUpload(new Error('late failure'));
+    rejectUpload?.(new Error('late failure'));
     await act(async () => await Promise.resolve());
     expect(store.get(settingsSyncStatusAtom)).toBe('idle');
     expect(store.get(settingsAtom).twitterEmoji).toBe(true);

--- a/src/app/hooks/useSettingsSync.test.tsx
+++ b/src/app/hooks/useSettingsSync.test.tsx
@@ -4,8 +4,19 @@ import { createStore, Provider } from 'jotai';
 import { createElement, type ReactNode } from 'react';
 import { settingsAtom, getSettings } from '$state/settings';
 
-import { SETTINGS_SYNC_VERSION } from '$utils/settingsSync';
+import { deserializeFromSync, SETTINGS_SYNC_VERSION } from '$utils/settingsSync';
 import { CustomAccountDataEvent } from '$types/matrix/accountData';
+
+const { getCachedThemeCss, putCachedThemeCss } = vi.hoisted(() => ({
+  getCachedThemeCss: vi
+    .fn<(url: string) => Promise<string | undefined>>()
+    .mockResolvedValue(undefined),
+  putCachedThemeCss: vi
+    .fn<(url: string, cssText: string) => Promise<void>>()
+    .mockResolvedValue(undefined),
+}));
+
+vi.mock('../theme/cache', () => ({ getCachedThemeCss, putCachedThemeCss }));
 
 import {
   settingsSyncLastSyncedAtom,
@@ -136,6 +147,55 @@ describe('useSettingsSyncEffect — sync enabled on mount', () => {
     expect(store.get(settingsAtom).twitterEmoji).toBe(false);
   });
 
+  it('best-effort hydrates embedded local tweak CSS without delaying settings application', async () => {
+    const tweakUrl = 'sable-import://tweak/restored/full.sable.css';
+    mockMx.getAccountData.mockReturnValueOnce({
+      getContent: () => ({
+        v: SETTINGS_SYNC_VERSION,
+        settings: {
+          themeRemoteTweakFavorites: [
+            {
+              fullUrl: tweakUrl,
+              displayName: 'Restored',
+              basename: 'restored',
+              cssText: 'body {}',
+            },
+          ],
+        },
+      }),
+    });
+    const store = makeStore({ settingsSyncEnabled: true });
+
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+
+    expect(store.get(settingsAtom).themeRemoteTweakFavorites[0]?.cssText).toBe('body {}');
+    await vi.waitFor(() => expect(putCachedThemeCss).toHaveBeenCalledWith(tweakUrl, 'body {}'));
+  });
+
+  it('keeps an oversized source-only local tweak on initial remote settings load', () => {
+    const oversizedUrl = 'sable-import://tweak/oversized/full.sable.css';
+    mockMx.getAccountData.mockReturnValueOnce({
+      getContent: () => ({
+        v: SETTINGS_SYNC_VERSION,
+        settings: { themeRemoteTweakFavorites: [], themeRemoteEnabledTweakFullUrls: [] },
+      }),
+    });
+    const store = makeStore({
+      settingsSyncEnabled: true,
+      themeRemoteTweakFavorites: [
+        {
+          fullUrl: oversizedUrl,
+          displayName: 'Oversized',
+          basename: 'oversized',
+          cssText: 'x'.repeat(256 * 1024 + 1),
+        },
+      ],
+      themeRemoteEnabledTweakFullUrls: [oversizedUrl],
+    });
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+    expect(store.get(settingsAtom).themeRemoteEnabledTweakFullUrls).toContain(oversizedUrl);
+  });
+
   it('sets lastSynced after loading from account data on mount', () => {
     const remoteContent = { v: SETTINGS_SYNC_VERSION, settings: { twitterEmoji: false } };
     mockMx.getAccountData.mockReturnValueOnce({ getContent: () => remoteContent });
@@ -172,12 +232,13 @@ describe('useSettingsSyncEffect — debounced upload', () => {
     vi.useRealTimers();
   });
 
-  it('uploads settings after the debounce delay', () => {
+  it('uploads settings after the debounce delay', async () => {
     const store = makeStore({ settingsSyncEnabled: true });
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(2000);
+      await Promise.resolve();
     });
 
     expect(mockMx.setAccountData).toHaveBeenCalledOnce();
@@ -190,12 +251,82 @@ describe('useSettingsSyncEffect — debounced upload', () => {
     expect(typeof content.synctoken).toBe('string');
   });
 
-  it('sets sync status to syncing while the upload is in flight', () => {
+  it('backfills legacy local tweak CSS from cache into the upload payload', async () => {
+    const tweakUrl = 'sable-import://tweak/legacy/full.sable.css';
+    getCachedThemeCss.mockResolvedValueOnce('.legacy { color: purple; }');
+    const store = makeStore({
+      settingsSyncEnabled: true,
+      themeRemoteTweakFavorites: [{ fullUrl: tweakUrl, displayName: 'Legacy', basename: 'legacy' }],
+    });
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    const uploadedContent = mockMx.setAccountData.mock.calls[0]?.[1];
+    expect(uploadedContent?.settings).toMatchObject({
+      themeRemoteTweakFavorites: [{ fullUrl: tweakUrl, cssText: '.legacy { color: purple; }' }],
+    });
+    expect(
+      deserializeFromSync(uploadedContent, getSettings())?.themeRemoteTweakFavorites[0]?.cssText
+    ).toBe('.legacy { color: purple; }');
+  });
+
+  it('cancels a stale deferred backfill when settings change', async () => {
+    let resolveCache: (css: string | undefined) => void = () => undefined;
+    getCachedThemeCss.mockImplementationOnce(
+      () => new Promise<string | undefined>((resolve) => (resolveCache = resolve))
+    );
+    const store = makeStore({
+      settingsSyncEnabled: true,
+      themeRemoteTweakFavorites: [
+        {
+          fullUrl: 'sable-import://tweak/legacy/full.sable.css',
+          displayName: 'Legacy',
+          basename: 'legacy',
+        },
+      ],
+    });
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => store.set(settingsAtom, { ...store.get(settingsAtom), twitterEmoji: false }));
+    resolveCache('body {}');
+    await act(async () => await Promise.resolve());
+    expect(mockMx.setAccountData).not.toHaveBeenCalled();
+  });
+
+  it('cancels a deferred backfill when settings sync is disabled', async () => {
+    let resolveCache: (css: string | undefined) => void = () => undefined;
+    getCachedThemeCss.mockImplementationOnce(
+      () => new Promise<string | undefined>((resolve) => (resolveCache = resolve))
+    );
+    const store = makeStore({
+      settingsSyncEnabled: true,
+      themeRemoteTweakFavorites: [
+        {
+          fullUrl: 'sable-import://tweak/legacy/full.sable.css',
+          displayName: 'Legacy',
+          basename: 'legacy',
+        },
+      ],
+    });
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => store.set(settingsAtom, { ...store.get(settingsAtom), settingsSyncEnabled: false }));
+    resolveCache('body {}');
+    await act(async () => await Promise.resolve());
+    expect(mockMx.setAccountData).not.toHaveBeenCalled();
+  });
+
+  it('sets sync status to syncing after cache backfill while the upload is in flight', async () => {
     const store = makeStore({ settingsSyncEnabled: true });
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(2000);
+      await Promise.resolve();
     });
 
     expect(store.get(settingsSyncStatusAtom)).toBe('syncing');
@@ -213,6 +344,26 @@ describe('useSettingsSyncEffect — debounced upload', () => {
     });
 
     expect(store.get(settingsSyncStatusAtom)).toBe('error');
+  });
+
+  it('keeps idle state after disabling sync during an in-flight request and ignores its late failure', async () => {
+    let rejectUpload: (error: Error) => void = () => undefined;
+    mockMx.setAccountData.mockImplementationOnce(
+      () => new Promise<void>((_resolve, reject) => (rejectUpload = reject))
+    );
+    const store = makeStore({ settingsSyncEnabled: true, twitterEmoji: true });
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    expect(store.get(settingsSyncStatusAtom)).toBe('syncing');
+    act(() => store.set(settingsAtom, { ...store.get(settingsAtom), settingsSyncEnabled: false }));
+    expect(store.get(settingsSyncStatusAtom)).toBe('idle');
+    rejectUpload(new Error('late failure'));
+    await act(async () => await Promise.resolve());
+    expect(store.get(settingsSyncStatusAtom)).toBe('idle');
+    expect(store.get(settingsAtom).twitterEmoji).toBe(true);
   });
 });
 
@@ -234,8 +385,9 @@ describe('useSettingsSyncEffect — echo-token loop prevention', () => {
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
 
     // Trigger the upload.
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(2000);
+      await Promise.resolve();
     });
 
     // Capture the echo token that was uploaded.
@@ -262,8 +414,9 @@ describe('useSettingsSyncEffect — echo-token loop prevention', () => {
     const store = makeStore({ settingsSyncEnabled: true });
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(2000);
+      await Promise.resolve();
     });
 
     const uploadedContent: Record<string, unknown> | undefined =
@@ -289,13 +442,19 @@ describe('useSettingsSyncEffect — echo-token loop prevention', () => {
     expect(lastSynced!).toBeLessThanOrEqual(after);
   });
 
-  it('applies an event from another device (different or absent echo token)', () => {
+  it('applies an event from another device and hydrates its embedded local tweak CSS', async () => {
     const store = makeStore({ settingsSyncEnabled: true, twitterEmoji: true });
     renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+    const tweakUrl = 'sable-import://tweak/live/full.sable.css';
 
     const remoteEvent = makeSableSettingsEvent({
       v: SETTINGS_SYNC_VERSION,
-      settings: { twitterEmoji: false },
+      settings: {
+        twitterEmoji: false,
+        themeRemoteTweakFavorites: [
+          { fullUrl: tweakUrl, displayName: 'Live', basename: 'live', cssText: '.live {}' },
+        ],
+      },
       // No synctoken — definitely from another device.
     });
 
@@ -304,5 +463,32 @@ describe('useSettingsSyncEffect — echo-token loop prevention', () => {
     });
 
     expect(store.get(settingsAtom).twitterEmoji).toBe(false);
+    await vi.waitFor(() => expect(putCachedThemeCss).toHaveBeenCalledWith(tweakUrl, '.live {}'));
+  });
+
+  it('keeps an oversized source-only local tweak on a live remote update', () => {
+    const oversizedUrl = 'sable-import://tweak/oversized-live/full.sable.css';
+    const store = makeStore({
+      settingsSyncEnabled: true,
+      themeRemoteTweakFavorites: [
+        {
+          fullUrl: oversizedUrl,
+          displayName: 'Oversized',
+          basename: 'oversized',
+          cssText: 'x'.repeat(256 * 1024 + 1),
+        },
+      ],
+      themeRemoteEnabledTweakFullUrls: [oversizedUrl],
+    });
+    renderHook(() => useSettingsSyncEffect(), { wrapper: makeWrapper(store) });
+    act(() => {
+      callbackHolder.current?.(
+        makeSableSettingsEvent({
+          v: SETTINGS_SYNC_VERSION,
+          settings: { themeRemoteTweakFavorites: [], themeRemoteEnabledTweakFullUrls: [] },
+        })
+      );
+    });
+    expect(store.get(settingsAtom).themeRemoteEnabledTweakFullUrls).toContain(oversizedUrl);
   });
 });

--- a/src/app/hooks/useSettingsSync.ts
+++ b/src/app/hooks/useSettingsSync.ts
@@ -5,10 +5,11 @@ import type { MatrixEvent } from '$types/matrix-sdk';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useAccountDataCallback } from '$hooks/useAccountDataCallback';
 import { settingsAtom } from '$state/settings';
-import { deserializeFromSync, serializeForSync } from '$utils/settingsSync';
+import { deserializeFromSync, prepareSettingsForSync } from '$utils/settingsSync';
 import { CustomAccountDataEvent } from '$types/matrix/accountData';
+import { backfillLocalTweakCss, hydrateSyncedLocalTweakCss } from '../theme/syncedTweakCss';
 
-export type SyncStatus = 'idle' | 'syncing' | 'error';
+export type SyncStatus = 'idle' | 'syncing' | 'partial' | 'error';
 
 /** Milliseconds to wait after a local settings change before uploading. */
 const DEBOUNCE_MS = 2000;
@@ -50,6 +51,7 @@ export function useSettingsSyncEffect(): void {
     const { synctoken: echoField, ...content } = event.getContent();
     const merged = deserializeFromSync(content, settingsRef.current);
     if (merged) {
+      void hydrateSyncedLocalTweakCss(merged.themeRemoteTweakFavorites);
       if (JSON.stringify(merged) !== JSON.stringify(settingsRef.current)) {
         setSettings(merged);
       }
@@ -57,29 +59,27 @@ export function useSettingsSyncEffect(): void {
     }
   }, [mx, syncEnabled, setSettings, setLastSynced]);
 
-  // Echo-detection: track the token of our last upload
-  // When our upload echoes back via ClientEvent.AccountData we skip applying it
-  // (to avoid overwriting settings that changed between upload and echo).
-  const pendingEchoTokenRef = useRef<string | null>(null);
+  const uploadGenerationRef = useRef(0);
+  const ownEchoesRef = useRef(new Map<string, { generation: number; status: SyncStatus }>());
 
   // Live updates from other devices
   const onAccountData = useCallback(
     (event: MatrixEvent) => {
       if (event.getType() !== (CustomAccountDataEvent.SableSettings as string)) return;
-      if (!settingsRef.current.settingsSyncEnabled) return;
-
       const rawContent = event.getContent();
-
-      // If this is the echo of our own upload, just confirm success and skip.
-      if (
-        typeof rawContent.synctoken === 'string' &&
-        rawContent.synctoken === pendingEchoTokenRef.current
-      ) {
-        pendingEchoTokenRef.current = null;
-        setLastSynced(Date.now());
-        setSyncStatus('idle');
+      const ownEcho =
+        typeof rawContent.synctoken === 'string'
+          ? ownEchoesRef.current.get(rawContent.synctoken)
+          : undefined;
+      if (ownEcho) {
+        ownEchoesRef.current.delete(rawContent.synctoken as string);
+        if (ownEcho.generation === uploadGenerationRef.current) {
+          setLastSynced(Date.now());
+          setSyncStatus(ownEcho.status);
+        }
         return;
       }
+      if (!settingsRef.current.settingsSyncEnabled) return;
 
       // Strip internal synctoken field before deserializing so stale tokens from
       // previous sessions (stored on the homeserver) don't bypass the check above
@@ -88,6 +88,7 @@ export function useSettingsSyncEffect(): void {
 
       // Otherwise it came from another device — apply it.
       const merged = deserializeFromSync(content, settingsRef.current);
+      if (merged) void hydrateSyncedLocalTweakCss(merged.themeRemoteTweakFavorites);
       // Skip if nothing actually changed (deserializeFromSync always returns a
       // new object, so compare values to avoid a spurious settings → upload loop).
       if (merged && JSON.stringify(merged) !== JSON.stringify(settingsRef.current)) {
@@ -105,23 +106,49 @@ export function useSettingsSyncEffect(): void {
   // Debounced upload whenever settings change
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
   useEffect(() => {
-    if (!syncEnabled) return undefined;
-
     clearTimeout(timerRef.current);
+    const generation = ++uploadGenerationRef.current;
+    if (!syncEnabled) {
+      setSyncStatus('idle');
+      return undefined;
+    }
+    let cancelled = false;
     timerRef.current = setTimeout(() => {
-      setSyncStatus('syncing');
-      const token = Math.random().toString(36).slice(2, 10);
-      pendingEchoTokenRef.current = token;
-      const content = { ...serializeForSync(settingsRef.current), synctoken: token };
-      mx.setAccountData(
-        CustomAccountDataEvent.SableSettings,
-        content as Record<string, unknown>
-      ).catch(() => {
-        pendingEchoTokenRef.current = null;
-        setSyncStatus('error');
-      });
+      void (async () => {
+        const current = settingsRef.current;
+        const themeRemoteTweakFavorites = await backfillLocalTweakCss(
+          current.themeRemoteTweakFavorites
+        );
+        if (
+          cancelled ||
+          generation !== uploadGenerationRef.current ||
+          !settingsRef.current.settingsSyncEnabled
+        )
+          return;
+        const prepared = prepareSettingsForSync({ ...current, themeRemoteTweakFavorites });
+        const token = Math.random().toString(36).slice(2, 10);
+        const completionStatus: SyncStatus =
+          prepared.excludedLocalTweakUrls.length > 0 ? 'partial' : 'idle';
+        ownEchoesRef.current.set(token, { generation, status: completionStatus });
+        setSyncStatus('syncing');
+        const content = {
+          ...prepared.content,
+          synctoken: token,
+        };
+        mx.setAccountData(
+          CustomAccountDataEvent.SableSettings,
+          content as Record<string, unknown>
+        ).catch(() => {
+          ownEchoesRef.current.delete(token);
+          if (generation === uploadGenerationRef.current) setSyncStatus('error');
+        });
+      })();
     }, DEBOUNCE_MS);
 
-    return () => clearTimeout(timerRef.current);
+    return () => {
+      cancelled = true;
+      if (generation === uploadGenerationRef.current) uploadGenerationRef.current += 1;
+      clearTimeout(timerRef.current);
+    };
   }, [mx, settings, syncEnabled, setSyncStatus]);
 }

--- a/src/app/pages/ThemeManager.test.tsx
+++ b/src/app/pages/ThemeManager.test.tsx
@@ -10,6 +10,12 @@ const settings = {
   underlineLinks: false,
   reducedMotion: false,
   themeRemoteEnabledTweakFullUrls: [] as string[],
+  themeRemoteTweakFavorites: [] as {
+    fullUrl: string;
+    displayName: string;
+    basename: string;
+    cssText?: string;
+  }[],
 };
 
 let systemThemeKind = ThemeKind.Light;
@@ -87,6 +93,7 @@ beforeEach(() => {
   settings.underlineLinks = false;
   settings.reducedMotion = false;
   settings.themeRemoteEnabledTweakFullUrls = [];
+  settings.themeRemoteTweakFavorites = [];
   cachedCss = '';
   cacheUpdateListener = undefined;
   document.body.className = '';
@@ -148,6 +155,29 @@ describe('ThemeManager', () => {
     cacheUpdateListener?.({ url: themeUrl, contentHash: 'new-hash' });
     await waitFor(() =>
       expect(document.getElementById('sable-remote-theme-style')).toHaveTextContent('blue')
+    );
+  });
+
+  it('applies embedded CSS for a restored local tweak when the cache is unavailable', async () => {
+    const tweakUrl = 'sable-import://tweak/restored/full.sable.css';
+    settings.themeRemoteEnabledTweakFullUrls = [tweakUrl];
+    settings.themeRemoteTweakFavorites = [
+      {
+        fullUrl: tweakUrl,
+        displayName: 'Restored',
+        basename: 'restored',
+        cssText: '.restored { color: red; }',
+      },
+    ];
+
+    render(
+      <AuthRouteThemeManager>
+        <div>child</div>
+      </AuthRouteThemeManager>
+    );
+
+    await waitFor(() =>
+      expect(document.getElementById('sable-remote-tweaks-style')).toHaveTextContent('color: red')
     );
   });
 });

--- a/src/app/pages/ThemeManager.tsx
+++ b/src/app/pages/ThemeManager.tsx
@@ -16,6 +16,7 @@ import { useOptionalClientConfig } from '$hooks/useClientConfig';
 import { getCachedThemeCss, putCachedThemeCss, subscribeThemeCacheUpdates } from '../theme/cache';
 import { applyCspNonce } from '$utils/cspNonce';
 import { isLocalImportBundledUrl } from '../theme/localImportUrls';
+import { getEmbeddedLocalTweakCss } from '../theme/syncedTweakCss';
 import { themeCatalogListingBaseUrl } from '../theme/catalogDefaults';
 import { fetch } from '$utils/fetch';
 import {
@@ -138,6 +139,7 @@ export function AuthRouteThemeManager({ children }: { children: ReactNode }) {
   const [underlineLinks] = useSetting(settingsAtom, 'underlineLinks');
   const [reducedMotion] = useSetting(settingsAtom, 'reducedMotion');
   const [enabledTweakUrls] = useSetting(settingsAtom, 'themeRemoteEnabledTweakFullUrls');
+  const [tweakFavorites] = useSetting(settingsAtom, 'themeRemoteTweakFavorites');
 
   useEffect(() => {
     document.body.className = '';
@@ -213,7 +215,15 @@ export function AuthRouteThemeManager({ children }: { children: ReactNode }) {
     }
 
     const applyTweakCss = async () => {
-      const texts = await Promise.all(urls.map((url) => loadRemoteThemeCssText(url.trim())));
+      const texts = await Promise.all(
+        urls.map((url) => {
+          const trimmedUrl = url.trim();
+          const embeddedCss = getEmbeddedLocalTweakCss(
+            tweakFavorites?.find((favorite) => favorite.fullUrl === trimmedUrl)
+          );
+          return embeddedCss ?? loadRemoteThemeCssText(trimmedUrl);
+        })
+      );
       if (cancelled) return;
       const chunks = texts.filter((text): text is string => Boolean(text));
       let node = document.getElementById(REMOTE_TWEAKS_STYLE_ID) as HTMLStyleElement | null;
@@ -235,7 +245,7 @@ export function AuthRouteThemeManager({ children }: { children: ReactNode }) {
       cancelled = true;
       unsubscribe();
     };
-  }, [enabledTweakUrls]);
+  }, [enabledTweakUrls, tweakFavorites]);
 
   return (
     <>

--- a/src/app/pages/ThemeManager.tsx
+++ b/src/app/pages/ThemeManager.tsx
@@ -216,7 +216,7 @@ export function AuthRouteThemeManager({ children }: { children: ReactNode }) {
 
     const applyTweakCss = async () => {
       const texts = await Promise.all(
-        urls.map((url) => {
+        urls.map(async (url) => {
           const trimmedUrl = url.trim();
           const embeddedCss = getEmbeddedLocalTweakCss(
             tweakFavorites?.find((favorite) => favorite.fullUrl === trimmedUrl)

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -7,6 +7,7 @@ import type {
   PushTransportOverrides,
 } from '$features/settings/notifications/NotificationTransport';
 import type { IImageInfo } from '$types/matrix/common';
+import { isLocalImportTweakUrl } from '../theme/localImportUrls';
 import { sanitizeShortcutOverrides, type ShortcutOverrides } from '../keyboard/shortcuts';
 
 const STORAGE_KEY = 'settings';
@@ -66,6 +67,8 @@ export type ThemeRemoteTweakFavorite = {
   basename: string;
   pinned?: boolean;
   importedLocal?: boolean;
+  /** CSS for locally imported tweaks, replicated with settings for device restore. */
+  cssText?: string;
 };
 
 /** Custom profile card hero colors: which brightness schemes to honor. */
@@ -589,7 +592,9 @@ function sanitizeThemeRemoteFavorites(val: unknown): ThemeRemoteFavorite[] | und
   return out;
 }
 
-function sanitizeThemeRemoteTweakFavorites(val: unknown): ThemeRemoteTweakFavorite[] | undefined {
+export function sanitizeThemeRemoteTweakFavorites(
+  val: unknown
+): ThemeRemoteTweakFavorite[] | undefined {
   if (!Array.isArray(val)) return undefined;
   const out: ThemeRemoteTweakFavorite[] = [];
   for (const item of val) {
@@ -600,12 +605,15 @@ function sanitizeThemeRemoteTweakFavorites(val: unknown): ThemeRemoteTweakFavori
       typeof o.displayName === 'string' &&
       typeof o.basename === 'string'
     ) {
+      const cssText =
+        isLocalImportTweakUrl(o.fullUrl) && typeof o.cssText === 'string' ? o.cssText : undefined;
       out.push({
         fullUrl: o.fullUrl,
         displayName: o.displayName,
         basename: o.basename,
         pinned: typeof o.pinned === 'boolean' ? o.pinned : undefined,
         importedLocal: typeof o.importedLocal === 'boolean' ? o.importedLocal : undefined,
+        cssText,
       });
     }
   }

--- a/src/app/theme/processThemeImport.test.ts
+++ b/src/app/theme/processThemeImport.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./cache', () => ({
+  putCachedThemeCss: vi
+    .fn<(url: string, cssText: string) => Promise<void>>()
+    .mockResolvedValue(undefined),
+}));
+
+import { processPastedOrUploadedCss } from './processThemeImport';
+
+describe('processPastedOrUploadedCss', () => {
+  it('returns CSS with a locally pasted tweak for settings sync', async () => {
+    const cssText = '/*\n@sable-tweak\nname: Pasted\n*/\n.pasted { color: red; }';
+    const result = await processPastedOrUploadedCss(cssText);
+
+    expect(result).toMatchObject({
+      ok: true,
+      role: 'tweak',
+      importedLocal: true,
+      cssText,
+    });
+  });
+});

--- a/src/app/theme/processThemeImport.ts
+++ b/src/app/theme/processThemeImport.ts
@@ -35,6 +35,8 @@ export type ProcessedThemeImport =
       basename: string;
       description?: string;
       importedLocal: boolean;
+      /** Present for pasted/uploaded local tweaks so callers can persist it with the favorite. */
+      cssText?: string;
     }
   | { ok: false; error: string };
 
@@ -268,6 +270,7 @@ export async function processPastedOrUploadedCss(
       basename,
       description: tweakMeta.description?.trim(),
       importedLocal: true,
+      cssText: trimmed,
     };
   }
 

--- a/src/app/theme/syncedTweakCss.test.ts
+++ b/src/app/theme/syncedTweakCss.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { getCachedThemeCss, putCachedThemeCss } = vi.hoisted(() => ({
+  getCachedThemeCss: vi
+    .fn<(url: string) => Promise<string | undefined>>()
+    .mockResolvedValue(undefined),
+  putCachedThemeCss: vi
+    .fn<(url: string, cssText: string) => Promise<void>>()
+    .mockResolvedValue(undefined),
+}));
+
+vi.mock('./cache', () => ({ getCachedThemeCss, putCachedThemeCss }));
+
+import {
+  getEmbeddedLocalTweakCss,
+  hydrateSyncedLocalTweakCss,
+  resolveSavedTweakCss,
+} from './syncedTweakCss';
+
+describe('synced local tweak CSS', () => {
+  it('hydrates only embedded local tweak CSS and tolerates cache failures', async () => {
+    putCachedThemeCss.mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+    await expect(
+      hydrateSyncedLocalTweakCss([
+        {
+          fullUrl: 'sable-import://tweak/one/full.sable.css',
+          displayName: 'One',
+          basename: 'one',
+          cssText: 'a {}',
+        },
+        {
+          fullUrl: 'https://example.test/tweak.sable.css',
+          displayName: 'Remote',
+          basename: 'remote',
+          cssText: 'b {}',
+        },
+      ])
+    ).resolves.toBeUndefined();
+    expect(putCachedThemeCss).toHaveBeenCalledTimes(1);
+  });
+
+  it('provides embedded CSS as a deterministic local-listing fallback only', () => {
+    expect(
+      getEmbeddedLocalTweakCss({
+        fullUrl: 'sable-import://tweak/one/full.sable.css',
+        displayName: 'One',
+        basename: 'one',
+        cssText: 'a {}',
+      })
+    ).toBe('a {}');
+    expect(
+      getEmbeddedLocalTweakCss({
+        fullUrl: 'https://example.test/tweak.sable.css',
+        displayName: 'Remote',
+        basename: 'remote',
+        cssText: 'b {}',
+      })
+    ).toBeUndefined();
+  });
+
+  it('resolves embedded local CSS for saved-tweak rendering when cache reads and writes fail', async () => {
+    const favorite = {
+      fullUrl: 'sable-import://tweak/one/full.sable.css',
+      displayName: 'One',
+      basename: 'one',
+      cssText: 'a {}',
+    };
+    getCachedThemeCss.mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+    putCachedThemeCss.mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+
+    await expect(resolveSavedTweakCss(favorite)).resolves.toBe('a {}');
+  });
+
+  it('prefers newer embedded local CSS over stale cached CSS', async () => {
+    getCachedThemeCss.mockResolvedValueOnce('stale {}');
+    const callsBefore = getCachedThemeCss.mock.calls.length;
+    await expect(
+      resolveSavedTweakCss({
+        fullUrl: 'sable-import://tweak/one/full.sable.css',
+        displayName: 'One',
+        basename: 'one',
+        cssText: 'new {}',
+      })
+    ).resolves.toBe('new {}');
+    expect(getCachedThemeCss).toHaveBeenCalledTimes(callsBefore);
+  });
+});

--- a/src/app/theme/syncedTweakCss.ts
+++ b/src/app/theme/syncedTweakCss.ts
@@ -1,0 +1,65 @@
+import type { ThemeRemoteTweakFavorite } from '$state/settings';
+
+import { getCachedThemeCss, putCachedThemeCss } from './cache';
+import { isLocalImportTweakUrl } from './localImportUrls';
+
+/**
+ * Restores replicated local tweak CSS to the device-local cache. Cache failures
+ * are deliberately ignored: settings sync must work without IndexedDB.
+ */
+export async function hydrateSyncedLocalTweakCss(
+  favorites: ThemeRemoteTweakFavorite[]
+): Promise<void> {
+  await Promise.all(
+    favorites.map(async ({ fullUrl, cssText }) => {
+      if (!isLocalImportTweakUrl(fullUrl) || typeof cssText !== 'string') return;
+      try {
+        await putCachedThemeCss(fullUrl, cssText);
+      } catch {
+        // IndexedDB may be unavailable (for example in private browsing).
+      }
+    })
+  );
+}
+
+/** CSS embedded in settings is only valid for local tweak imports. */
+export function getEmbeddedLocalTweakCss(
+  favorite: ThemeRemoteTweakFavorite | undefined
+): string | undefined {
+  return favorite && isLocalImportTweakUrl(favorite.fullUrl) ? favorite.cssText : undefined;
+}
+
+/** Resolve saved tweak CSS from cache, with embedded local CSS as a cache-independent fallback. */
+export async function resolveSavedTweakCss(favorite: ThemeRemoteTweakFavorite): Promise<string> {
+  const embeddedCss = getEmbeddedLocalTweakCss(favorite);
+  if (embeddedCss) {
+    void putCachedThemeCss(favorite.fullUrl, embeddedCss).catch(() => undefined);
+    return embeddedCss;
+  }
+  try {
+    const cachedCss = await getCachedThemeCss(favorite.fullUrl);
+    if (cachedCss) return cachedCss;
+  } catch {
+    // Embedded CSS remains usable when IndexedDB is unavailable.
+  }
+  return '';
+}
+
+/** Restores CSS for pre-sync local favorites from the device cache before upload. */
+export async function backfillLocalTweakCss(
+  favorites: ThemeRemoteTweakFavorite[]
+): Promise<ThemeRemoteTweakFavorite[]> {
+  return Promise.all(
+    favorites.map(async (favorite) => {
+      if (!isLocalImportTweakUrl(favorite.fullUrl) || typeof favorite.cssText === 'string') {
+        return favorite;
+      }
+      try {
+        const cssText = await getCachedThemeCss(favorite.fullUrl);
+        return typeof cssText === 'string' ? { ...favorite, cssText } : favorite;
+      } catch {
+        return favorite;
+      }
+    })
+  );
+}

--- a/src/app/utils/settingsSync.test.ts
+++ b/src/app/utils/settingsSync.test.ts
@@ -7,6 +7,7 @@ import {
   deserializeFromSync,
   exportSettingsAsJson,
   importSettingsFromJson,
+  prepareSettingsForSync,
 } from './settingsSync';
 
 // fixtures
@@ -181,6 +182,191 @@ describe('deserializeFromSync', () => {
     expect(result!.hour24Clock).toBe(true);
     // non-syncable comes from base, not tweaked (pageZoom etc. same anyway)
     expect(result!.settingsSyncEnabled).toBe(base.settingsSyncEnabled);
+  });
+
+  it('round-trips embedded local tweak CSS without changing the sync version', () => {
+    const tweakUrl = 'sable-import://tweak/restored/full.sable.css';
+    const tweaked = {
+      ...base,
+      themeRemoteTweakFavorites: [
+        { fullUrl: tweakUrl, displayName: 'Restored', basename: 'restored', cssText: 'body {}' },
+      ],
+    };
+    const payload = serializeForSync(tweaked);
+    expect(payload.v).toBe(SETTINGS_SYNC_VERSION);
+    expect(payload.settings.themeRemoteTweakFavorites?.[0]?.cssText).toBe('body {}');
+    expect(deserializeFromSync(payload, base)?.themeRemoteTweakFavorites[0]?.cssText).toBe(
+      'body {}'
+    );
+  });
+
+  it('atomically excludes local tweaks beyond the aggregate CSS budget and their enabled URLs', () => {
+    const firstUrl = 'sable-import://tweak/first/full.sable.css';
+    const secondUrl = 'sable-import://tweak/second/full.sable.css';
+    const prepared = prepareSettingsForSync({
+      ...base,
+      themeRemoteTweakFavorites: [
+        {
+          fullUrl: firstUrl,
+          displayName: 'First',
+          basename: 'first',
+          cssText: 'a'.repeat(256 * 1024),
+        },
+        { fullUrl: secondUrl, displayName: 'Second', basename: 'second', cssText: 'b' },
+      ],
+      themeRemoteEnabledTweakFullUrls: [firstUrl, secondUrl],
+    });
+    expect(prepared.excludedLocalTweakUrls).toEqual([secondUrl]);
+    expect(
+      prepared.content.settings.themeRemoteTweakFavorites?.map((favorite) => favorite.fullUrl)
+    ).toEqual([firstUrl]);
+    expect(prepared.content.settings.themeRemoteEnabledTweakFullUrls).toEqual([firstUrl]);
+  });
+
+  it('preserves locally excluded oversized tweaks and enabled URLs during a remote merge', () => {
+    const oversizedUrl = 'sable-import://tweak/oversized/full.sable.css';
+    const current = {
+      ...base,
+      themeRemoteTweakFavorites: [
+        {
+          fullUrl: oversizedUrl,
+          displayName: 'Oversized',
+          basename: 'oversized',
+          cssText: 'x'.repeat(256 * 1024 + 1),
+        },
+      ],
+      themeRemoteEnabledTweakFullUrls: [oversizedUrl],
+    };
+    const result = deserializeFromSync(
+      {
+        v: SETTINGS_SYNC_VERSION,
+        settings: {
+          themeRemoteTweakFavorites: [
+            {
+              fullUrl: 'https://example.test/remote.css',
+              displayName: 'Remote',
+              basename: 'remote',
+            },
+          ],
+          themeRemoteEnabledTweakFullUrls: ['https://example.test/remote.css'],
+        },
+      },
+      current
+    );
+    expect(result?.themeRemoteTweakFavorites.map((favorite) => favorite.fullUrl)).toEqual([
+      'https://example.test/remote.css',
+      oversizedUrl,
+    ]);
+    expect(result?.themeRemoteEnabledTweakFullUrls).toEqual([
+      'https://example.test/remote.css',
+      oversizedUrl,
+    ]);
+
+    const enabledOnlyResult = deserializeFromSync(
+      {
+        v: SETTINGS_SYNC_VERSION,
+        settings: { themeRemoteEnabledTweakFullUrls: ['https://example.test/remote.css'] },
+      },
+      current
+    );
+    expect(enabledOnlyResult?.themeRemoteEnabledTweakFullUrls).toEqual([
+      'https://example.test/remote.css',
+      oversizedUrl,
+    ]);
+  });
+
+  it('drops embedded CSS for remote tweak URLs without dropping local CSS', () => {
+    const remote = {
+      v: SETTINGS_SYNC_VERSION,
+      settings: {
+        themeRemoteTweakFavorites: [
+          {
+            fullUrl: 'https://example.test/tweak.sable.css',
+            displayName: 'Remote',
+            basename: 'remote',
+            cssText: 'body {}',
+          },
+          {
+            fullUrl: 'sable-import://tweak/local/full.sable.css',
+            displayName: 'Local',
+            basename: 'local',
+            cssText: 'body {}',
+          },
+        ],
+      },
+    };
+    expect(deserializeFromSync(remote, base)?.themeRemoteTweakFavorites).toEqual([
+      {
+        fullUrl: 'https://example.test/tweak.sable.css',
+        displayName: 'Remote',
+        basename: 'remote',
+      },
+      {
+        fullUrl: 'sable-import://tweak/local/full.sable.css',
+        displayName: 'Local',
+        basename: 'local',
+        cssText: 'body {}',
+      },
+    ]);
+  });
+
+  it('preserves body-less legacy local records for a source device to backfill later', () => {
+    const tweakUrl = 'sable-import://tweak/legacy/full.sable.css';
+    const remote = {
+      v: SETTINGS_SYNC_VERSION,
+      settings: {
+        themeRemoteTweakFavorites: [
+          { fullUrl: tweakUrl, displayName: 'Legacy', basename: 'legacy' },
+        ],
+        themeRemoteEnabledTweakFullUrls: [tweakUrl],
+      },
+    };
+    expect(
+      deserializeFromSync(remote, {
+        ...base,
+        themeRemoteTweakFavorites: [{ fullUrl: tweakUrl, displayName: 'Local', basename: 'local' }],
+      })?.themeRemoteTweakFavorites
+    ).toHaveLength(1);
+    const restored = deserializeFromSync(remote, base);
+    expect(restored?.themeRemoteTweakFavorites).toHaveLength(1);
+    expect(restored?.themeRemoteEnabledTweakFullUrls).toEqual([tweakUrl]);
+  });
+
+  it('preserves structured v1 settings during deserialization', () => {
+    const result = deserializeFromSync(
+      {
+        v: SETTINGS_SYNC_VERSION,
+        settings: { perRoomShowRoomIcon: { '!room:example': 'always' } },
+      },
+      base
+    );
+    expect(result?.perRoomShowRoomIcon).toEqual({ '!room:example': 'always' });
+  });
+
+  it('falls back safely for malformed tweak fields and sanitizes enabled URLs', () => {
+    const current = {
+      ...base,
+      themeRemoteTweakFavorites: [
+        { fullUrl: 'https://example.test/ok.css', displayName: 'Ok', basename: 'ok' },
+      ],
+    };
+    const result = deserializeFromSync(
+      {
+        v: SETTINGS_SYNC_VERSION,
+        settings: {
+          themeRemoteTweakFavorites: { bad: true },
+          themeRemoteEnabledTweakFullUrls: [
+            ' https://example.test/ok.css ',
+            4,
+            '',
+            'x'.repeat(8193),
+          ],
+        },
+      },
+      current
+    );
+    expect(result?.themeRemoteTweakFavorites).toEqual(current.themeRemoteTweakFavorites);
+    expect(result?.themeRemoteEnabledTweakFullUrls).toEqual(['https://example.test/ok.css']);
   });
 
   it('ignores extra unknown keys in the remote payload', () => {

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -1,4 +1,5 @@
-import type { Settings } from '$state/settings';
+import { sanitizeThemeRemoteTweakFavorites, type Settings } from '$state/settings';
+import { isLocalImportTweakUrl } from '../theme/localImportUrls';
 import { sanitizeShortcutOverrides } from '../keyboard/shortcuts';
 
 /**
@@ -31,18 +32,56 @@ export const NON_SYNCABLE_KEYS = new Set<keyof Settings>([
 ]);
 
 export const SETTINGS_SYNC_VERSION = 1;
+export const MAX_SYNCED_LOCAL_TWEAK_CSS_BYTES = 256 * 1024;
+const MAX_SYNCED_TWEAK_URL_LENGTH = 8192;
 
 export type SettingsSyncContent = {
   v: number;
   settings: Partial<Settings>;
 };
 
-/** Strip non-syncable keys and wrap in a versioned envelope. */
-export const serializeForSync = (settings: Settings): SettingsSyncContent => {
-  const syncable = { ...settings } as Partial<Settings>;
-  NON_SYNCABLE_KEYS.forEach((key) => delete syncable[key]);
-  return { v: SETTINGS_SYNC_VERSION, settings: syncable };
+export type PreparedSettingsSync = {
+  content: SettingsSyncContent;
+  excludedLocalTweakUrls: string[];
 };
+
+export function sanitizeThemeRemoteEnabledTweakFullUrls(val: unknown): string[] | undefined {
+  if (!Array.isArray(val)) return undefined;
+  return val.flatMap((url) => {
+    if (typeof url !== 'string') return [];
+    const trimmed = url.trim();
+    return trimmed.length > 0 && trimmed.length <= MAX_SYNCED_TWEAK_URL_LENGTH ? [trimmed] : [];
+  });
+}
+
+/** Prepare a bounded, atomic local-tweak payload and report any excluded URLs. */
+export const prepareSettingsForSync = (settings: Settings): PreparedSettingsSync => {
+  const syncable = { ...settings } as Partial<Settings>;
+  const favorites = sanitizeThemeRemoteTweakFavorites(settings.themeRemoteTweakFavorites) ?? [];
+  let usedCssBytes = 0;
+  const excludedLocalTweakUrls: string[] = [];
+  syncable.themeRemoteTweakFavorites = favorites.filter((favorite) => {
+    if (!isLocalImportTweakUrl(favorite.fullUrl) || typeof favorite.cssText !== 'string')
+      return true;
+    const bytes = new TextEncoder().encode(favorite.cssText).byteLength;
+    if (usedCssBytes + bytes > MAX_SYNCED_LOCAL_TWEAK_CSS_BYTES) {
+      excludedLocalTweakUrls.push(favorite.fullUrl);
+      return false;
+    }
+    usedCssBytes += bytes;
+    return true;
+  });
+  const excluded = new Set(excludedLocalTweakUrls);
+  syncable.themeRemoteEnabledTweakFullUrls = (
+    sanitizeThemeRemoteEnabledTweakFullUrls(settings.themeRemoteEnabledTweakFullUrls) ?? []
+  ).filter((url) => !excluded.has(url));
+  NON_SYNCABLE_KEYS.forEach((key) => delete syncable[key]);
+  return { content: { v: SETTINGS_SYNC_VERSION, settings: syncable }, excludedLocalTweakUrls };
+};
+
+/** Strip non-syncable keys and wrap in a versioned envelope. */
+export const serializeForSync = (settings: Settings): SettingsSyncContent =>
+  prepareSettingsForSync(settings).content;
 
 /**
  * Validate incoming account data and merge it into current settings.
@@ -56,9 +95,50 @@ export const deserializeFromSync = (data: unknown, currentSettings: Settings): S
   const remote = content.settings;
   if (!remote || typeof remote !== 'object' || Array.isArray(remote)) return null;
 
-  const merged = { ...currentSettings, ...(remote as Partial<Settings>) };
+  const remoteSettings = remote as Partial<Settings>;
+  const merged = { ...currentSettings, ...remoteSettings };
+  const remoteTweakFavorites = sanitizeThemeRemoteTweakFavorites(
+    remoteSettings.themeRemoteTweakFavorites
+  );
+  if ('themeRemoteTweakFavorites' in remoteSettings) {
+    const excluded = new Set(prepareSettingsForSync(currentSettings).excludedLocalTweakUrls);
+    const remoteFavorites = remoteTweakFavorites ?? currentSettings.themeRemoteTweakFavorites;
+    const remoteUrls = new Set(remoteFavorites.map((favorite) => favorite.fullUrl));
+    const preservedExcluded = currentSettings.themeRemoteTweakFavorites.filter(
+      (favorite) => excluded.has(favorite.fullUrl) && !remoteUrls.has(favorite.fullUrl)
+    );
+    merged.themeRemoteTweakFavorites = [...remoteFavorites, ...preservedExcluded];
+    if ('themeRemoteEnabledTweakFullUrls' in remoteSettings) {
+      const remoteEnabled =
+        sanitizeThemeRemoteEnabledTweakFullUrls(remoteSettings.themeRemoteEnabledTweakFullUrls) ??
+        currentSettings.themeRemoteEnabledTweakFullUrls;
+      const remoteEnabledSet = new Set(remoteEnabled);
+      merged.themeRemoteEnabledTweakFullUrls = [
+        ...remoteEnabled,
+        ...currentSettings.themeRemoteEnabledTweakFullUrls.filter(
+          (url) => excluded.has(url) && !remoteEnabledSet.has(url)
+        ),
+      ];
+    }
+  }
+  if (
+    'themeRemoteEnabledTweakFullUrls' in remoteSettings &&
+    !('themeRemoteTweakFavorites' in remoteSettings)
+  ) {
+    const remoteEnabled =
+      sanitizeThemeRemoteEnabledTweakFullUrls(remoteSettings.themeRemoteEnabledTweakFullUrls) ??
+      currentSettings.themeRemoteEnabledTweakFullUrls;
+    const remoteEnabledSet = new Set(remoteEnabled);
+    const excluded = new Set(prepareSettingsForSync(currentSettings).excludedLocalTweakUrls);
+    merged.themeRemoteEnabledTweakFullUrls = [
+      ...remoteEnabled,
+      ...currentSettings.themeRemoteEnabledTweakFullUrls.filter(
+        (url) => excluded.has(url) && !remoteEnabledSet.has(url)
+      ),
+    ];
+  }
   merged.shortcutOverrides =
-    sanitizeShortcutOverrides((remote as Partial<Settings>).shortcutOverrides) ??
+    sanitizeShortcutOverrides(remoteSettings.shortcutOverrides) ??
     currentSettings.shortcutOverrides;
   // Always restore non-syncable keys from local state.
   NON_SYNCABLE_KEYS.forEach((key) => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Restores locally imported CSS tweaks after settings sync on a new device. The change migrates legacy cache-only tweaks, restores listing and application without IndexedDB races, bounds aggregate CSS payloads, preserves source-only oversized tweaks, and reports partial sync when necessary.

#### Verification

- `npm run test:run -- src/app/utils/settingsSync.test.ts src/app/hooks/useSettingsSync.test.tsx src/app/theme/syncedTweakCss.test.ts src/app/pages/ThemeManager.test.tsx src/app/theme/processThemeImport.test.ts src/app/features/settings/cosmetics/ThemeCatalogSettings.test.tsx` (65 passed)
- `npm run fmt:check -- src/app/utils/settingsSync.ts src/app/utils/settingsSync.test.ts`
- `git diff --check`
- `npm run typecheck` remains blocked by pre-existing Matrix OAuth exports and the missing sharekit declaration; no errors point to this change.

Fixes #1208

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!-- The template requires this explanation to be written by the contributor, not generated by AI. -->