### PR TITLE
fix: avoid relation fetches during cached sync replay

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,9 @@
   "pnpm": {
     "overrides": {
       "jsdom>undici": "^7.28.0"
+    },
+    "patchedDependencies": {
+      "matrix-js-sdk@42.0.0": "patches/matrix-js-sdk@42.0.0.patch"
     }
   }
 }

--- a/patches/matrix-js-sdk@42.0.0.patch
+++ b/patches/matrix-js-sdk@42.0.0.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/models/room.js b/lib/models/room.js
+index c2569abf4cb49aa42c24ecf7763c4cc671440172..812424ca29db3ecdaa26d68adf46974df3cc0dfb 100644
+--- a/lib/models/room.js
++++ b/lib/models/room.js
+@@ -2581,7 +2581,7 @@ export class Room extends ReadReceipt {
+         shouldLiveInThread,
+         threadId = ""
+       } = this.eventShouldLiveIn(event, neighbouringEvents, threadRoots);
+-      if (!shouldLiveInThread && !shouldLiveInRoom && event.isRelation()) {
++      if (!fromCache && !shouldLiveInThread && !shouldLiveInRoom && event.isRelation()) {
+         try {
+           const parentEvent = new MatrixEvent(await this.client.fetchRoomEvent(this.roomId, event.relationEventId));
+           neighbouringEvents.push(parentEvent);
+diff --git a/src/models/room.ts b/src/models/room.ts
+index 48ddfdae84997d3aa8cc1f0deed3cdb0248669c2..2d401736038f295178e3066305b645fe54631ceb 100644
+--- a/src/models/room.ts
++++ b/src/models/room.ts
+@@ -3128,7 +3128,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
+                 threadId = "",
+             } = this.eventShouldLiveIn(event, neighbouringEvents, threadRoots);
+
+-            if (!shouldLiveInThread && !shouldLiveInRoom && event.isRelation()) {
++            if (!fromCache && !shouldLiveInThread && !shouldLiveInRoom && event.isRelation()) {
+                 try {
+                     const parentEvent = new MatrixEvent(
+                         await this.client.fetchRoomEvent(this.roomId, event.relationEventId!),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   jsdom>undici: ^7.28.0
 
+patchedDependencies:
+  matrix-js-sdk@42.0.0:
+    hash: 900d58d3f1e71118cbcc42d34bc638d75dc48fcc0d3422ed04436241c8a29319
+    path: patches/matrix-js-sdk@42.0.0.patch
+
 importers:
 
   .:
@@ -184,7 +189,7 @@ importers:
         version: 18.0.5
       matrix-js-sdk:
         specifier: 42.0.0
-        version: 42.0.0
+        version: 42.0.0(patch_hash=900d58d3f1e71118cbcc42d34bc638d75dc48fcc0d3422ed04436241c8a29319)
       matrix-widget-api:
         specifier: ^1.17.0
         version: 1.17.0
@@ -8978,7 +8983,7 @@ snapshots:
 
   matrix-events-sdk@0.0.1: {}
 
-  matrix-js-sdk@42.0.0:
+  matrix-js-sdk@42.0.0(patch_hash=900d58d3f1e71118cbcc42d34bc638d75dc48fcc0d3422ed04436241c8a29319):
     dependencies:
       '@babel/runtime': 8.0.0
       '@matrix-org/matrix-sdk-crypto-wasm': 18.3.1

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -43,6 +43,7 @@ import {
   type SessionsAction,
 } from '$state/sessions';
 import { createLogger } from '$utils/debug';
+import { createDebugLogger } from '$utils/debugLogger';
 import { useSyncNicknames } from '$hooks/useNickname';
 import { useAppVisibility } from '$hooks/useAppVisibility';
 import { composerIcon, DotsThreeOutlineVerticalIcon } from '$components/icons/phosphor';
@@ -57,6 +58,7 @@ import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 
 const log = createLogger('ClientRoot');
+const debugLog = createDebugLogger('ClientRoot');
 
 const isClientReady = (syncState: string | null): boolean =>
   syncState === 'PREPARED' || syncState === 'SYNCING' || syncState === 'CATCHUP';
@@ -255,8 +257,10 @@ export function ClientRoot({ children }: ClientRootProps) {
   const { baseUrl, userId } = activeSession ?? {};
 
   const loadedUserIdRef = useRef<string | undefined>(undefined);
+  const pettingCatStartTimeRef = useRef(performance.now());
   const syncStartTimeRef = useRef(performance.now());
   const firstSyncReadyRef = useRef(false);
+  const pettingCatCompletedRef = useRef(false);
   const [syncReadyClient, setSyncReadyClient] = useState<MatrixClient>();
 
   const [loadState, loadMatrix, setLoadState] = useAsyncCallback<MatrixClient, Error, []>(
@@ -278,7 +282,6 @@ export function ClientRoot({ children }: ClientRootProps) {
   );
 
   const mx = loadState.status === AsyncStatus.Success ? loadState.data : undefined;
-
   const roomMatch =
     matchPath(HOME_ROOM_PATH, location.pathname) ??
     matchPath(DIRECT_ROOM_PATH, location.pathname) ??
@@ -301,6 +304,25 @@ export function ClientRoot({ children }: ClientRootProps) {
     )
   );
 
+  const completePettingCat = useCallback(
+    (outcome: 'success' | 'error', finalSyncState: string | null) => {
+      if (pettingCatCompletedRef.current) return;
+      pettingCatCompletedRef.current = true;
+
+      const data = {
+        outcome,
+        totalDurationMs: Math.round(performance.now() - pettingCatStartTimeRef.current),
+        syncWaitDurationMs: Math.round(performance.now() - syncStartTimeRef.current),
+        finalSyncState: finalSyncState ?? 'none',
+        transport: activeSession?.slidingSyncOptIn === true ? 'sliding' : 'classic',
+      };
+
+      if (outcome === 'success') debugLog.info('sync', 'petting_cat_complete', data);
+      else debugLog.warn('sync', 'petting_cat_complete', data);
+    },
+    [activeSession?.slidingSyncOptIn]
+  );
+
   useEffect(() => {
     if (!activeSession) return;
     if (loadedUserIdRef.current && loadedUserIdRef.current !== activeSession.userId) {
@@ -316,6 +338,10 @@ export function ClientRoot({ children }: ClientRootProps) {
         stopClient(mx);
       }
       loadedUserIdRef.current = undefined;
+      pettingCatStartTimeRef.current = performance.now();
+      syncStartTimeRef.current = pettingCatStartTimeRef.current;
+      firstSyncReadyRef.current = false;
+      pettingCatCompletedRef.current = false;
       setLoadState({ status: AsyncStatus.Idle });
       navigate(getHomePath(), { replace: true });
     }
@@ -347,6 +373,10 @@ export function ClientRoot({ children }: ClientRootProps) {
 
   useEffect(() => {
     if (loadState.status === AsyncStatus.Idle) {
+      pettingCatStartTimeRef.current = performance.now();
+      syncStartTimeRef.current = pettingCatStartTimeRef.current;
+      firstSyncReadyRef.current = false;
+      pettingCatCompletedRef.current = false;
       loadMatrix();
     }
   }, [loadState, loadMatrix]);
@@ -369,8 +399,9 @@ export function ClientRoot({ children }: ClientRootProps) {
     if (isClientReady(mx.getSyncState())) {
       setSyncReadyClient(mx);
       firstSyncReadyRef.current = true;
+      completePettingCat('success', mx.getSyncState());
     }
-  }, [mx]);
+  }, [completePettingCat, mx]);
 
   useSyncState(
     mx,
@@ -384,10 +415,11 @@ export function ClientRoot({ children }: ClientRootProps) {
               'sable.sync.time_to_ready_ms',
               performance.now() - syncStartTimeRef.current
             );
+            completePettingCat('success', state);
           }
         }
       },
-      [mx]
+      [completePettingCat, mx]
     )
   );
 
@@ -434,14 +466,16 @@ export function ClientRoot({ children }: ClientRootProps) {
   useEffect(() => {
     if (loadState.status === AsyncStatus.Error) {
       Sentry.captureException(loadState.error, { tags: { phase: 'load' } });
+      completePettingCat('error', mx?.getSyncState() ?? null);
     }
-  }, [loadState]);
+  }, [completePettingCat, loadState, mx]);
 
   useEffect(() => {
     if (startState.status === AsyncStatus.Error) {
       Sentry.captureException(startState.error, { tags: { phase: 'start' } });
+      completePettingCat('error', mx?.getSyncState() ?? null);
     }
-  }, [startState]);
+  }, [completePettingCat, mx, startState]);
 
   return (
     <AutoDiscovery userId={userId ?? ''} baseUrl={baseUrl ?? ''}>

--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -35,7 +35,6 @@ import type { SlidingSyncDiagnostics } from './slidingSync';
 import { scopeEphemeralExtensions, SlidingSyncManager } from './slidingSync';
 import { PresenceSyncManager } from './presenceSync';
 import { SlidingSyncSidebarCache } from './slidingSyncSidebarCache';
-import { hydrateRoomMember } from './roomMemberHydration';
 import { clearCachedUserProfiles } from './userProfileCache';
 import {
   primeVersionsFromCache,
@@ -112,24 +111,31 @@ const measureStartupPhase = async <T>(
   const startTime = performance.now();
   try {
     const result = await task();
-    Sentry.metrics.distribution('sable.startup.phase_ms', performance.now() - startTime, {
+    const durationMs = performance.now() - startTime;
+    Sentry.metrics.distribution('sable.startup.phase_ms', durationMs, {
       attributes: { phase, outcome: 'success', ...attributes },
+    });
+    debugLog.info('general', 'startup_phase_complete', {
+      phase,
+      durationMs: Math.round(durationMs),
+      outcome: 'success',
+      ...attributes,
     });
     return result;
   } catch (error) {
-    Sentry.metrics.distribution('sable.startup.phase_ms', performance.now() - startTime, {
+    const durationMs = performance.now() - startTime;
+    Sentry.metrics.distribution('sable.startup.phase_ms', durationMs, {
       attributes: { phase, outcome: 'error', ...attributes },
+    });
+    debugLog.warn('general', 'startup_phase_complete', {
+      phase,
+      durationMs: Math.round(durationMs),
+      outcome: 'error',
+      ...attributes,
     });
     throw error;
   }
 };
-
-type FetchRoomEventResult = Awaited<ReturnType<MatrixClient['fetchRoomEvent']>>;
-type MatrixClientWithWritableFetchRoomEvent = MatrixClient & {
-  fetchRoomEvent: (roomId: string, eventId: string) => Promise<FetchRoomEventResult>;
-};
-
-const fetchRoomEventStartupCleanupByClient = new WeakMap<MatrixClient, () => void>();
 
 const slidingSyncRequestCleanupByClient = new WeakMap<MatrixClient, () => void>();
 
@@ -170,49 +176,6 @@ function installSlidingSyncRequestPatch(mx: MatrixClient, manager: SlidingSyncMa
     slidingSyncRequestCleanupByClient.delete(mx);
     mxWritable.slidingSync = original;
   });
-}
-
-function installStartupFetchRoomEventPatch(
-  mx: MatrixClient,
-  slidingSyncManager: SlidingSyncManager
-): void {
-  fetchRoomEventStartupCleanupByClient.get(mx)?.();
-
-  const mxWritable = mx as MatrixClientWithWritableFetchRoomEvent;
-  const origFetchRoomEvent = mx.fetchRoomEvent.bind(mx);
-
-  let restored = false;
-  const restore = () => {
-    if (restored) return;
-    restored = true;
-    fetchRoomEventStartupCleanupByClient.delete(mx);
-    mx.removeListener(ClientEvent.Sync, onSync);
-    mxWritable.fetchRoomEvent = origFetchRoomEvent;
-  };
-
-  const onSync = (state: SyncState) => {
-    if (isInitialSyncReady(state)) restore();
-  };
-
-  mxWritable.fetchRoomEvent = (roomId: string, eventId: string) => {
-    if (slidingSyncManager.isRoomActive(roomId)) {
-      return origFetchRoomEvent(roomId, eventId).then((event) => {
-        if (typeof event.sender === 'string') {
-          void hydrateRoomMember(mx, roomId, event.sender);
-        }
-        return event;
-      });
-    }
-    const cachedEvent = mx.getRoom(roomId)?.findEventById(eventId);
-    const payload: FetchRoomEventResult = cachedEvent?.event ?? {
-      event_id: eventId,
-      room_id: roomId,
-    };
-    return Promise.resolve(payload);
-  };
-
-  fetchRoomEventStartupCleanupByClient.set(mx, restore);
-  mx.on(ClientEvent.Sync, onSync);
 }
 
 const deleteDatabase = (name: string): Promise<void> =>
@@ -396,9 +359,23 @@ export const initClient = async (session: Session): Promise<MatrixClient> => {
     initOutcome = 'error';
     throw error;
   } finally {
-    Sentry.metrics.distribution('sable.startup.phase_ms', performance.now() - initStartTime, {
+    const durationMs = performance.now() - initStartTime;
+    Sentry.metrics.distribution('sable.startup.phase_ms', durationMs, {
       attributes: { phase: 'client_init', outcome: initOutcome },
     });
+    if (initOutcome === 'success') {
+      debugLog.info('general', 'startup_phase_complete', {
+        phase: 'client_init',
+        durationMs: Math.round(durationMs),
+        outcome: initOutcome,
+      });
+    } else {
+      debugLog.warn('general', 'startup_phase_complete', {
+        phase: 'client_init',
+        durationMs: Math.round(durationMs),
+        outcome: initOutcome,
+      });
+    }
   }
 };
 
@@ -497,7 +474,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig):
       initialRoomIds: config?.initialRoomIds,
     });
 
-    installStartupFetchRoomEventPatch(mx, manager);
     installSlidingSyncRequestPatch(mx, manager);
 
     manager.attach();
@@ -521,13 +497,12 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig):
       config?.onCachedRoomsLoaded?.();
     }
   } catch (err) {
-    debugLog.error('network', 'Failed to start client with sliding sync', {
+    debugLog.error('network', 'Failed to start client sync', {
       error: err instanceof Error ? err.message : String(err),
       userId: mx.getUserId(),
       baseUrl: useSliding ? baseUrl : undefined,
       stack: err instanceof Error ? err.stack : undefined,
     });
-    fetchRoomEventStartupCleanupByClient.get(mx)?.();
     slidingSyncRequestCleanupByClient.get(mx)?.();
     membershipActionCleanupByClient.get(mx)?.();
     disposeSlidingSync(mx);
@@ -539,7 +514,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig):
 export const stopClient = (mx: MatrixClient): void => {
   log.log('stopClient', mx.getUserId());
   debugLog.info('sync', 'Stopping client', { userId: mx.getUserId() });
-  fetchRoomEventStartupCleanupByClient.get(mx)?.();
   slidingSyncRequestCleanupByClient.get(mx)?.();
   disposeSlidingSync(mx);
   disposePresenceSync(mx);

--- a/src/client/matrixSdkPatch.test.ts
+++ b/src/client/matrixSdkPatch.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MatrixClient } from '$types/matrix-sdk';
+import { MatrixEvent, Room } from '$types/matrix-sdk';
+
+const roomId = '!room:example.com';
+const parentEventId = '$missing-parent';
+
+const makeRelationEvent = (): MatrixEvent =>
+  new MatrixEvent({
+    event_id: '$relation',
+    room_id: roomId,
+    sender: '@user:example.com',
+    type: 'm.reaction',
+    content: {
+      'm.relates_to': {
+        event_id: parentEventId,
+        rel_type: 'm.annotation',
+        key: '👍',
+      },
+    },
+  });
+
+const makeRoom = (fetchRoomEvent: MatrixClient['fetchRoomEvent']): Room => {
+  const client = {
+    fetchRoomEvent,
+    supportsThreads: () => true,
+  } as unknown as MatrixClient;
+  return new Room(roomId, client, '@user:example.com');
+};
+
+describe('matrix-js-sdk Room.addLiveEvents patch', () => {
+  it('skips unresolved relation-parent fetching from cache', async () => {
+    const fetchRoomEvent = vi.fn<MatrixClient['fetchRoomEvent']>();
+    const room = makeRoom(fetchRoomEvent);
+
+    await room.addLiveEvents([makeRelationEvent()], { fromCache: true, addToState: false });
+
+    expect(fetchRoomEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['fromCache false', { fromCache: false, addToState: false }],
+    ['fromCache omitted', { addToState: false }],
+  ])('fetches unresolved relation parents for live events (%s)', async (_label, options) => {
+    const fetchRoomEvent = vi.fn<MatrixClient['fetchRoomEvent']>().mockResolvedValue({
+      event_id: parentEventId,
+      room_id: roomId,
+      type: 'm.room.message',
+    });
+    const room = makeRoom(fetchRoomEvent);
+
+    await room.addLiveEvents([makeRelationEvent()], options);
+
+    expect(fetchRoomEvent).toHaveBeenCalledWith(roomId, parentEventId);
+  });
+});


### PR DESCRIPTION
## Summary
- patch `matrix-js-sdk` to skip missing relation-parent fetches only for events marked `fromCache`
- remove the startup-time `fetchRoomEvent` override and the unused classic room-summary cache
- add direct cached-versus-live relation regression coverage and startup timing diagnostics

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm vitest run src/client/matrixSdkPatch.test.ts src/client/slidingSyncSidebarCache.test.ts`
- `pnpm exec oxlint src/client/initMatrix.ts src/client/matrixSdkPatch.test.ts src/client/slidingSyncSidebarCache.ts`
- `pnpm typecheck`
- `pnpm build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm tauri android build --debug --apk --target aarch64`
- installed and launched the debug APK on Android

The SDK patch preserves normal relation-parent fetching for live events (`fromCache: false` or omitted).