### PR TITLE
[#1203] fix ios version and buildVersion

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -485,11 +485,15 @@ jobs:
           NORMALIZED_IPA="$(dirname "$IPA")/Sable-${VERSION}-ios-arm64.ipa"
           [ "$IPA" = "$NORMALIZED_IPA" ] || mv "$IPA" "$NORMALIZED_IPA"
           IPA="$NORMALIZED_IPA"
-          IPA_VERSION="$(unzip -p "$IPA" 'Payload/*.app/Info.plist' 2>/dev/null | plutil -extract CFBundleVersion raw -o - - 2>/dev/null || true)"
+          unzip -p "$IPA" 'Payload/*.app/Info.plist' >Info.plist
+          # version - CFBundleShortVersionString, buildVersion - CFBundleVersion : https://faq.altstore.io/developers/make-a-source#app-versions
+          IPA_VERSION="$(plutil -extract CFBundleShortVersionString raw -o - Info.plist 2>/dev/null || true)"
+          IPA_BUILD="$(plutil -extract CFBundleVersion raw -o - Info.plist 2>/dev/null || true)"
           echo "size=$(stat -f%z "$IPA")" >> "$GITHUB_OUTPUT"
           echo "path=$IPA" >> "$GITHUB_OUTPUT"
           echo "name=$(basename "$IPA")" >> "$GITHUB_OUTPUT"
           echo "ipa_version=${IPA_VERSION:-$VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ipa_build=${IPA_BUILD:-$VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Attest iOS bundle
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -508,6 +512,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ALTSTORE_VERSION: ${{ steps.ipa.outputs.ipa_version }}
+          ALTSTORE_VERSION_BUILD: ${{ steps.ipa.outputs.ipa_build }}
         run: |
           DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/${{ steps.ipa.outputs.name }}"
           DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -517,7 +522,7 @@ jobs:
             echo "Using repo altstore-source.json"
           fi
           node .github/scripts/update-altstore-source.mjs \
-            altstore-source.json "${ALTSTORE_VERSION:-$VERSION}" "${ALTSTORE_VERSION:-$VERSION}" "${{ steps.ipa.outputs.size }}" "$DOWNLOAD_URL" "$DATE" "Sable $VERSION"
+            altstore-source.json "${ALTSTORE_VERSION:-$VERSION}" "${ALTSTORE_VERSION_BUILD:-$VERSION}" "${{ steps.ipa.outputs.size }}" "$DOWNLOAD_URL" "$DATE" "Sable $VERSION"
           gh release upload "$TAG" altstore-source.json --clobber
 
   updater-manifest:


### PR DESCRIPTION
version should be CFBundleShortVersionString
buildVersion should be CFBundleVersion
details: https://faq.altstore.io/developers/make-a-source#version-string

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1203

So there is actually `version` and `buildVersion` and validation for them based on different values from `Info.plist`
[`version`](https://faq.altstore.io/developers/make-a-source#version-string) should match `CFBundleShortVersionString` 
[`buildVersion`](https://faq.altstore.io/developers/make-a-source#buildversion-string) should match `CFBundleVersion`

I've checked locally that unzipping, setting variables and generation of `altstore-source.json`, should be fine now.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
