### PR TITLE
Fix Maps that contain incorrect numbers for lat/lon crashing sable

### DIFF
--- a/.changeset/fix-crashing-maps.md
+++ b/.changeset/fix-crashing-maps.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Maps that contain incorrect numbers for lat/lon crashing sable

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -44,6 +44,7 @@ import 'leaflet/dist/leaflet.css';
 
 import * as css from './MsgTypeRenderers.css';
 import { markerIcon } from '$features/room/location-modal/LocationDialog';
+import { isNumber } from 'matrix-js-sdk/lib/utils';
 
 export interface BundleContent extends IPreviewUrlResponse {
   matched_url: string;
@@ -705,6 +706,7 @@ export function MLocation({ content, showMaps }: MLocationProps) {
   }
   const location = parseGeoUri(geoUri);
   if (!location) return <BrokenContent />;
+  const isValid = isNumber(Number(location.latitude)) && isNumber(Number(location.longitude));
   const coords: LatLngExpression = [Number(location.latitude), Number(location.longitude)];
 
   return (
@@ -733,18 +735,23 @@ export function MLocation({ content, showMaps }: MLocationProps) {
         <Chip
           as="a"
           size="400"
-          href={`https://www.openstreetmap.org/?mlat=${location.latitude}&mlon=${location.longitude}#map=16/${location.latitude}/${location.longitude}`}
+          href={
+            isValid
+              ? `https://www.openstreetmap.org/?mlat=${location.latitude}&mlon=${location.longitude}#map=16/${location.latitude}/${location.longitude}`
+              : undefined
+          }
           target="_blank"
           rel="noreferrer noopener"
           variant="Primary"
           radii="Pill"
           className={css.LocationExternalChip}
           before={sizedIcon(ArrowSquareOut, '50')}
+          aria-disabled={!isValid}
         >
           <Text size="B300">Open Location</Text>
         </Chip>
       </Box>
-      {showMaps && (
+      {showMaps && isValid && (
         <MapContainer
           center={coords}
           zoom={16}


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fix Maps that contain incorrect numbers for lat/lon crashing sable
Fixes #

It also disables the button to open it in OSM since osm cannot handle broken coords either

<img width="589" height="670" alt="image" src="https://github.com/user-attachments/assets/a6a469e9-3808-4929-9257-bf692a9be7e2" />


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Written w the assistance of having crashed the app for someone by accident </3