### PR TITLE
fix: detect identity reset by listening to cross-signing key changes

### DIFF
--- a/src/app/hooks/useDeviceVerificationStatus.ts
+++ b/src/app/hooks/useDeviceVerificationStatus.ts
@@ -1,10 +1,22 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { CryptoApi } from '$types/matrix-sdk';
+import { type CryptoApi, type CryptoEventHandlerMap, CryptoEvent } from '$types/matrix-sdk';
 import { verifiedDevice } from '$utils/matrix-crypto';
 import { fulfilledPromiseSettledResult } from '$utils/common';
 import { useAlive } from './useAlive';
 import { useMatrixClient } from './useMatrixClient';
 import { useDeviceListChange } from './useDeviceList';
+
+export const useCrossSigningKeysChange = (
+  onChange: CryptoEventHandlerMap[CryptoEvent.KeysChanged]
+) => {
+  const mx = useMatrixClient();
+  useEffect(() => {
+    mx.on(CryptoEvent.KeysChanged, onChange);
+    return () => {
+      mx.removeListener(CryptoEvent.KeysChanged, onChange);
+    };
+  }, [mx, onChange]);
+};
 
 export enum VerificationStatus {
   Unknown,
@@ -48,6 +60,8 @@ export const useDeviceVerificationDetect = (
       [userId, updateStatus]
     )
   );
+
+  useCrossSigningKeysChange(useCallback(() => updateStatus(), [updateStatus]));
 };
 
 export const useDeviceVerificationStatus = (
@@ -97,6 +111,8 @@ export const useUnverifiedDeviceCount = (
       [userId, updateCount]
     )
   );
+
+  useCrossSigningKeysChange(useCallback(() => updateCount(), [updateCount]));
 
   useEffect(() => {
     updateCount();


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When the server/IdP resets identity, the Matrix SDK fires CryptoEvent.KeysChanged, but the client only re-evaluated verification status on CryptoEvent.DevicesUpdated. So after a reset the client kept showing "Verified" and never surfaced the unverified state.
Adds useCrossSigningKeysChange (mirroring useDeviceListChange) and wires it into both verification hooks so status and unverified-device count re-evaluate on key changes. The existing unverified banner and Devices page then reflect the reset.

Fixes #1255

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
