### PR TITLE
fix: use window origin for call widget parentUrl on Tauri

### DIFF
--- a/src/app/plugins/call/CallEmbed.intent.test.ts
+++ b/src/app/plugins/call/CallEmbed.intent.test.ts
@@ -157,4 +157,20 @@ describe('CallEmbed.getWidget', () => {
 
     expect(url.pathname).toContain('/public/element-call/index.html');
   });
+
+  it('uses the actual window origin as parentUrl on Tauri, not the canonical app URL', () => {
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://tauri.localhost',
+        protocol: 'https:',
+        host: 'tauri.localhost',
+        hostname: 'tauri.localhost',
+      },
+    });
+    const room = createRoom(false);
+    const widget = CallEmbed.getWidget(mx, room, ElementCallIntent.StartCallVoice, 'dark');
+    const url = new URL(widget.getCompleteUrl({ currentUserId: '@alice:example.com' }));
+
+    expect(url.searchParams.get('parentUrl')).toBe('https://tauri.localhost');
+  });
 });

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -10,7 +10,7 @@ import {
 } from 'matrix-widget-api';
 import { CallWidgetDriver } from './CallWidgetDriver';
 import { trimTrailingSlash } from '../../utils/common';
-import { getAppOrigin } from '../../utils/platform';
+import { getWindowOrigin } from '../../utils/platform';
 import type { ElementCallThemeKind, ElementMediaStateDetail } from './types';
 import { color, config } from 'folds';
 import { ElementCallIntent, ElementWidgetActions } from './types';
@@ -97,7 +97,7 @@ export class CallEmbed {
   ): Widget {
     const userId = mx.getSafeUserId();
     const deviceId = mx.getDeviceId() ?? '';
-    const clientOrigin = getAppOrigin();
+    const clientOrigin = getWindowOrigin();
     const widgetId = 'call-embed';
 
     const params = new URLSearchParams({

--- a/src/app/utils/platform.test.ts
+++ b/src/app/utils/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { getAppOrigin } from './platform';
+import { getAppOrigin, getWindowOrigin } from './platform';
 import { isTauri } from '@tauri-apps/api/core';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -42,5 +42,31 @@ describe('getAppOrigin', () => {
       host: 'app.sable.moe',
     });
     expect(getAppOrigin()).toBe('https://app.sable.moe');
+  });
+});
+
+describe('getWindowOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the real tauri:// origin when window.location.origin is the opaque "null"', () => {
+    vi.stubGlobal('location', {
+      origin: 'null',
+      hostname: 'localhost',
+      protocol: 'tauri:',
+      host: 'localhost',
+    });
+    expect(getWindowOrigin()).toBe('tauri://localhost');
+  });
+
+  it('returns window.location.origin in a normal web environment', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://app.example.com',
+      hostname: 'app.example.com',
+      protocol: 'https:',
+      host: 'app.example.com',
+    });
+    expect(getWindowOrigin()).toBe('https://app.example.com');
   });
 });

--- a/src/app/utils/platform.ts
+++ b/src/app/utils/platform.ts
@@ -38,3 +38,12 @@ export function getAppOrigin(): string {
     ? `${window.location.protocol}//${window.location.host}`
     : window.location.origin;
 }
+
+// Runtime origin of the current window. getAppOrigin() returns the canonical
+// app URL on Tauri, which does not match the parent frame — use this for
+// widget parentUrl / postMessage targetOrigin.
+export function getWindowOrigin(): string {
+  return window.location.origin === 'null'
+    ? `${window.location.protocol}//${window.location.host}`
+    : window.location.origin;
+}


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
