### PR TITLE
fix: feed room state to call widget after capabilities are notified

### DIFF
--- a/src/app/hooks/useMatrixRTCSession.tsx
+++ b/src/app/hooks/useMatrixRTCSession.tsx
@@ -15,27 +15,7 @@ const MatrixRTCSessionContext = createContext<ActiveRTCSessionIds>(new Set());
 
 export function MatrixRTCSessionProvider({ children }: { children: ReactNode }): ReactElement {
   const mx = useMatrixClient();
-  const [activeRoomIds, setActiveRoomIds] = useState<ActiveRTCSessionIds>(() => {
-    // Seed with rooms that currently have an active session.
-    // There is no public `getRoomSessions()` bulk method on MatrixRTCSessionManager,
-    // so we iterate all client rooms and check each one individually.
-    const ids = new Set<string>();
-    try {
-      for (const room of mx.getRooms()) {
-        try {
-          const session = mx.matrixRTC.getRoomSession(room);
-          if (session.memberships.length > 0) {
-            ids.add(room.roomId);
-          }
-        } catch {
-          // Individual room session lookup failure is non-fatal.
-        }
-      }
-    } catch {
-      // Best-effort seed; the subscription below will keep it accurate.
-    }
-    return ids;
-  });
+  const [activeRoomIds, setActiveRoomIds] = useState<ActiveRTCSessionIds>(new Set());
 
   useEffect(() => {
     const handleStart = (roomId: string) => {

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -292,6 +292,43 @@ export class CallEmbed {
       this.readUpToMap[room.roomId] = roomEvent.getId()!;
     });
 
+    // Feed the room's state to the widget after capabilities are negotiated;
+    // feedStateUpdate silently drops events before the widget is ready.
+    const feedInitialState = () => {
+      const myUserId = this.mx.getSafeUserId();
+      this.room.currentState.events.forEach((stateKeyMap) => {
+        stateKeyMap.forEach((ev) => {
+          const raw = ev.getEffectiveEvent() as IRoomEvent | undefined;
+          if (raw === undefined) return;
+          this.call.feedStateUpdate(raw).catch((e) => {
+            console.error('Error feeding initial state to widget: ', e);
+          });
+        });
+      });
+
+      // Sliding sync may not have delivered m.room.member yet.
+      if (!this.room.currentState.getStateEvents('m.room.member', myUserId)) {
+        const membership = this.room.getMyMembership();
+        if (membership) {
+          const memberRaw = {
+            type: 'm.room.member',
+            state_key: myUserId,
+            room_id: this.roomId,
+            sender: myUserId,
+            content: { membership },
+            event_id: `$sable:${Date.now()}`,
+            origin_server_ts: Date.now(),
+            unsigned: {},
+          } as unknown as IRoomEvent;
+          this.call.feedStateUpdate(memberRaw).catch((e) => {
+            console.error('Error feeding member state to widget: ', e);
+          });
+        }
+      }
+    };
+
+    this.disposables.push(this.onCapabilitiesNotified(feedInitialState));
+
     // Bind handlers once and route removal through `disposables` so listeners can be
     // cleanly torn down when the embed is recreated.
     const boundOnEvent = this.onEvent.bind(this);

--- a/src/app/plugins/call/CallWidgetDriver.ts
+++ b/src/app/plugins/call/CallWidgetDriver.ts
@@ -245,6 +245,13 @@ export class CallWidgetDriver extends WidgetDriver {
     limit: number,
     since: string | undefined
   ): Promise<IRoomEvent[]> {
+    if (stateKey !== undefined) {
+      return this.readRoomState(roomId, eventType, stateKey);
+    }
+
+    const stateEvents = await this.readRoomState(roomId, eventType, undefined);
+    if (stateEvents.length > 0) return stateEvents;
+
     const safeLimit =
       limit > 0 ? Math.min(limit, Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER; // relatively arbitrary
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
