### PR TITLE
Small mobile tweaks

### DIFF
--- a/.changeset/swipe-to-edit.md
+++ b/.changeset/swipe-to-edit.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add swipe-to-edit gesture on mobile messages.

--- a/src/app/components/MobileSwipeDownModal.tsx
+++ b/src/app/components/MobileSwipeDownModal.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import { Box } from 'folds';
 import * as css from '$features/room/message/styles.css';
 import { useDismissOnBack } from '$utils/androidBack';
+import { getMobileSheetTiming, useMobileSheetAnimation } from './mobileSheetAnimation';
+import * as animationCss from './mobileSheetAnimation.css';
 
 interface MobileSwipeDownModalProps {
   children: (
@@ -22,6 +24,8 @@ export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDown
   const touchYDiff = useRef(0);
   const startTime = useRef(0);
   const [mounted, setMounted] = useState(false);
+  const resetAnimationRef = useRef<Animation>();
+  const { shouldReduceMotion } = useMobileSheetAnimation();
 
   useEffect(() => {
     setMounted(true);
@@ -43,9 +47,10 @@ export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDown
     // Only allow pulling down
     if (diff > 0) {
       touchYDiff.current = diff;
+      resetAnimationRef.current?.cancel();
+      containerRef.current?.getAnimations().forEach((animation) => animation.cancel());
       if (containerRef.current) {
-        containerRef.current.style.transform = `translateY(${diff}px)`;
-        containerRef.current.style.transition = 'none';
+        containerRef.current.style.transform = `translate3d(0, ${diff}px, 0)`;
       }
     }
   };
@@ -58,10 +63,24 @@ export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDown
     ) {
       requestClose();
     } else {
+      const currentOffset = touchYDiff.current;
       touchYDiff.current = 0;
       if (containerRef.current) {
-        containerRef.current.style.transform = '';
-        containerRef.current.style.transition = 'transform 0.2s ease-out';
+        const container = containerRef.current;
+        resetAnimationRef.current = container.animate(
+          [
+            { transform: `translate3d(0, ${currentOffset}px, 0)` },
+            { transform: 'translate3d(0, 0, 0)' },
+          ],
+          getMobileSheetTiming(shouldReduceMotion)
+        );
+        resetAnimationRef.current.addEventListener(
+          'finish',
+          () => {
+            container.style.transform = '';
+          },
+          { once: true }
+        );
       }
     }
     touchStartY.current = null;
@@ -92,11 +111,8 @@ export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDown
     >
       <Box
         ref={containerRef}
-        className={css.MessageMobileOptionsContainer}
-        style={{
-          transform: touchYDiff.current > 0 ? `translateY(${touchYDiff.current}px)` : undefined,
-          transition: touchStartY.current === null ? 'transform 0.2s ease-out' : 'none',
-        }}
+        className={`${css.MessageMobileOptionsContainer} ${animationCss.SheetEntrance}`}
+        style={shouldReduceMotion ? { animation: 'none' } : undefined}
         onClick={(e: React.MouseEvent) => e.stopPropagation()}
       >
         {children(dragHandleJSX, dragHandlers)}

--- a/src/app/components/SwipeableChatWrapper.tsx
+++ b/src/app/components/SwipeableChatWrapper.tsx
@@ -91,7 +91,6 @@ export function SwipeableChatWrapper({
     <div
       {...bind()}
       style={{
-        touchAction: 'pan-y',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',

--- a/src/app/components/SwipeableChatWrapper.tsx
+++ b/src/app/components/SwipeableChatWrapper.tsx
@@ -1,10 +1,10 @@
-import type { ReactNode } from 'react';
+import { useCallback, useLayoutEffect, useRef, type ReactNode } from 'react';
 import { animate, motion, useMotionValue } from 'framer-motion';
-import { useDrag } from '@use-gesture/react';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom, RightSwipeAction } from '$state/settings';
 import { haptic } from '$utils/haptics';
 import { mobileOrTablet } from '$utils/user-agent';
+import { useMobileNavDrawer } from '$components/page/MobileNavDrawerContext';
 
 interface SwipeableChatWrapperProps {
   children: ReactNode;
@@ -20,56 +20,51 @@ export function SwipeableChatWrapper({
   const [mobileGestures] = useSetting(settingsAtom, 'mobileGestures');
   const [rightSwipeAction] = useSetting(settingsAtom, 'rightSwipeAction');
   const x = useMotionValue(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gestureActiveRef = useRef(false);
+  const drawer = useMobileNavDrawer();
 
-  const bind = useDrag(
-    ({ first, active, offset: [ox], velocity: [vx], direction: [dx], event: e, cancel }) => {
-      if (first && e && 'target' in e && e.target instanceof HTMLElement) {
-        if (e.target.closest('[data-gestures="ignore"]')) {
-          cancel();
-          return;
-        }
+  const move = useCallback(
+    (distanceX: number) => {
+      if (!gestureActiveRef.current) {
+        gestureActiveRef.current = true;
+        x.stop();
       }
-
-      if (!mobileGestures || !mobileOrTablet()) return;
-
-      let val = ox;
 
       const canSwipeLeft =
         rightSwipeAction === RightSwipeAction.Members ? !!onOpenMembers : !!onReply;
-
-      // The drawer owns the rightward reveal; this wrapper only handles leftward actions.
-      if (val > 0) val = 0;
-      if (!canSwipeLeft && val < 0) val = 0;
-
-      if (active) {
-        // Take over any settling spring; offset is seeded from the live position.
-        if (first) x.stop();
-        x.set(val);
-      } else {
-        const swipeThreshold = 120;
-        const velocityThreshold = 0.5;
-
-        if (val < -swipeThreshold || (vx > velocityThreshold && dx < 0 && val < 0)) {
-          haptic('light');
-          if (rightSwipeAction === RightSwipeAction.Members) {
-            onOpenMembers?.();
-          } else {
-            onReply?.();
-          }
-        }
-        animate(x, 0, { type: 'spring', stiffness: 400, damping: 40 });
-      }
+      x.set(canSwipeLeft ? Math.max(-200, Math.min(0, distanceX)) : 0);
     },
-    {
-      axis: 'x',
-      bounds: { left: -200, right: 200 },
-      rubberband: true,
-      filterTaps: true,
-      pointer: { capture: false },
-      eventOptions: { passive: true },
-      from: () => [x.get(), 0],
-    }
+    [onOpenMembers, onReply, rightSwipeAction, x]
   );
+
+  const finish = useCallback(
+    (commit: boolean, distanceX = 0, velocityX = 0) => {
+      if (commit && (distanceX < -120 || velocityX < -0.5)) {
+        haptic('light');
+        if (rightSwipeAction === RightSwipeAction.Members) {
+          onOpenMembers?.();
+        } else {
+          onReply?.();
+        }
+      }
+
+      gestureActiveRef.current = false;
+      animate(x, 0, { type: 'spring', stiffness: 400, damping: 40 });
+    },
+    [onOpenMembers, onReply, rightSwipeAction, x]
+  );
+
+  useLayoutEffect(() => {
+    const element = containerRef.current;
+    if (!drawer || !element || !mobileGestures || !mobileOrTablet()) return undefined;
+
+    return drawer.registerChatSwipe(element, {
+      move,
+      end: ({ distanceX, velocityX }) => finish(true, distanceX, velocityX),
+      cancel: () => finish(false),
+    });
+  }, [drawer, finish, mobileGestures, move]);
 
   if (!mobileGestures || !mobileOrTablet()) {
     return (
@@ -89,7 +84,8 @@ export function SwipeableChatWrapper({
 
   return (
     <div
-      {...bind()}
+      ref={containerRef}
+      data-chat-swipe
       style={{
         overflow: 'hidden',
         display: 'flex',

--- a/src/app/components/SwipeableMessageWrapper.tsx
+++ b/src/app/components/SwipeableMessageWrapper.tsx
@@ -3,36 +3,76 @@ import { useDrag } from '@use-gesture/react';
 import type { ReactNode } from 'react';
 import { useMemo, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import { config } from 'folds';
-import { ArrowBendUpLeftIcon, getPhosphorIconSize } from '$components/icons/phosphor';
+import { ArrowBendUpLeftIcon, PencilSimple, getPhosphorIconSize } from '$components/icons/phosphor';
 import { haptic } from '$utils/haptics';
 import { mobileOrTablet } from '$utils/user-agent';
 import { RightSwipeAction, settingsAtom } from '$state/settings';
 
-function ActiveSwipeWrapper({ children, onReply }: { children: ReactNode; onReply: () => void }) {
+type SwipeActionMode = 'none' | 'reply' | 'edit';
+
+function ActiveSwipeWrapper({
+  children,
+  onReply,
+  onEdit,
+}: {
+  children: ReactNode;
+  onReply: () => void;
+  onEdit?: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const x = useMotionValue(0);
-  const [isReady, setIsReady] = useState(false);
-  const isReadyRef = useRef(false);
-  const iconOpacity = useTransform(x, [0, -8], [0, 1]);
+  const [actionMode, setActionMode] = useState<SwipeActionMode>('none');
+  const actionModeRef = useRef<SwipeActionMode>('none');
+  const iconOpacity = useTransform(x, [0, -12], [0, 1]);
+  const bgOpacity = useTransform(x, [0, -15], [0, 1]);
+  const gapWidth = useTransform(x, (val) => Math.abs(Math.min(0, val)));
 
   const bind = useDrag(
     ({ first, active, movement: [mx] }) => {
       if (first) x.stop();
 
+      const width = containerRef.current?.clientWidth || 360;
+      const replyThreshold = -Math.min(50, width * 0.2);
+      const editThreshold = -Math.min(110, width * 0.38);
+
       if (active) {
         const val = mx < 0 ? mx : 0;
-        x.set(Math.max(-80, val));
-        const nextReady = mx < -50;
-        if (nextReady !== isReadyRef.current) {
-          isReadyRef.current = nextReady;
-          setIsReady(nextReady);
-          if (nextReady) haptic('selection');
+        const dragDist = Math.abs(val);
+        const linearLimit = onEdit ? Math.min(100, width * 0.32) : Math.min(60, width * 0.18);
+        let smoothedDist = dragDist;
+
+        if (dragDist > linearLimit) {
+          const excess = dragDist - linearLimit;
+          const maxExcess = 45;
+          // Smooth exponential ease-out deceleration so the swipe slows down gradually instead of stopping abruptly
+          smoothedDist = linearLimit + maxExcess * (1 - Math.exp(-excess / 40));
+        }
+        x.set(-smoothedDist);
+
+        let nextMode: SwipeActionMode = 'none';
+        if (onEdit && mx < editThreshold) {
+          nextMode = 'edit';
+        } else if (mx < replyThreshold) {
+          nextMode = 'reply';
+        }
+
+        if (nextMode !== actionModeRef.current) {
+          actionModeRef.current = nextMode;
+          setActionMode(nextMode);
+          if (nextMode !== 'none') {
+            haptic(nextMode === 'edit' ? 'medium' : 'selection');
+          }
         }
       } else {
-        if (mx < -50) onReply();
-        animate(x, 0, { type: 'spring', stiffness: 300, damping: 35 });
-        isReadyRef.current = false;
-        setIsReady(false);
+        const currentMode = actionModeRef.current;
+        if (currentMode === 'edit' && onEdit) {
+          onEdit();
+        } else if (currentMode === 'reply') {
+          onReply();
+        }
+        animate(x, 0, { type: 'spring', stiffness: 300, damping: 26 });
+        actionModeRef.current = 'none';
+        setActionMode('none');
       }
     },
     {
@@ -44,34 +84,66 @@ function ActiveSwipeWrapper({ children, onReply }: { children: ReactNode; onRepl
     }
   );
 
+  const IconComponent = actionMode === 'edit' ? PencilSimple : ArrowBendUpLeftIcon;
+  const iconColor =
+    actionMode === 'edit'
+      ? 'var(--sable-primary-color, #6e56cf)'
+      : actionMode === 'reply'
+        ? 'var(--sable-surface-on-container, #ffffff)'
+        : 'rgba(255, 255, 255, 0.6)';
+
   return (
-    <div {...bind()} style={{ position: 'relative', touchAction: 'pan-y' }}>
-      <div
+    <div
+      data-gestures="ignore"
+      ref={containerRef}
+      {...bind()}
+      style={{ position: 'relative', touchAction: 'pan-y' }}
+    >
+      {/* Darkened backdrop for the revealed gap, anchored to the right edge */}
+      <motion.div
         style={{
           position: 'absolute',
           top: 0,
           bottom: 0,
           right: 0,
-          paddingRight: config.space.S400,
-          display: 'flex',
-          alignItems: 'center',
+          width: gapWidth,
+          backgroundColor: 'rgba(0, 0, 0, 0.35)',
+          opacity: bgOpacity,
+          borderTopRightRadius: '8px',
+          borderBottomRightRadius: '8px',
           zIndex: 0,
+          pointerEvents: 'none',
         }}
-      >
-        <motion.div style={{ opacity: iconOpacity }}>
-          <ArrowBendUpLeftIcon
+      />
+
+      <motion.div style={{ x, position: 'relative', zIndex: 2, willChange: 'transform' }}>
+        {children}
+
+        {/* Action icon pinned to the right edge of the sliding message */}
+        <motion.div
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: '100%',
+            width: '60px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1,
+            pointerEvents: 'none',
+            opacity: iconOpacity,
+          }}
+        >
+          <IconComponent
             size={getPhosphorIconSize('toolbar')}
             style={{
-              color: isReady
-                ? 'var(--sable-surface-on-container)'
-                : 'var(--sable-surface-container)',
-              transition: 'color 0.2s',
+              color: iconColor,
+              transition: 'color 0.2s, transform 0.2s',
+              transform: actionMode === 'edit' ? 'scale(1.2)' : 'scale(1)',
             }}
           />
         </motion.div>
-      </div>
-      <motion.div style={{ x, position: 'relative', zIndex: 1, willChange: 'transform' }}>
-        {children}
       </motion.div>
     </div>
   );
@@ -80,9 +152,11 @@ function ActiveSwipeWrapper({ children, onReply }: { children: ReactNode; onRepl
 export function SwipeableMessageWrapper({
   children,
   onReply,
+  onEdit,
 }: {
   children: ReactNode;
   onReply?: () => void;
+  onEdit?: () => void;
 }) {
   const settings = useAtomValue(settingsAtom);
 
@@ -98,5 +172,9 @@ export function SwipeableMessageWrapper({
     return children;
   }
 
-  return <ActiveSwipeWrapper onReply={onReply}>{children}</ActiveSwipeWrapper>;
+  return (
+    <ActiveSwipeWrapper onReply={onReply} onEdit={onEdit}>
+      {children}
+    </ActiveSwipeWrapper>
+  );
 }

--- a/src/app/components/SwipeableMessageWrapper.tsx
+++ b/src/app/components/SwipeableMessageWrapper.tsx
@@ -1,88 +1,108 @@
 import { useMotionValue, useTransform, motion, animate } from 'framer-motion';
-import { useDrag } from '@use-gesture/react';
 import type { ReactNode } from 'react';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { ArrowBendUpLeftIcon, PencilSimple, getPhosphorIconSize } from '$components/icons/phosphor';
 import { haptic } from '$utils/haptics';
 import { mobileOrTablet } from '$utils/user-agent';
 import { RightSwipeAction, settingsAtom } from '$state/settings';
+import { useMobileNavDrawer } from '$components/page/MobileNavDrawerContext';
 
-type SwipeActionMode = 'none' | 'reply' | 'edit';
+export type SwipeActionMode = 'none' | 'reply' | 'edit';
 
 function ActiveSwipeWrapper({
   children,
   onReply,
   onEdit,
+  onActionModeChange,
 }: {
   children: ReactNode;
   onReply: () => void;
   onEdit?: () => void;
+  onActionModeChange?: (mode: SwipeActionMode) => void;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const x = useMotionValue(0);
   const [actionMode, setActionMode] = useState<SwipeActionMode>('none');
   const actionModeRef = useRef<SwipeActionMode>('none');
-  const iconOpacity = useTransform(x, [0, -12], [0, 1]);
-  const bgOpacity = useTransform(x, [0, -15], [0, 1]);
+  const gestureActiveRef = useRef(false);
+  const iconOpacity = useTransform(x, [0, -24], [0, 1]);
   const gapWidth = useTransform(x, (val) => Math.abs(Math.min(0, val)));
+  const drawer = useMobileNavDrawer();
 
-  const bind = useDrag(
-    ({ first, active, movement: [mx] }) => {
-      if (first) x.stop();
+  const move = useCallback(
+    (distanceX: number) => {
+      if (!gestureActiveRef.current) {
+        gestureActiveRef.current = true;
+        x.stop();
+      }
 
       const width = containerRef.current?.clientWidth || 360;
       const replyThreshold = -Math.min(50, width * 0.2);
-      const editThreshold = -Math.min(110, width * 0.38);
+      const linearLimit = onEdit ? Math.min(100, width * 0.32) : Math.min(60, width * 0.18);
+      // Enter edit only deep into the resistant tail, when the message is
+      // visually close to its maximum travel.
+      const editThreshold = -(linearLimit + 90);
 
-      if (active) {
-        const val = mx < 0 ? mx : 0;
-        const dragDist = Math.abs(val);
-        const linearLimit = onEdit ? Math.min(100, width * 0.32) : Math.min(60, width * 0.18);
-        let smoothedDist = dragDist;
+      const dragDist = Math.abs(Math.min(0, distanceX));
+      let smoothedDist = dragDist;
 
-        if (dragDist > linearLimit) {
-          const excess = dragDist - linearLimit;
-          const maxExcess = 45;
-          // Smooth exponential ease-out deceleration so the swipe slows down gradually instead of stopping abruptly
-          smoothedDist = linearLimit + maxExcess * (1 - Math.exp(-excess / 40));
+      if (dragDist > linearLimit) {
+        const excess = dragDist - linearLimit;
+        const maxExcess = 45;
+        smoothedDist = linearLimit + maxExcess * (1 - Math.exp(-excess / 40));
+      }
+      x.set(-smoothedDist);
+
+      let nextMode: SwipeActionMode = 'none';
+      if (onEdit && distanceX < editThreshold) {
+        nextMode = 'edit';
+      } else if (distanceX < replyThreshold) {
+        nextMode = 'reply';
+      }
+
+      if (nextMode !== actionModeRef.current) {
+        actionModeRef.current = nextMode;
+        setActionMode(nextMode);
+        onActionModeChange?.(nextMode);
+        if (nextMode !== 'none') {
+          haptic(nextMode === 'edit' ? 'medium' : 'selection');
         }
-        x.set(-smoothedDist);
+      }
+    },
+    [onActionModeChange, onEdit, x]
+  );
 
-        let nextMode: SwipeActionMode = 'none';
-        if (onEdit && mx < editThreshold) {
-          nextMode = 'edit';
-        } else if (mx < replyThreshold) {
-          nextMode = 'reply';
-        }
-
-        if (nextMode !== actionModeRef.current) {
-          actionModeRef.current = nextMode;
-          setActionMode(nextMode);
-          if (nextMode !== 'none') {
-            haptic(nextMode === 'edit' ? 'medium' : 'selection');
-          }
-        }
-      } else {
+  const finish = useCallback(
+    (commit: boolean) => {
+      if (commit) {
         const currentMode = actionModeRef.current;
         if (currentMode === 'edit' && onEdit) {
           onEdit();
         } else if (currentMode === 'reply') {
           onReply();
         }
-        animate(x, 0, { type: 'spring', stiffness: 300, damping: 26 });
-        actionModeRef.current = 'none';
-        setActionMode('none');
       }
+
+      gestureActiveRef.current = false;
+      animate(x, 0, { type: 'spring', stiffness: 300, damping: 26 });
+      actionModeRef.current = 'none';
+      setActionMode('none');
+      onActionModeChange?.('none');
     },
-    {
-      axis: 'x',
-      bounds: { right: 0 },
-      rubberband: true,
-      filterTaps: true,
-      eventOptions: { passive: true },
-    }
+    [onActionModeChange, onEdit, onReply, x]
   );
+
+  useLayoutEffect(() => {
+    const element = containerRef.current;
+    if (!drawer || !element) return undefined;
+
+    return drawer.registerMessageSwipe(element, {
+      move,
+      end: () => finish(true),
+      cancel: () => finish(false),
+    });
+  }, [drawer, finish, move]);
 
   const IconComponent = actionMode === 'edit' ? PencilSimple : ArrowBendUpLeftIcon;
   const iconColor =
@@ -95,11 +115,14 @@ function ActiveSwipeWrapper({
   return (
     <div
       data-gestures="ignore"
+      data-message-swipe
       ref={containerRef}
-      {...bind()}
-      style={{ position: 'relative', touchAction: 'pan-y' }}
+      style={{
+        position: 'relative',
+        touchAction: 'pan-y',
+      }}
     >
-      {/* Darkened backdrop for the revealed gap, anchored to the right edge */}
+      {/* Keep the action centered in the portion of the message background being revealed. */}
       <motion.div
         style={{
           position: 'absolute',
@@ -107,43 +130,28 @@ function ActiveSwipeWrapper({
           bottom: 0,
           right: 0,
           width: gapWidth,
-          backgroundColor: 'rgba(0, 0, 0, 0.35)',
-          opacity: bgOpacity,
-          borderTopRightRadius: '8px',
-          borderBottomRightRadius: '8px',
-          zIndex: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1,
           pointerEvents: 'none',
+          overflow: 'hidden',
+          opacity: iconOpacity,
         }}
-      />
+      >
+        <IconComponent
+          size={getPhosphorIconSize('toolbar')}
+          style={{
+            flexShrink: 0,
+            color: iconColor,
+            transition: 'color 0.2s, transform 0.2s',
+            transform: actionMode === 'edit' ? 'scale(1.2)' : 'scale(1)',
+          }}
+        />
+      </motion.div>
 
       <motion.div style={{ x, position: 'relative', zIndex: 2, willChange: 'transform' }}>
         {children}
-
-        {/* Action icon pinned to the right edge of the sliding message */}
-        <motion.div
-          style={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: '100%',
-            width: '60px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1,
-            pointerEvents: 'none',
-            opacity: iconOpacity,
-          }}
-        >
-          <IconComponent
-            size={getPhosphorIconSize('toolbar')}
-            style={{
-              color: iconColor,
-              transition: 'color 0.2s, transform 0.2s',
-              transform: actionMode === 'edit' ? 'scale(1.2)' : 'scale(1)',
-            }}
-          />
-        </motion.div>
       </motion.div>
     </div>
   );
@@ -153,10 +161,12 @@ export function SwipeableMessageWrapper({
   children,
   onReply,
   onEdit,
+  onActionModeChange,
 }: {
   children: ReactNode;
   onReply?: () => void;
   onEdit?: () => void;
+  onActionModeChange?: (mode: SwipeActionMode) => void;
 }) {
   const settings = useAtomValue(settingsAtom);
 
@@ -173,7 +183,7 @@ export function SwipeableMessageWrapper({
   }
 
   return (
-    <ActiveSwipeWrapper onReply={onReply} onEdit={onEdit}>
+    <ActiveSwipeWrapper onReply={onReply} onEdit={onEdit} onActionModeChange={onActionModeChange}>
       {children}
     </ActiveSwipeWrapper>
   );

--- a/src/app/components/SwipeableOverlayWrapper.tsx
+++ b/src/app/components/SwipeableOverlayWrapper.tsx
@@ -88,7 +88,6 @@ export function SwipeableOverlayWrapper({
     <div
       {...bind()}
       style={{
-        touchAction: 'pan-y',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',

--- a/src/app/components/attachment-sheet/AttachmentSheet.test.tsx
+++ b/src/app/components/attachment-sheet/AttachmentSheet.test.tsx
@@ -108,14 +108,15 @@ describe('AttachmentSheet', () => {
     expect(onPointerDown).not.toHaveBeenCalled();
   });
 
-  it('closes once on Escape and returns focus to the opener', async () => {
+  it('does not move focus on open, closes once on Escape, and restores the opener', async () => {
     const handlers = callbacks();
     render(<AttachmentSheetHarness handlers={handlers} />);
     const opener = screen.getByRole('button', { name: 'Open attachments' });
 
     opener.focus();
     fireEvent.click(opener);
-    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Share' })).toHaveFocus());
+    expect(screen.getByRole('dialog', { name: 'Share' })).not.toHaveFocus();
+    expect(opener).toHaveFocus();
     fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
 
     expect(handlers.onClose).toHaveBeenCalledOnce();

--- a/src/app/components/attachment-sheet/AttachmentSheet.tsx
+++ b/src/app/components/attachment-sheet/AttachmentSheet.tsx
@@ -1,6 +1,5 @@
-import { type RefObject, useEffect, useRef } from 'react';
+import { type RefObject, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { AnimatePresence, animate, motion, useMotionValue, useReducedMotion } from 'framer-motion';
 import { useDrag } from '@use-gesture/react';
 import FocusTrap from 'focus-trap-react';
 import { useSetting } from '$state/hooks/settings';
@@ -8,6 +7,8 @@ import { settingsAtom } from '$state/settings';
 import { useAndroidBackHandler } from '$utils/androidBack';
 import { stopPropagation } from '$utils/keyboard';
 import { mobileOrTablet } from '$utils/user-agent';
+import { getMobileSheetTiming, useMobileSheetAnimation } from '$components/mobileSheetAnimation';
+import * as animationCss from '$components/mobileSheetAnimation.css';
 import type { Icon } from '@phosphor-icons/react';
 import {
   Image as ImageIcon,
@@ -47,20 +48,21 @@ export function AttachmentSheet({
   containerRef,
 }: AttachmentSheetProps) {
   const [mobileGestures] = useSetting(settingsAtom, 'mobileGestures');
-  const [reducedMotion] = useSetting(settingsAtom, 'reducedMotion');
   const containerEl = containerRef.current;
   const sheetRef = useRef<HTMLDivElement>(null);
   const skipReturnFocusRef = useRef(false);
-  const y = useMotionValue(0);
-  const prefersReducedMotion = useReducedMotion() ?? false;
-  const shouldReduceMotion = reducedMotion || prefersReducedMotion;
+  const dragYRef = useRef(0);
+  const resetAnimationRef = useRef<Animation>();
+  const { shouldReduceMotion } = useMobileSheetAnimation();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (open) {
       skipReturnFocusRef.current = false;
-      y.set(0);
+      dragYRef.current = 0;
+      resetAnimationRef.current?.cancel();
+      if (sheetRef.current) sheetRef.current.style.transform = '';
     }
-  }, [open, y]);
+  }, [open]);
 
   useAndroidBackHandler(() => {
     onClose();
@@ -84,17 +86,36 @@ export function AttachmentSheet({
       const val = Math.max(0, oy);
 
       if (active) {
-        if (first) y.stop();
-        y.set(val);
+        if (first) {
+          resetAnimationRef.current?.cancel();
+          sheetRef.current?.getAnimations().forEach((animation) => animation.cancel());
+        }
+        dragYRef.current = val;
+        if (sheetRef.current) {
+          sheetRef.current.style.transform = `translate3d(0, ${val}px, 0)`;
+        }
       } else {
         const swipedDown = val > SWIPE_THRESHOLD || (vy > VELOCITY_THRESHOLD && dy > 0);
 
         if (swipedDown) {
           onClose();
-        } else if (shouldReduceMotion) {
-          y.set(0);
-        } else {
-          animate(y, 0, { type: 'spring', stiffness: 400, damping: 40 });
+        } else if (sheetRef.current) {
+          const sheet = sheetRef.current;
+          resetAnimationRef.current = sheet.animate(
+            [
+              { transform: `translate3d(0, ${dragYRef.current}px, 0)` },
+              { transform: 'translate3d(0, 0, 0)' },
+            ],
+            getMobileSheetTiming(shouldReduceMotion)
+          );
+          resetAnimationRef.current.addEventListener(
+            'finish',
+            () => {
+              dragYRef.current = 0;
+              sheet.style.transform = '';
+            },
+            { once: true }
+          );
         }
       }
     },
@@ -104,7 +125,7 @@ export function AttachmentSheet({
       rubberband: true,
       filterTaps: true,
       pointer: { capture: true },
-      from: () => [0, y.get()],
+      from: () => [0, dragYRef.current],
     }
   );
 
@@ -173,64 +194,48 @@ export function AttachmentSheet({
     </>
   );
 
-  const sheetElement = (
-    <AnimatePresence>
-      {open && (
-        <>
-          <motion.div
-            className={css.Backdrop}
-            initial={shouldReduceMotion ? false : { opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
-            onClick={onClose}
-            onPointerDown={(event) => event.stopPropagation()}
-            data-gestures="ignore"
-            aria-hidden="true"
-          />
+  const sheetElement = open ? (
+    <>
+      <div
+        className={`${css.Backdrop} ${animationCss.BackdropEntrance}`}
+        style={shouldReduceMotion ? { animation: 'none' } : undefined}
+        onClick={onClose}
+        onPointerDown={(event) => event.stopPropagation()}
+        data-gestures="ignore"
+        aria-hidden="true"
+      />
 
-          <FocusTrap
-            focusTrapOptions={{
-              initialFocus: () => sheetRef.current ?? containerEl,
-              fallbackFocus: () => sheetRef.current ?? containerEl,
-              returnFocusOnDeactivate: true,
-              setReturnFocus: (previousActiveElement: HTMLElement) =>
-                skipReturnFocusRef.current ? false : previousActiveElement,
-              allowOutsideClick: true,
-              clickOutsideDeactivates: false,
-              escapeDeactivates: (event: KeyboardEvent) => {
-                if (!stopPropagation(event)) return false;
-                onClose();
-                return false;
-              },
-            }}
-          >
-            <motion.div
-              ref={sheetRef}
-              className={css.Sheet}
-              initial={shouldReduceMotion ? false : { y: '100%' }}
-              animate={{ y: 0 }}
-              exit={{ y: '100%' }}
-              transition={
-                shouldReduceMotion
-                  ? { duration: 0 }
-                  : { type: 'spring', damping: 32, stiffness: 340 }
-              }
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="attachment-sheet-title"
-              tabIndex={-1}
-              onPointerDown={(event) => event.stopPropagation()}
-            >
-              <motion.div style={{ y, display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-                {sheetContent}
-              </motion.div>
-            </motion.div>
-          </FocusTrap>
-        </>
-      )}
-    </AnimatePresence>
-  );
+      <FocusTrap
+        focusTrapOptions={{
+          initialFocus: () => sheetRef.current ?? containerEl,
+          fallbackFocus: () => sheetRef.current ?? containerEl,
+          returnFocusOnDeactivate: true,
+          setReturnFocus: (previousActiveElement: HTMLElement) =>
+            skipReturnFocusRef.current ? false : previousActiveElement,
+          allowOutsideClick: true,
+          clickOutsideDeactivates: false,
+          escapeDeactivates: (event: KeyboardEvent) => {
+            if (!stopPropagation(event)) return false;
+            onClose();
+            return false;
+          },
+        }}
+      >
+        <div
+          ref={sheetRef}
+          className={`${css.Sheet} ${animationCss.SheetEntrance}`}
+          style={shouldReduceMotion ? { animation: 'none' } : undefined}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="attachment-sheet-title"
+          tabIndex={-1}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          {sheetContent}
+        </div>
+      </FocusTrap>
+    </>
+  ) : null;
 
   // Never render inline: without the active pane as a portal target, the sheet
   // could briefly anchor to the room layout and cover the sidebar.

--- a/src/app/components/attachment-sheet/AttachmentSheet.tsx
+++ b/src/app/components/attachment-sheet/AttachmentSheet.tsx
@@ -207,8 +207,11 @@ export function AttachmentSheet({
 
       <FocusTrap
         focusTrapOptions={{
-          initialFocus: () => sheetRef.current ?? containerEl,
+          // Moving focus to the bottom sheet makes iOS reposition the visual viewport
+          // and briefly jolts the timeline. Existing mobile sheets leave focus in place.
+          initialFocus: false,
           fallbackFocus: () => sheetRef.current ?? containerEl,
+          preventScroll: true,
           returnFocusOnDeactivate: true,
           setReturnFocus: (previousActiveElement: HTMLElement) =>
             skipReturnFocusRef.current ? false : previousActiveElement,

--- a/src/app/components/mobileSheetAnimation.css.ts
+++ b/src/app/components/mobileSheetAnimation.css.ts
@@ -1,0 +1,32 @@
+import { keyframes, style } from '@vanilla-extract/css';
+import { MOBILE_SHEET_DURATION_MS, MOBILE_SHEET_EASING } from './mobileSheetAnimationConstants';
+
+const slideIn = keyframes({
+  from: { transform: 'translate3d(0, 100%, 0)' },
+  to: { transform: 'translate3d(0, 0, 0)' },
+});
+
+const fadeIn = keyframes({
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+});
+
+export const SheetEntrance = style({
+  animation: `${slideIn} ${MOBILE_SHEET_DURATION_MS}ms ${MOBILE_SHEET_EASING}`,
+  willChange: 'transform',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      animation: 'none',
+    },
+  },
+});
+
+export const BackdropEntrance = style({
+  animation: `${fadeIn} 180ms ease-out`,
+  willChange: 'opacity',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      animation: 'none',
+    },
+  },
+});

--- a/src/app/components/mobileSheetAnimation.ts
+++ b/src/app/components/mobileSheetAnimation.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
+import { MOBILE_SHEET_DURATION_MS, MOBILE_SHEET_EASING } from './mobileSheetAnimationConstants';
+
+export const getMobileSheetTiming = (reducedMotion: boolean): KeyframeAnimationOptions => ({
+  duration: reducedMotion ? 0 : MOBILE_SHEET_DURATION_MS,
+  easing: MOBILE_SHEET_EASING,
+  fill: 'forwards',
+});
+
+export function useMobileSheetAnimation() {
+  const [reducedMotion] = useSetting(settingsAtom, 'reducedMotion');
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    () => window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+  );
+
+  useEffect(() => {
+    const query = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!query) return undefined;
+    const handleChange = () => setPrefersReducedMotion(query.matches);
+    query.addEventListener('change', handleChange);
+    return () => query.removeEventListener('change', handleChange);
+  }, []);
+
+  return {
+    shouldReduceMotion: reducedMotion || prefersReducedMotion,
+  };
+}

--- a/src/app/components/mobileSheetAnimationConstants.ts
+++ b/src/app/components/mobileSheetAnimationConstants.ts
@@ -1,0 +1,2 @@
+export const MOBILE_SHEET_DURATION_MS = 240;
+export const MOBILE_SHEET_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)';

--- a/src/app/components/page/MobileNavDrawer.tsx
+++ b/src/app/components/page/MobileNavDrawer.tsx
@@ -1,5 +1,13 @@
 import type { ReactNode } from 'react';
-import { startTransition, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { matchPath, useLocation, useNavigate } from 'react-router-dom';
 import { useSetting } from '$state/hooks/settings';
@@ -19,6 +27,12 @@ import {
 import { resolveSection } from '$pages/pathUtils';
 import { isRoomAlias, isRoomId } from '$utils/matrix';
 import { PersistentRoomHost } from './PersistentRoomHost';
+import { MobileNavDrawerContext, type MobileSwipeTarget } from './MobileNavDrawerContext';
+import {
+  classifyMobileGesture,
+  getDrawerSettlePosition,
+  type MobileGestureMode,
+} from './mobileSwipeCoordinator';
 
 type MobileNavDrawerProps = {
   nav: ReactNode;
@@ -27,8 +41,21 @@ type MobileNavDrawerProps = {
   children: ReactNode;
 };
 
-/** Sliding mobile drawer: the list and active room are adjacent snap panels;
- * native scrolling reveals the other panel and commits the route after settling. */
+const DRAWER_TRANSITION_MS = 220;
+
+type ActiveTouchGesture = {
+  startX: number;
+  startY: number;
+  startPosition: number;
+  lastX: number;
+  lastTime: number;
+  velocityX: number;
+  mode: MobileGestureMode;
+  message?: MobileSwipeTarget;
+  chat?: MobileSwipeTarget;
+};
+
+/** Sliding mobile drawer with one touch coordinator and a GPU-transformed panel track. */
 export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDrawerProps) {
   const [mobileGestures] = useSetting(settingsAtom, 'mobileGestures');
   const reduceMotion = useReducedMotion();
@@ -62,14 +89,83 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
   const contentOpen = !listView;
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
   const navPanelRef = useRef<HTMLDivElement | null>(null);
   const contentPanelRef = useRef<HTMLDivElement | null>(null);
   const [width, setWidth] = useState(0);
+  const widthRef = useRef(0);
+  const positionRef = useRef(0);
 
   const [panelIntent, setPanelIntent] = useState(contentOpen ? 1 : 0);
-  const userScrollRef = useRef(false);
-  const touchActiveRef = useRef(false);
-  const scrollEndTimerRef = useRef<number>();
+  const gestureRef = useRef<ActiveTouchGesture>();
+  const messageTargetsRef = useRef(new WeakMap<HTMLElement, MobileSwipeTarget>());
+  const chatTargetsRef = useRef(new WeakMap<HTMLElement, MobileSwipeTarget>());
+  const settleAnimationRef = useRef<number>();
+  const programmaticTargetRef = useRef<number>();
+
+  const setTrackPosition = useCallback((position: number) => {
+    positionRef.current = position;
+    if (trackRef.current) {
+      trackRef.current.style.transform = `translate3d(${position}px, 0, 0)`;
+    }
+  }, []);
+
+  const settleToPanel = useCallback(
+    (targetPosition: number, onComplete?: () => void) => {
+      if (!trackRef.current) return;
+
+      window.cancelAnimationFrame(settleAnimationRef.current ?? 0);
+      if (reduceMotion) {
+        setTrackPosition(targetPosition);
+        onComplete?.();
+        return;
+      }
+
+      const startPosition = positionRef.current;
+      const distance = targetPosition - startPosition;
+      if (Math.abs(distance) <= 1) {
+        setTrackPosition(targetPosition);
+        onComplete?.();
+        return;
+      }
+
+      const startTime = window.performance.now();
+      const tick = (time: number) => {
+        const progress = Math.min(1, (time - startTime) / DRAWER_TRANSITION_MS);
+        const eased = 1 - (1 - progress) ** 3;
+        setTrackPosition(startPosition + distance * eased);
+
+        if (progress < 1) {
+          settleAnimationRef.current = window.requestAnimationFrame(tick);
+        } else {
+          setTrackPosition(targetPosition);
+          settleAnimationRef.current = undefined;
+          onComplete?.();
+        }
+      };
+
+      settleAnimationRef.current = window.requestAnimationFrame(tick);
+    },
+    [reduceMotion, setTrackPosition]
+  );
+
+  const registerMessageSwipe = useCallback((element: HTMLElement, target: MobileSwipeTarget) => {
+    messageTargetsRef.current.set(element, target);
+    return () => {
+      if (messageTargetsRef.current.get(element) === target) {
+        messageTargetsRef.current.delete(element);
+      }
+    };
+  }, []);
+
+  const registerChatSwipe = useCallback((element: HTMLElement, target: MobileSwipeTarget) => {
+    chatTargetsRef.current.set(element, target);
+    return () => {
+      if (chatTargetsRef.current.get(element) === target) {
+        chatTargetsRef.current.delete(element);
+      }
+    };
+  }, []);
 
   const [roomArmed, setRoomArmed] = useState(() => isRoomRoute || canOpenRoom);
   useEffect(() => {
@@ -84,19 +180,51 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
     return () => cic(handle as number);
   }, [isRoomRoute, canOpenRoom, roomArmed]);
 
+  const openContent = useCallback(
+    (path: string) => {
+      const viewport = viewportRef.current;
+      if (!viewport || width === 0) {
+        startTransition(() => navigate(path));
+        return;
+      }
+
+      setRoomArmed(true);
+      programmaticTargetRef.current = -width;
+
+      // Start the exact same settle used after a swipe immediately, while the
+      // selected room renders concurrently in the panel being revealed.
+      settleToPanel(-width, () => {
+        if (programmaticTargetRef.current === -width) {
+          programmaticTargetRef.current = undefined;
+        }
+        setPanelIntent(1);
+      });
+      startTransition(() => navigate(path));
+    },
+    [navigate, settleToPanel, width]
+  );
+
   useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el) return undefined;
-    const update = () => setWidth(el.clientWidth);
+    const update = () => {
+      const nextWidth = el.clientWidth;
+      const previousWidth = widthRef.current;
+      const nextPosition =
+        previousWidth > 0
+          ? (positionRef.current / previousWidth) * nextWidth
+          : contentOpen
+            ? -nextWidth
+            : 0;
+      widthRef.current = nextWidth;
+      setTrackPosition(nextPosition);
+      setWidth(nextWidth);
+    };
     update();
     const observer = new ResizeObserver(update);
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
-
-  useLayoutEffect(() => {
-    setPanelIntent(contentOpen ? 1 : 0);
-  }, [contentOpen]);
+  }, [contentOpen, setTrackPosition]);
 
   useLayoutEffect(() => {
     navPanelRef.current?.toggleAttribute('inert', panelIntent === 1);
@@ -106,25 +234,26 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
   useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el || width === 0) return;
-    const targetLeft = contentOpen ? width : 0;
+    const targetPosition = contentOpen ? -width : 0;
 
-    userScrollRef.current = false;
-    touchActiveRef.current = false;
-    window.clearTimeout(scrollEndTimerRef.current);
-    if (Math.abs(el.scrollLeft - targetLeft) > 5) {
-      el.scrollTo({ left: targetLeft, behavior: reduceMotion ? 'auto' : 'smooth' });
+    if (programmaticTargetRef.current === targetPosition) return;
+
+    if (Math.abs(positionRef.current - targetPosition) > 5) {
+      settleToPanel(targetPosition, () => setPanelIntent(contentOpen ? 1 : 0));
+    } else {
+      setPanelIntent(contentOpen ? 1 : 0);
     }
-  }, [contentOpen, width, reduceMotion]);
+  }, [contentOpen, settleToPanel, width]);
 
-  const finishUserScroll = useCallback(() => {
-    const viewport = viewportRef.current;
-    if (!viewport || !userScrollRef.current || width === 0) return;
+  const commitPanel = useCallback(
+    (roomVisible: boolean) => {
+      if (width === 0) return;
 
-    userScrollRef.current = false;
-    const roomVisible = viewport.scrollLeft >= width / 2;
-    setPanelIntent(roomVisible ? 1 : 0);
+      setTrackPosition(roomVisible ? -width : 0);
+      setPanelIntent(roomVisible ? 1 : 0);
 
-    if (roomVisible !== contentOpen) {
+      if (roomVisible === contentOpen) return;
+
       if (roomVisible) {
         const section = resolveSection(location.pathname);
         if (section?.getRoomPath) {
@@ -134,75 +263,165 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
             return;
           }
         }
-        viewport.scrollTo({ left: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+        settleToPanel(0);
         setPanelIntent(0);
-      } else {
-        const section = resolveSection(location.pathname);
-        if (section) {
-          if (section.getRoomPath && matchedRoomId && isRoomRoute) {
-            setLastRoom((prev) => ({ ...prev, [section.key]: matchedRoomId }));
-          }
-          startTransition(() => navigate(section.listPath));
-        }
+        return;
       }
-    }
-  }, [
-    contentOpen,
-    isRoomRoute,
-    lastRoom,
-    location.pathname,
-    matchedRoomId,
-    navigate,
-    reduceMotion,
-    setLastRoom,
-    width,
-  ]);
 
-  const scheduleScrollEnd = useCallback(
-    (delay = 120) => {
-      window.clearTimeout(scrollEndTimerRef.current);
-      scrollEndTimerRef.current = window.setTimeout(finishUserScroll, delay);
+      const section = resolveSection(location.pathname);
+      if (!section) return;
+      if (section.getRoomPath && matchedRoomId && isRoomRoute) {
+        setLastRoom((prev) => ({ ...prev, [section.key]: matchedRoomId }));
+      }
+      startTransition(() => navigate(section.listPath));
     },
-    [finishUserScroll]
+    [
+      contentOpen,
+      isRoomRoute,
+      lastRoom,
+      location.pathname,
+      matchedRoomId,
+      navigate,
+      settleToPanel,
+      setLastRoom,
+      setTrackPosition,
+      width,
+    ]
+  );
+
+  const finishGesture = useCallback(
+    (cancelled: boolean) => {
+      const gesture = gestureRef.current;
+      gestureRef.current = undefined;
+      if (!gesture) return;
+
+      const distanceX = gesture.lastX - gesture.startX;
+      if (gesture.mode === 'message') {
+        if (cancelled) gesture.message?.cancel();
+        else gesture.message?.end({ distanceX, velocityX: gesture.velocityX });
+        return;
+      }
+      if (gesture.mode === 'chat') {
+        if (cancelled) gesture.chat?.cancel();
+        else gesture.chat?.end({ distanceX, velocityX: gesture.velocityX });
+        return;
+      }
+      if (gesture.mode !== 'drawer' || width === 0) return;
+
+      const targetPosition = getDrawerSettlePosition({
+        startPosition: gesture.startPosition,
+        distanceX,
+        velocityX: gesture.velocityX,
+        width,
+        cancelled,
+      });
+
+      settleToPanel(targetPosition, () => commitPanel(targetPosition === -width));
+    },
+    [commitPanel, settleToPanel, width]
   );
 
   useEffect(() => {
-    return () => window.clearTimeout(scrollEndTimerRef.current);
+    return () => {
+      window.cancelAnimationFrame(settleAnimationRef.current ?? 0);
+      const gesture = gestureRef.current;
+      gestureRef.current = undefined;
+      gesture?.message?.cancel();
+      gesture?.chat?.cancel();
+    };
   }, []);
 
-  const allowScroll = mobileGestures && (canOpenRoom || contentOpen);
+  const contextValue = useMemo(
+    () => ({ openContent, registerChatSwipe, registerMessageSwipe }),
+    [openContent, registerChatSwipe, registerMessageSwipe]
+  );
 
-  return (
+  const drawer = (
     <div
       ref={viewportRef}
       className="no-scrollbar"
-      onTouchStart={() => {
-        userScrollRef.current = true;
-        touchActiveRef.current = true;
-        window.clearTimeout(scrollEndTimerRef.current);
+      onTouchStartCapture={(event) => {
+        const viewport = viewportRef.current;
+        const touch = event.touches[0];
+        if (!mobileGestures || !viewport || !touch) return;
+        if (event.touches.length !== 1) {
+          finishGesture(true);
+          return;
+        }
+
+        const target = event.target instanceof Element ? event.target : event.currentTarget;
+        const messageElement = target.closest<HTMLElement>('[data-message-swipe]');
+        const chatElement = target.closest<HTMLElement>('[data-chat-swipe]');
+        const ignoredElement = target.closest<HTMLElement>('[data-gestures="ignore"]');
+        const message = messageElement ? messageTargetsRef.current.get(messageElement) : undefined;
+        const chat = chatElement ? chatTargetsRef.current.get(chatElement) : undefined;
+        const blocked = ignoredElement !== null && ignoredElement !== messageElement;
+
+        gestureRef.current = {
+          startX: touch.clientX,
+          startY: touch.clientY,
+          startPosition: positionRef.current,
+          lastX: touch.clientX,
+          lastTime: event.timeStamp,
+          velocityX: 0,
+          mode: blocked ? 'blocked' : 'pending',
+          message,
+          chat,
+        };
+        if (positionRef.current > -width && canOpenRoom) setRoomArmed(true);
       }}
-      onScroll={() => {
-        if (!userScrollRef.current || width === 0) return;
-        if (!touchActiveRef.current) scheduleScrollEnd();
+      onTouchMoveCapture={(event) => {
+        const viewport = viewportRef.current;
+        const gesture = gestureRef.current;
+        const touch = event.touches[0];
+        if (!viewport || !gesture || !touch || gesture.mode === 'blocked') return;
+
+        const distanceX = touch.clientX - gesture.startX;
+        const distanceY = touch.clientY - gesture.startY;
+        const elapsed = event.timeStamp - gesture.lastTime;
+        if (elapsed > 0) {
+          gesture.velocityX = (touch.clientX - gesture.lastX) / elapsed;
+          gesture.lastX = touch.clientX;
+          gesture.lastTime = event.timeStamp;
+        }
+
+        if (gesture.mode === 'pending') {
+          gesture.mode = classifyMobileGesture({
+            distanceX,
+            distanceY,
+            startPosition: positionRef.current,
+            width,
+            canOpenRoom,
+            hasMessage: gesture.message !== undefined,
+            hasChat: gesture.chat !== undefined,
+          });
+          if (gesture.mode === 'drawer' || gesture.mode === 'message' || gesture.mode === 'chat') {
+            const animationActive = settleAnimationRef.current !== undefined;
+            window.cancelAnimationFrame(settleAnimationRef.current ?? 0);
+            settleAnimationRef.current = undefined;
+            programmaticTargetRef.current = undefined;
+            if (animationActive) gesture.startPosition = positionRef.current - distanceX;
+          }
+        }
+
+        if (gesture.mode === 'drawer') {
+          setTrackPosition(Math.max(-width, Math.min(0, gesture.startPosition + distanceX)));
+        } else if (gesture.mode === 'message') {
+          gesture.message?.move(distanceX);
+        } else if (gesture.mode === 'chat') {
+          gesture.chat?.move(distanceX);
+        }
       }}
-      onTouchEnd={() => {
-        touchActiveRef.current = false;
-        scheduleScrollEnd(180);
-      }}
-      onTouchCancel={() => {
-        touchActiveRef.current = false;
-        scheduleScrollEnd();
-      }}
+      onTouchEndCapture={() => finishGesture(false)}
+      onTouchCancelCapture={() => finishGesture(true)}
       style={{
         display: 'flex',
         flexGrow: 1,
         height: '100%',
         width: '100%',
-        overflowX: allowScroll ? 'auto' : 'hidden',
-        overflowY: 'hidden',
+        overflow: 'hidden',
         overscrollBehaviorX: 'none',
-        scrollSnapType: 'x mandatory',
-        WebkitOverflowScrolling: 'touch',
+        touchAction: 'pan-y',
       }}
     >
       <style>{`
@@ -215,62 +434,78 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
         }
       `}</style>
       <div
-        ref={navPanelRef}
-        className="no-scrollbar"
+        ref={trackRef}
         style={{
-          width: '100%',
-          flexBasis: '100%',
+          display: 'flex',
+          width: '200%',
           height: '100%',
           flexShrink: 0,
-          scrollSnapAlign: 'start',
-          scrollSnapStop: 'always',
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          transform: 'translateZ(0)',
-          backfaceVisibility: 'hidden',
+          transform: 'translate3d(0, 0, 0)',
+          willChange: 'transform',
         }}
       >
         <div
+          ref={navPanelRef}
+          className="no-scrollbar"
           style={{
-            flexGrow: 1,
-            minHeight: 0,
+            width: '50%',
+            flexBasis: '50%',
+            height: '100%',
+            flexShrink: 0,
             display: 'flex',
-            flexDirection: 'row',
+            flexDirection: 'column',
             overflow: 'hidden',
+            transform: 'translateZ(0)',
+            backfaceVisibility: 'hidden',
           }}
         >
-          {rail && <div style={{ flexShrink: 0, display: 'flex', overflow: 'hidden' }}>{rail}</div>}
-          <div style={{ flexGrow: 1, minWidth: 0, display: 'flex', overflow: 'hidden' }}>{nav}</div>
+          <div
+            style={{
+              flexGrow: 1,
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'row',
+              overflow: 'hidden',
+            }}
+          >
+            {rail && (
+              <div style={{ flexShrink: 0, display: 'flex', overflow: 'hidden' }}>{rail}</div>
+            )}
+            <div style={{ flexGrow: 1, minWidth: 0, display: 'flex', overflow: 'hidden' }}>
+              {nav}
+            </div>
+          </div>
+          {bottomNav}
         </div>
-        {bottomNav}
-      </div>
-      <div
-        ref={contentPanelRef}
-        className="no-scrollbar"
-        style={{
-          width: '100%',
-          flexBasis: '100%',
-          height: '100%',
-          flexShrink: 0,
-          scrollSnapAlign: 'start',
-          scrollSnapStop: 'always',
-          display: 'flex',
-          overflow: 'hidden',
-          transform: 'translateZ(0)',
-          backfaceVisibility: 'hidden',
-        }}
-      >
-        {isRoomRoute ? (
-          <PersistentRoomHost inactive={panelIntent === 0} />
-        ) : listView ? (
-          roomArmed ? (
+        <div
+          ref={contentPanelRef}
+          className="no-scrollbar"
+          style={{
+            width: '50%',
+            flexBasis: '50%',
+            height: '100%',
+            flexShrink: 0,
+            display: 'flex',
+            overflow: 'hidden',
+            transform: 'translateZ(0)',
+            backfaceVisibility: 'hidden',
+          }}
+        >
+          {isRoomRoute ? (
             <PersistentRoomHost inactive={panelIntent === 0} />
-          ) : null
-        ) : (
-          children
-        )}
+          ) : listView ? (
+            roomArmed ? (
+              <PersistentRoomHost inactive={panelIntent === 0} />
+            ) : null
+          ) : (
+            children
+          )}
+        </div>
       </div>
     </div>
+  );
+
+  return (
+    <MobileNavDrawerContext.Provider value={contextValue}>{drawer}</MobileNavDrawerContext.Provider>
   );
 }

--- a/src/app/components/page/MobileNavDrawer.tsx
+++ b/src/app/components/page/MobileNavDrawer.tsx
@@ -1,12 +1,11 @@
 import type { ReactNode } from 'react';
 import { startTransition, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import type { AnimationPlaybackControls } from 'framer-motion';
-import { animate, motion, useDragControls, useMotionValue, useReducedMotion } from 'framer-motion';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { matchPath, useLocation, useNavigate } from 'react-router-dom';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { lastVisitedRoomAtom } from '$state/room/lastRoom';
+import { useReducedMotion } from 'framer-motion';
 import {
   DIRECT_PATH,
   DIRECT_ROOM_PATH,
@@ -21,11 +20,6 @@ import { resolveSection } from '$pages/pathUtils';
 import { isRoomAlias, isRoomId } from '$utils/matrix';
 import { PersistentRoomHost } from './PersistentRoomHost';
 
-const SETTLE_STIFFNESS = 1000;
-const SETTLE_DAMPING = 63;
-const OPEN_FRACTION = 0.35;
-const VELOCITY_THRESHOLD = 400;
-
 type MobileNavDrawerProps = {
   nav: ReactNode;
   rail?: ReactNode;
@@ -33,8 +27,8 @@ type MobileNavDrawerProps = {
   children: ReactNode;
 };
 
-/** Sliding mobile drawer: the list and active room are adjacent panels; dragging
- * reveals the list and commits the route on release. */
+/** Sliding mobile drawer: the list and active room are adjacent snap panels;
+ * native scrolling reveals the other panel and commits the route after settling. */
 export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDrawerProps) {
   const [mobileGestures] = useSetting(settingsAtom, 'mobileGestures');
   const reduceMotion = useReducedMotion();
@@ -55,8 +49,8 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
   const matchedRoomId = roomMatch?.params.roomIdOrAlias
     ? decodeURIComponent(roomMatch.params.roomIdOrAlias)
     : undefined;
-  // `:roomIdOrAlias` also matches non-room segments like `create`, `search`, `lobby`.
-  // Only treat it as a room when it's a real Matrix id/alias.
+  // `:roomIdOrAlias` also matches non-room segments like `create`, `search`, and `lobby`.
+  // Only treat it as a room when it is a real Matrix ID or alias.
   const isRoomRoute = !!matchedRoomId && (isRoomId(matchedRoomId) || isRoomAlias(matchedRoomId));
 
   const listView =
@@ -71,17 +65,15 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
   const navPanelRef = useRef<HTMLDivElement | null>(null);
   const contentPanelRef = useRef<HTMLDivElement | null>(null);
   const [width, setWidth] = useState(0);
-  const x = useMotionValue(0);
-  const dragControls = useDragControls();
-  const settleAnimRef = useRef<AnimationPlaybackControls | null>(null);
 
-  const initialIntent = contentOpen ? 1 : 0;
-  const [panelIntent, setPanelIntent] = useState(initialIntent);
-  const panelIntentRef = useRef(initialIntent);
+  const [panelIntent, setPanelIntent] = useState(contentOpen ? 1 : 0);
+  const userScrollRef = useRef(false);
+  const touchActiveRef = useRef(false);
+  const scrollEndTimerRef = useRef<number>();
 
-  const [roomArmed, setRoomArmed] = useState(isRoomRoute);
+  const [roomArmed, setRoomArmed] = useState(() => isRoomRoute || canOpenRoom);
   useEffect(() => {
-    if (isRoomRoute) {
+    if (isRoomRoute || canOpenRoom) {
       setRoomArmed(true);
       return undefined;
     }
@@ -90,26 +82,7 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
     const cic = window.cancelIdleCallback ?? window.clearTimeout;
     const handle = ric(() => setRoomArmed(true));
     return () => cic(handle as number);
-  }, [isRoomRoute, roomArmed]);
-
-  const settle = useCallback(
-    (target: number) => {
-      settleAnimRef.current?.stop();
-      settleAnimRef.current = null;
-
-      if (reduceMotion) {
-        x.jump(target);
-        return;
-      }
-      settleAnimRef.current = animate(x, target, {
-        type: 'spring',
-        stiffness: SETTLE_STIFFNESS,
-        damping: SETTLE_DAMPING,
-        velocity: 0,
-      });
-    },
-    [reduceMotion, x]
-  );
+  }, [isRoomRoute, canOpenRoom, roomArmed]);
 
   useLayoutEffect(() => {
     const el = viewportRef.current;
@@ -122,163 +95,182 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
   }, []);
 
   useLayoutEffect(() => {
+    setPanelIntent(contentOpen ? 1 : 0);
+  }, [contentOpen]);
+
+  useLayoutEffect(() => {
     navPanelRef.current?.toggleAttribute('inert', panelIntent === 1);
     contentPanelRef.current?.toggleAttribute('inert', panelIntent === 0);
   }, [panelIntent]);
 
   useLayoutEffect(() => {
-    const routePanel = contentOpen ? 1 : 0;
-    if (routePanel !== panelIntentRef.current) {
-      panelIntentRef.current = routePanel;
-      setPanelIntent(routePanel);
-      const target = routePanel === 1 ? -width : 0;
-      if (width > 0 && !reduceMotion) {
-        settle(target);
+    const el = viewportRef.current;
+    if (!el || width === 0) return;
+    const targetLeft = contentOpen ? width : 0;
+
+    userScrollRef.current = false;
+    touchActiveRef.current = false;
+    window.clearTimeout(scrollEndTimerRef.current);
+    if (Math.abs(el.scrollLeft - targetLeft) > 5) {
+      el.scrollTo({ left: targetLeft, behavior: reduceMotion ? 'auto' : 'smooth' });
+    }
+  }, [contentOpen, width, reduceMotion]);
+
+  const finishUserScroll = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || !userScrollRef.current || width === 0) return;
+
+    userScrollRef.current = false;
+    const roomVisible = viewport.scrollLeft >= width / 2;
+    setPanelIntent(roomVisible ? 1 : 0);
+
+    if (roomVisible !== contentOpen) {
+      if (roomVisible) {
+        const section = resolveSection(location.pathname);
+        if (section?.getRoomPath) {
+          const lastRoomId = lastRoom?.[section.key];
+          if (lastRoomId) {
+            startTransition(() => navigate(section.getRoomPath!(lastRoomId)));
+            return;
+          }
+        }
+        viewport.scrollTo({ left: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+        setPanelIntent(0);
       } else {
-        settleAnimRef.current?.stop();
-        settleAnimRef.current = null;
-        x.jump(target);
+        const section = resolveSection(location.pathname);
+        if (section) {
+          if (section.getRoomPath && matchedRoomId && isRoomRoute) {
+            setLastRoom((prev) => ({ ...prev, [section.key]: matchedRoomId }));
+          }
+          startTransition(() => navigate(section.listPath));
+        }
       }
     }
-  }, [contentOpen, width, x, settle, reduceMotion]);
+  }, [
+    contentOpen,
+    isRoomRoute,
+    lastRoom,
+    location.pathname,
+    matchedRoomId,
+    navigate,
+    reduceMotion,
+    setLastRoom,
+    width,
+  ]);
 
-  useLayoutEffect(() => {
-    settleAnimRef.current?.stop();
-    settleAnimRef.current = null;
-    const target = panelIntentRef.current === 1 ? -width : 0;
-    x.jump(target);
-  }, [width, x]);
+  const scheduleScrollEnd = useCallback(
+    (delay = 120) => {
+      window.clearTimeout(scrollEndTimerRef.current);
+      scrollEndTimerRef.current = window.setTimeout(finishUserScroll, delay);
+    },
+    [finishUserScroll]
+  );
+
+  useEffect(() => {
+    return () => window.clearTimeout(scrollEndTimerRef.current);
+  }, []);
+
+  const allowScroll = mobileGestures && (canOpenRoom || contentOpen);
 
   return (
     <div
-      onPointerDown={(event) => {
-        if (!mobileGestures || width === 0) return;
-        const target = event.target as HTMLElement | null;
-        if (target?.closest('[data-gestures="ignore"]')) return;
-        // On the list panel, only start drag tracking when a room is available to open.
-        if (panelIntentRef.current === 0 && !canOpenRoom) return;
-        dragControls.start(event);
-      }}
       ref={viewportRef}
+      className="no-scrollbar"
+      onTouchStart={() => {
+        userScrollRef.current = true;
+        touchActiveRef.current = true;
+        window.clearTimeout(scrollEndTimerRef.current);
+      }}
+      onScroll={() => {
+        if (!userScrollRef.current || width === 0) return;
+        if (!touchActiveRef.current) scheduleScrollEnd();
+      }}
+      onTouchEnd={() => {
+        touchActiveRef.current = false;
+        scheduleScrollEnd(180);
+      }}
+      onTouchCancel={() => {
+        touchActiveRef.current = false;
+        scheduleScrollEnd();
+      }}
       style={{
-        position: 'relative',
-        overflow: 'hidden',
         display: 'flex',
         flexGrow: 1,
         height: '100%',
         width: '100%',
-        touchAction: 'manipulation',
+        overflowX: allowScroll ? 'auto' : 'hidden',
+        overflowY: 'hidden',
+        overscrollBehaviorX: 'none',
+        scrollSnapType: 'x mandatory',
+        WebkitOverflowScrolling: 'touch',
       }}
     >
-      <motion.div
-        drag={mobileGestures ? 'x' : false}
-        dragControls={dragControls}
-        dragListener={false}
-        dragConstraints={{ left: -width, right: 0 }}
-        dragDirectionLock
-        dragElastic={0.05}
-        dragMomentum={false}
-        onDragStart={() => {
-          x.stop();
-          settleAnimRef.current?.stop();
-          settleAnimRef.current = null;
-          if (panelIntentRef.current === 0 && !roomArmed) setRoomArmed(true);
+      <style>{`
+        .no-scrollbar::-webkit-scrollbar {
+          display: none;
+        }
+        .no-scrollbar {
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+        }
+      `}</style>
+      <div
+        ref={navPanelRef}
+        className="no-scrollbar"
+        style={{
+          width: '100%',
+          flexBasis: '100%',
+          height: '100%',
+          flexShrink: 0,
+          scrollSnapAlign: 'start',
+          scrollSnapStop: 'always',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          transform: 'translateZ(0)',
+          backfaceVisibility: 'hidden',
         }}
-        onDragEnd={(_event, info) => {
-          const { offset, velocity } = info;
-
-          if (panelIntentRef.current === 1) {
-            // Room panel → swipe right to reveal the list.
-            const opened = offset.x > width * OPEN_FRACTION || velocity.x > VELOCITY_THRESHOLD;
-            if (opened) {
-              panelIntentRef.current = 0;
-              setPanelIntent(0);
-              settle(0);
-              const section = resolveSection(location.pathname);
-              if (section?.getRoomPath && matchedRoomId && isRoomRoute) {
-                setLastRoom((prev) => ({ ...prev, [section.key]: matchedRoomId }));
-              }
-              if (section) startTransition(() => navigate(section.listPath));
-            } else {
-              settle(-width);
-            }
-            return;
-          }
-
-          // List panel → swipe left to open the last visited room.
-          const wantRoom = -offset.x > width * OPEN_FRACTION || velocity.x < -VELOCITY_THRESHOLD;
-          if (wantRoom) {
-            const section = resolveSection(location.pathname);
-            if (section?.getRoomPath) {
-              const lastRoomId = lastRoom?.[section.key];
-              if (lastRoomId) {
-                const roomPath = section.getRoomPath(lastRoomId);
-                panelIntentRef.current = 1;
-                setPanelIntent(1);
-                settle(-width);
-                startTransition(() => navigate(roomPath));
-              } else {
-                settle(0);
-              }
-            } else {
-              settle(0);
-            }
-          } else {
-            settle(0);
-          }
-        }}
-        style={{ x, display: 'flex', height: '100%', willChange: 'transform' }}
       >
         <div
-          ref={navPanelRef}
           style={{
-            width,
-            height: '100%',
-            flexShrink: 0,
+            flexGrow: 1,
+            minHeight: 0,
             display: 'flex',
-            flexDirection: 'column',
+            flexDirection: 'row',
             overflow: 'hidden',
           }}
         >
-          <div
-            style={{
-              flexGrow: 1,
-              minHeight: 0,
-              display: 'flex',
-              flexDirection: 'row',
-              overflow: 'hidden',
-            }}
-          >
-            {rail && (
-              <div style={{ flexShrink: 0, display: 'flex', overflow: 'hidden' }}>{rail}</div>
-            )}
-            <div style={{ flexGrow: 1, minWidth: 0, display: 'flex', overflow: 'hidden' }}>
-              {nav}
-            </div>
-          </div>
-          {bottomNav}
+          {rail && <div style={{ flexShrink: 0, display: 'flex', overflow: 'hidden' }}>{rail}</div>}
+          <div style={{ flexGrow: 1, minWidth: 0, display: 'flex', overflow: 'hidden' }}>{nav}</div>
         </div>
-        <div
-          ref={contentPanelRef}
-          style={{
-            width,
-            height: '100%',
-            flexShrink: 0,
-            display: 'flex',
-            overflow: 'hidden',
-          }}
-        >
-          {isRoomRoute ? (
+        {bottomNav}
+      </div>
+      <div
+        ref={contentPanelRef}
+        className="no-scrollbar"
+        style={{
+          width: '100%',
+          flexBasis: '100%',
+          height: '100%',
+          flexShrink: 0,
+          scrollSnapAlign: 'start',
+          scrollSnapStop: 'always',
+          display: 'flex',
+          overflow: 'hidden',
+          transform: 'translateZ(0)',
+          backfaceVisibility: 'hidden',
+        }}
+      >
+        {isRoomRoute ? (
+          <PersistentRoomHost inactive={panelIntent === 0} />
+        ) : listView ? (
+          roomArmed ? (
             <PersistentRoomHost inactive={panelIntent === 0} />
-          ) : listView ? (
-            roomArmed ? (
-              <PersistentRoomHost inactive={panelIntent === 0} />
-            ) : null
-          ) : (
-            children
-          )}
-        </div>
-      </motion.div>
+          ) : null
+        ) : (
+          children
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/components/page/MobileNavDrawerContext.ts
+++ b/src/app/components/page/MobileNavDrawerContext.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react';
+
+export type MobileSwipeEnd = {
+  distanceX: number;
+  velocityX: number;
+};
+
+export type MobileSwipeTarget = {
+  move: (distanceX: number) => void;
+  end: (gesture: MobileSwipeEnd) => void;
+  cancel: () => void;
+};
+
+export type MobileNavDrawerControls = {
+  openContent: (path: string) => void;
+  registerChatSwipe: (element: HTMLElement, target: MobileSwipeTarget) => () => void;
+  registerMessageSwipe: (element: HTMLElement, target: MobileSwipeTarget) => () => void;
+};
+
+export const MobileNavDrawerContext = createContext<MobileNavDrawerControls | undefined>(undefined);
+
+export function useMobileNavDrawer(): MobileNavDrawerControls | undefined {
+  return useContext(MobileNavDrawerContext);
+}
+
+export function useOpenMobileDrawerContent(): ((path: string) => void) | undefined {
+  return useMobileNavDrawer()?.openContent;
+}

--- a/src/app/components/page/Page.tsx
+++ b/src/app/components/page/Page.tsx
@@ -89,7 +89,6 @@ export function PageNavContent({
         size="300"
         hideTrack
         visibility="Hover"
-        style={{ touchAction: 'pan-y' }}
       >
         <div className={css.PageNavContent}>{children}</div>
       </Scroll>

--- a/src/app/components/page/mobileSwipeCoordinator.test.ts
+++ b/src/app/components/page/mobileSwipeCoordinator.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { classifyMobileGesture, getDrawerSettlePosition } from './mobileSwipeCoordinator';
+
+const width = 400;
+
+describe('classifyMobileGesture', () => {
+  it('gives a rightward room gesture to the drawer', () => {
+    expect(
+      classifyMobileGesture({
+        distanceX: 20,
+        distanceY: 2,
+        startPosition: -width,
+        width,
+        canOpenRoom: true,
+        hasMessage: true,
+        hasChat: true,
+      })
+    ).toBe('drawer');
+  });
+
+  it('gives a leftward room gesture to the message before the chat', () => {
+    expect(
+      classifyMobileGesture({
+        distanceX: -20,
+        distanceY: 2,
+        startPosition: -width,
+        width,
+        canOpenRoom: true,
+        hasMessage: true,
+        hasChat: true,
+      })
+    ).toBe('message');
+  });
+
+  it('uses the chat action away from a message', () => {
+    expect(
+      classifyMobileGesture({
+        distanceX: -20,
+        distanceY: 2,
+        startPosition: -width,
+        width,
+        canOpenRoom: true,
+        hasMessage: false,
+        hasChat: true,
+      })
+    ).toBe('chat');
+  });
+
+  it('opens the last room when swiping left from the list', () => {
+    expect(
+      classifyMobileGesture({
+        distanceX: -20,
+        distanceY: 2,
+        startPosition: 0,
+        width,
+        canOpenRoom: true,
+        hasMessage: false,
+        hasChat: false,
+      })
+    ).toBe('drawer');
+  });
+
+  it('leaves vertical scrolling native', () => {
+    expect(
+      classifyMobileGesture({
+        distanceX: 5,
+        distanceY: 20,
+        startPosition: -width,
+        width,
+        canOpenRoom: true,
+        hasMessage: true,
+        hasChat: true,
+      })
+    ).toBe('vertical');
+  });
+});
+
+describe('getDrawerSettlePosition', () => {
+  it('commits a sufficiently long back swipe', () => {
+    expect(
+      getDrawerSettlePosition({
+        startPosition: -width,
+        distanceX: 100,
+        velocityX: 0.1,
+        width,
+        cancelled: false,
+      })
+    ).toBe(0);
+  });
+
+  it('commits a fast back flick', () => {
+    expect(
+      getDrawerSettlePosition({
+        startPosition: -width,
+        distanceX: 20,
+        velocityX: 0.6,
+        width,
+        cancelled: false,
+      })
+    ).toBe(0);
+  });
+
+  it('returns to the room after an incomplete gesture', () => {
+    expect(
+      getDrawerSettlePosition({
+        startPosition: -width,
+        distanceX: 20,
+        velocityX: 0.1,
+        width,
+        cancelled: false,
+      })
+    ).toBe(-width);
+  });
+
+  it('returns to the starting panel when cancelled', () => {
+    expect(
+      getDrawerSettlePosition({
+        startPosition: -width,
+        distanceX: 200,
+        velocityX: 1,
+        width,
+        cancelled: true,
+      })
+    ).toBe(-width);
+  });
+});

--- a/src/app/components/page/mobileSwipeCoordinator.ts
+++ b/src/app/components/page/mobileSwipeCoordinator.ts
@@ -1,0 +1,60 @@
+export const GESTURE_LOCK_THRESHOLD = 8;
+export const DRAWER_COMMIT_FRACTION = 0.22;
+export const DRAWER_VELOCITY_THRESHOLD = 0.45;
+
+export type MobileGestureMode = 'pending' | 'vertical' | 'drawer' | 'message' | 'chat' | 'blocked';
+
+export function classifyMobileGesture({
+  distanceX,
+  distanceY,
+  startPosition,
+  width,
+  canOpenRoom,
+  hasMessage,
+  hasChat,
+}: {
+  distanceX: number;
+  distanceY: number;
+  startPosition: number;
+  width: number;
+  canOpenRoom: boolean;
+  hasMessage: boolean;
+  hasChat: boolean;
+}): MobileGestureMode {
+  if (Math.max(Math.abs(distanceX), Math.abs(distanceY)) < GESTURE_LOCK_THRESHOLD) {
+    return 'pending';
+  }
+  if (Math.abs(distanceY) >= Math.abs(distanceX)) return 'vertical';
+  if (
+    (distanceX > 0 && startPosition < 0) ||
+    (distanceX < 0 && startPosition > -width && canOpenRoom)
+  ) {
+    return 'drawer';
+  }
+  if (distanceX < 0 && hasMessage) return 'message';
+  if (distanceX < 0 && hasChat) return 'chat';
+  return 'blocked';
+}
+
+export function getDrawerSettlePosition({
+  startPosition,
+  distanceX,
+  velocityX,
+  width,
+  cancelled,
+}: {
+  startPosition: number;
+  distanceX: number;
+  velocityX: number;
+  width: number;
+  cancelled: boolean;
+}): number {
+  const startedInRoom = startPosition <= -width / 2;
+  if (cancelled) return startedInRoom ? -width : 0;
+
+  const passedDistance = Math.abs(distanceX) >= width * DRAWER_COMMIT_FRACTION;
+  const passedVelocity = Math.abs(velocityX) >= DRAWER_VELOCITY_THRESHOLD;
+  if (startedInRoom && distanceX > 0 && (passedDistance || passedVelocity)) return 0;
+  if (!startedInRoom && distanceX < 0 && (passedDistance || passedVelocity)) return -width;
+  return startedInRoom ? -width : 0;
+}

--- a/src/app/components/sidebar/SidebarItem.tsx
+++ b/src/app/components/sidebar/SidebarItem.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import type { Position } from 'folds';
 import { as, Avatar, Text, Tooltip, TooltipProvider, toRem } from 'folds';
 import type { ComponentProps, ReactNode, RefCallback } from 'react';
+import { mobileOrTablet } from '$utils/user-agent';
 import * as css from './Sidebar.css';
 
 export const SidebarItemBottom = as<'div', css.SidebarItemVariants>(
@@ -69,7 +70,7 @@ export function SidebarItemTooltip({
   children: (triggerRef: RefCallback<HTMLElement | SVGElement>) => ReactNode;
   position?: Position;
 }) {
-  if (!tooltip) {
+  if (!tooltip || mobileOrTablet()) {
     return children(() => undefined);
   }
 

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -79,6 +79,7 @@ import { nicknamesAtom } from '$state/nicknames';
 import { useRoomNavigate } from '$hooks/useRoomNavigate';
 import { warmupRoomDecryption } from '$utils/decryptScheduler';
 import { useMobileTapActivation } from '$hooks/useMobileTapActivation';
+import { useOpenMobileDrawerContent } from '$components/page/MobileNavDrawerContext';
 
 // Call Hooks & Plugins
 import { useCallMembers, useCallSession } from '$hooks/useCall';
@@ -336,6 +337,7 @@ export function RoomNavItem({
   const navigate = useNavigate();
   const screenSize = useScreenSizeContext();
   const isMobile = screenSize === ScreenSize.Mobile;
+  const openMobileDrawerContent = useOpenMobileDrawerContent();
 
   const callSession = useCallSession(room);
   const callMembers = useCallMembers(room, callSession);
@@ -414,13 +416,21 @@ export function RoomNavItem({
         navigateRoom(room.roomId);
       }
     } else {
-      // Render the room off the urgent path so the tap doesn't freeze the UI on mount.
-      startTransition(() => navigate(linkPath));
+      if (isMobile && openMobileDrawerContent) {
+        openMobileDrawerContent(linkPath);
+      } else {
+        // Render the room off the urgent path so the tap doesn't freeze the UI on mount.
+        startTransition(() => navigate(linkPath));
+      }
     }
   };
 
   const mobileTapActivation = useMobileTapActivation(isMobile && !room.isCallRoom(), () => {
-    navigate(linkPath);
+    if (openMobileDrawerContent) {
+      openMobileDrawerContent(linkPath);
+    } else {
+      navigate(linkPath);
+    }
   });
 
   const handleChatButtonClick = (evt: MouseEvent<HTMLButtonElement>) => {

--- a/src/app/features/room/AudioMessageRecorder.css.ts
+++ b/src/app/features/room/AudioMessageRecorder.css.ts
@@ -26,7 +26,6 @@ export const Container = style([
     maxWidth: toRem(280),
     minWidth: 0,
     overflow: 'hidden',
-    touchAction: 'pan-y',
     userSelect: 'none',
   },
 ]);

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -76,6 +76,7 @@ import {
   replaceWithElement,
   BlockType,
 } from '$components/editor';
+import { stripMarkdownEscapesForHiddenPreviews } from './message/hiddenLinkPreviews';
 import { plainToEditorInput } from '$components/editor/input';
 import type { GifData } from '$components/emoji-board';
 import { EmojiBoard, EmojiBoardTab } from '$components/emoji-board';
@@ -110,7 +111,13 @@ import { fulfilledPromiseSettledResult } from '$utils/common';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { matchesShortcut } from '../../keyboard/shortcuts';
-import { getMentionContent, isThreadRelationEvent, reactionOrEditEvent } from '$utils/room';
+import {
+  getEditedEvent,
+  getMentionContent,
+  isThreadRelationEvent,
+  reactionOrEditEvent,
+} from '$utils/room';
+import { htmlToMarkdown } from '$plugins/markdown';
 import { Command, SHRUG, TABLEFLIP, UNFLIP, useCommands } from '$hooks/useCommands';
 import { mobileOrTablet } from '$utils/user-agent';
 import { Reply, ThreadIndicator } from '$components/message';
@@ -163,6 +170,7 @@ import {
   menuIcon,
   Microphone,
   PaperPlaneTilt,
+  PencilSimple,
   getPhosphorIconSize,
   PlusCircle,
   Smiley,
@@ -301,10 +309,24 @@ interface RoomInputProps {
   room: Room;
   threadRootId?: string;
   onEditLastMessage?: () => void;
+  editId?: string;
+  onCancelEdit?: () => void;
 }
 
 export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
-  ({ editor, fileDropContainerRef, roomId, room, threadRootId, onEditLastMessage }, ref) => {
+  (
+    {
+      editor,
+      fileDropContainerRef,
+      roomId,
+      room,
+      threadRootId,
+      onEditLastMessage,
+      editId,
+      onCancelEdit,
+    },
+    ref
+  ) => {
     // When in thread mode, isolate drafts by thread root ID so thread replies
     // don't clobber the main room draft (and vice versa).
     const draftKey = threadRootId ?? roomId;
@@ -563,6 +585,138 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       [draftKey, editor, setMsgDraft]
     );
 
+    const editingEvent = editId ? room.findEventById(editId) : undefined;
+    const getEditingContent = useCallback(
+      (event: MatrixEvent): IContent => {
+        const eventId = event.getId();
+        const timeline = eventId ? room.getTimelineForEvent(eventId) : undefined;
+        const latestEdit =
+          eventId && timeline
+            ? getEditedEvent(eventId, event, timeline.getTimelineSet())
+            : undefined;
+        return latestEdit?.getContent()['m.new_content'] ?? event.getContent();
+      },
+      [room]
+    );
+
+    const prevEditingEventId = useRef<string>();
+    const preEditDraftRef = useRef<Editor['children']>();
+    useEffect(() => {
+      if (!mobileOrTablet()) {
+        prevEditingEventId.current = undefined;
+        preEditDraftRef.current = undefined;
+        return;
+      }
+
+      if (editingEvent) {
+        if (editingEvent.getId() !== prevEditingEventId.current) {
+          if (!prevEditingEventId.current) {
+            preEditDraftRef.current = structuredClone(editor.children);
+          }
+          prevEditingEventId.current = editingEvent.getId();
+
+          const content = getEditingContent(editingEvent);
+          let bodyText = (content.body as string | undefined) ?? '';
+          const customHtml = (content.formatted_body as string | undefined) ?? undefined;
+
+          const rawPmp = content['com.beeper.per_message_profile'];
+          const pmpDisplayname =
+            rawPmp !== null &&
+            typeof rawPmp === 'object' &&
+            'displayname' in rawPmp &&
+            typeof rawPmp.displayname === 'string' &&
+            rawPmp.displayname.length > 0
+              ? (rawPmp.displayname as string)
+              : undefined;
+
+          if (pmpDisplayname && typeof bodyText === 'string') {
+            const bodyPrefix = `${pmpDisplayname}: `;
+            if (bodyText.startsWith(bodyPrefix)) {
+              bodyText = bodyText.slice(bodyPrefix.length);
+            }
+          }
+          const editableHtml = pmpDisplayname
+            ? customHtml?.replace(/^<strong\s+data-mx-profile-fallback[^>]*>.*?<\/strong>/, '')
+            : customHtml;
+
+          const mentionOptions = {
+            room,
+            nicknames,
+            mxUserId: mx.getUserId() ?? undefined,
+          };
+
+          const initialValue = plainToEditorInput(
+            editableHtml
+              ? stripMarkdownEscapesForHiddenPreviews(htmlToMarkdown(editableHtml))
+              : typeof bodyText === 'string'
+                ? stripMarkdownEscapesForHiddenPreviews(bodyText)
+                : '',
+            mentionOptions
+          );
+
+          resetEditor(editor);
+          resetEditorHistory(editor);
+          Transforms.insertFragment(editor, initialValue);
+
+          requestAnimationFrame(() => {
+            try {
+              ReactEditor.focus(editor);
+              moveCursor(editor);
+            } catch {
+              // Ignore focus error
+            }
+          });
+        }
+      } else {
+        const previousDraft = preEditDraftRef.current;
+        if (prevEditingEventId.current && previousDraft) {
+          resetEditor(editor);
+          resetEditorHistory(editor);
+          Transforms.insertFragment(editor, previousDraft);
+        }
+        preEditDraftRef.current = undefined;
+        if (
+          prevEditingEventId.current &&
+          (!replyDraft?.eventId || replyDraft.eventId === threadRootId)
+        ) {
+          requestAnimationFrame(() => {
+            try {
+              const domNode = ReactEditor.toDOMNode(editor, editor);
+              domNode.blur();
+              (document.activeElement as HTMLElement)?.blur();
+            } catch {
+              // Ignore blur error
+            }
+          });
+        }
+        prevEditingEventId.current = undefined;
+      }
+    }, [
+      editingEvent,
+      editor,
+      getEditingContent,
+      mx,
+      nicknames,
+      room,
+      replyDraft?.eventId,
+      threadRootId,
+    ]);
+
+    useEffect(() => {
+      if (editId && replyDraft?.eventId && replyDraft.eventId !== threadRootId) {
+        if (threadRootId) {
+          setReplyDraft({
+            userId: mx.getUserId() ?? '',
+            eventId: threadRootId,
+            body: '',
+            relation: { rel_type: RelationType.Thread, event_id: threadRootId },
+          });
+        } else {
+          setReplyDraft(undefined);
+        }
+      }
+    }, [editId, threadRootId, setReplyDraft, mx, replyDraft?.eventId]);
+
     useEffect(() => {
       if (replyDraft !== undefined) {
         setSilentReply(replyDraft.userId === mx.getUserId() || !mentionInReplies);
@@ -571,10 +725,13 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     const prevReplyEventId = useRef(replyDraft?.eventId);
     useEffect(() => {
-      if (replyDraft?.eventId !== prevReplyEventId.current) {
-        prevReplyEventId.current = replyDraft?.eventId;
+      const prevId = prevReplyEventId.current;
+      const newId = replyDraft?.eventId;
 
-        if (replyDraft?.eventId) {
+      if (newId !== prevId) {
+        prevReplyEventId.current = newId;
+
+        if (newId && newId !== threadRootId) {
           requestAnimationFrame(() => {
             try {
               ReactEditor.focus(editor);
@@ -583,9 +740,19 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
               // Ignore focus errors
             }
           });
+        } else if (!newId && prevId && prevId !== threadRootId && !editId) {
+          requestAnimationFrame(() => {
+            try {
+              const domNode = ReactEditor.toDOMNode(editor, editor);
+              domNode.blur();
+              (document.activeElement as HTMLElement)?.blur();
+            } catch {
+              // Ignore blur errors
+            }
+          });
         }
       }
-    }, [replyDraft?.eventId, editor]);
+    }, [replyDraft?.eventId, threadRootId, editId, editor]);
 
     const handleFileMetadata = useCallback(
       (fileItem: TUploadItem, metadata: TUploadMetadata) => {
@@ -879,6 +1046,116 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     );
 
     const submit = useCallback(async () => {
+      if (editingEvent && mobileOrTablet()) {
+        let plainText = toPlainText(editor.children).trim();
+        if (!plainText) {
+          onCancelEdit?.();
+          return;
+        }
+
+        let customHtml = trimCustomHtml(
+          toMatrixCustomHTML(editor.children, {
+            forEmote: editingEvent.getContent().msgtype === MsgType.Emote,
+            room,
+          })
+        );
+        const oldContent = editingEvent.getContent();
+        const currentContent = getEditingContent(editingEvent);
+        const eventId = editingEvent.getId();
+        if (!eventId) return;
+
+        const msgtype = oldContent.msgtype ?? MsgType.Text;
+        const newContent: IContent = {
+          msgtype,
+          body: plainText,
+        };
+
+        const rawPmp =
+          currentContent['com.beeper.per_message_profile'] ??
+          oldContent['com.beeper.per_message_profile'];
+        const pmpDisplayname =
+          rawPmp !== null &&
+          typeof rawPmp === 'object' &&
+          'displayname' in rawPmp &&
+          typeof rawPmp.displayname === 'string' &&
+          rawPmp.displayname.length > 0
+            ? rawPmp.displayname
+            : undefined;
+
+        if (pmpDisplayname) {
+          const bodyPrefix = `${pmpDisplayname}: `;
+          if (!plainText.startsWith(bodyPrefix)) plainText = bodyPrefix + plainText;
+
+          const htmlPrefix = `<strong data-mx-profile-fallback>${sanitizeText(pmpDisplayname)}: </strong>`;
+          if (!customHtml.startsWith(htmlPrefix)) customHtml = htmlPrefix + customHtml;
+          newContent.body = plainText;
+          newContent['com.beeper.per_message_profile'] = rawPmp;
+        }
+
+        const mentionData = getMentions(mx, roomId, editor);
+        const previousMentions = currentContent['m.mentions'];
+        if (
+          previousMentions &&
+          typeof previousMentions === 'object' &&
+          'user_ids' in previousMentions &&
+          Array.isArray(previousMentions.user_ids)
+        ) {
+          previousMentions.user_ids.forEach((userId) => {
+            if (typeof userId === 'string') mentionData.users.add(userId);
+          });
+        }
+        const mMentions = getMentionContent(Array.from(mentionData.users), mentionData.room);
+        newContent['m.mentions'] = mMentions;
+
+        const content: IContent = {
+          ...oldContent,
+          'm.relates_to': {
+            event_id: eventId,
+            rel_type: RelationType.Replace,
+          },
+          body: `* ${plainText}`,
+          'm.mentions': mMentions,
+          'm.new_content': newContent,
+        };
+
+        if (pmpDisplayname || !customHtmlEqualsPlainText(customHtml, plainText)) {
+          newContent.format = 'org.matrix.custom.html';
+          newContent.formatted_body = customHtml;
+          content.format = 'org.matrix.custom.html';
+          content.formatted_body = `* ${customHtml}`;
+        } else {
+          delete content.format;
+          delete content.formatted_body;
+        }
+
+        if (oldContent.info !== undefined && oldContent.msgtype !== MsgType.Text) {
+          const filename = 'filename' in oldContent ? oldContent.filename : oldContent.body;
+          content.filename = filename;
+          newContent.filename = filename;
+          content.info = oldContent.info;
+          newContent.info = oldContent.info;
+          if (oldContent.file !== undefined) newContent.file = oldContent.file;
+          if (oldContent.url !== undefined) newContent.url = oldContent.url;
+
+          const spoilerKey = 'page.codeberg.everypizza.msc4193.spoiler';
+          if (oldContent[spoilerKey] !== undefined) {
+            content[spoilerKey] = oldContent[spoilerKey];
+            newContent[spoilerKey] = oldContent[spoilerKey];
+          }
+        }
+
+        const linkPreviews = getLinks(editor.children)?.map((matchedUrl) => ({
+          matched_url: matchedUrl,
+        }));
+        content['com.beeper.linkpreviews'] = linkPreviews ?? [];
+        newContent['com.beeper.linkpreviews'] = linkPreviews ?? [];
+
+        await mx.sendMessage(roomId, content as RoomMessageEventContent);
+        onCancelEdit?.();
+        sendTypingStatus(false);
+        return;
+      }
+
       if (selectedFiles.some((f) => f.encrypting)) return;
       uploadBoardHandlers.current?.handleSend();
       if (
@@ -1282,6 +1559,9 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       selectedFiles,
       enableMediaGalleries,
       sendIndividualAttachmentAsCaption,
+      editingEvent,
+      getEditingContent,
+      onCancelEdit,
     ]);
 
     const handleKeyDown: KeyboardEventHandler = useCallback(
@@ -1339,6 +1619,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         }
         if (isKeyHotkey('escape', evt)) {
           evt.preventDefault();
+          if (editingEvent && mobileOrTablet()) {
+            onCancelEdit?.();
+            resetEditor(editor);
+            resetEditorHistory(editor);
+            return;
+          }
           if (showAudioRecorder) {
             audioRecorderRef.current?.cancel();
             return;
@@ -1367,6 +1653,8 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         onEditLastMessage,
         setEmojiBoardTab,
         shortcutOverrides,
+        editingEvent,
+        onCancelEdit,
       ]
     );
 
@@ -1663,6 +1951,45 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                     <Text style={{ color: color.Critical.Main }} size="T300">
                       {sendError}
                     </Text>
+                  </Box>
+                </div>
+              )}
+              {editingEvent && mobileOrTablet() && (
+                <div>
+                  <Box
+                    alignItems="Center"
+                    gap="300"
+                    style={{
+                      padding: `${config.space.S200} ${config.space.S300} 0`,
+                    }}
+                  >
+                    <IconButton
+                      onClick={() => {
+                        onCancelEdit?.();
+                        resetEditor(editor);
+                        resetEditorHistory(editor);
+                      }}
+                      variant="SurfaceVariant"
+                      style={{ background: 'transparent' }}
+                      size="300"
+                      radii="300"
+                      aria-label="Cancel editing"
+                      title="Cancel editing"
+                    >
+                      {chipIcon(X)}
+                    </IconButton>
+                    <Box
+                      direction="Row"
+                      gap="200"
+                      alignItems="Center"
+                      grow="Yes"
+                      style={{ minWidth: 0 }}
+                    >
+                      {menuIcon(PencilSimple)}
+                      <Text size="T300" truncate>
+                        Editing message: {editingEvent.getContent().body as string}
+                      </Text>
+                    </Box>
                   </Box>
                 </div>
               )}

--- a/src/app/features/room/RoomTimeline.css.ts
+++ b/src/app/features/room/RoomTimeline.css.ts
@@ -35,7 +35,6 @@ export const TimelineFloat = recipe({
 export type TimelineFloatVariants = RecipeVariants<typeof TimelineFloat>;
 export const messageList = style({
   overflowY: 'scroll',
-  touchAction: 'pan-y',
   scrollbarGutter: 'stable',
   overflowAnchor: 'none',
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -303,6 +303,8 @@ export type RoomTimelineProps = {
   editor: Editor;
   onEditorReset?: () => void;
   onEditLastMessageRef?: React.MutableRefObject<(() => void) | undefined>;
+  editId?: string;
+  onEditId?: (editId?: string) => void;
 };
 
 export function RoomTimeline({
@@ -311,12 +313,16 @@ export function RoomTimeline({
   editor,
   onEditorReset,
   onEditLastMessageRef,
+  editId: propsEditId,
+  onEditId: propsOnEditId,
 }: Readonly<RoomTimelineProps>) {
   const mx = useMatrixClient();
   const alive = useAlive();
   const roomSyncLoading = useSlidingSyncRoomLoading(room.roomId);
 
-  const { editId, handleEdit } = useMessageEdit(editor, { onReset: onEditorReset, alive });
+  const internalEdit = useMessageEdit(editor, { onReset: onEditorReset, alive });
+  const editId = propsOnEditId ? propsEditId : internalEdit.editId;
+  const handleEdit = propsOnEditId ?? internalEdit.handleEdit;
   const { navigateRoom } = useRoomNavigate();
   const isInactivePanel = useIsInactivePanel();
 

--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -13,6 +13,7 @@ import { useEditor, resetEditor } from '$components/editor';
 import { Page } from '$components/page';
 import { useKeyDown } from '$hooks/useKeyDown';
 import { editableActiveElement } from '$utils/dom';
+import { mobileOrTablet } from '$utils/user-agent';
 import { settingsAtom } from '$state/settings';
 import { useSetting } from '$state/hooks/settings';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
@@ -30,6 +31,8 @@ import { callEmbedAtom } from '$state/callEmbed';
 import { useCallJoined } from '$hooks/useCallEmbed';
 import { CallView } from '$features/call/CallView';
 import { useRoom } from '$hooks/useRoom';
+import { useMessageEdit } from '$hooks/useMessageEdit';
+import { useAlive } from '$hooks/useAlive';
 import { RoomViewFollowing, RoomViewFollowingPlaceholder } from './RoomViewFollowing';
 import { RoomInput } from './RoomInput';
 import { RoomTombstone } from './RoomTombstone';
@@ -92,6 +95,12 @@ export function RoomView({ eventId }: { eventId?: string }) {
 
   const [editorResetKey, setEditorResetKey] = useState(0);
   const handleResetEditor = useCallback(() => setEditorResetKey((prev) => prev + 1), []);
+  const alive = useAlive();
+  const { editId, handleEdit } = useMessageEdit(editor, {
+    onReset: handleResetEditor,
+    alive,
+    focusOnCancel: !mobileOrTablet(),
+  });
 
   useDelayedEventsSupport();
   const delayedEventsSupported = useAtomValue(delayedEventsSupportedAtom);
@@ -156,6 +165,8 @@ export function RoomView({ eventId }: { eventId?: string }) {
             editor={editor}
             onEditorReset={handleResetEditor}
             onEditLastMessageRef={editLastMessageRef}
+            editId={editId}
+            onEditId={handleEdit}
           />
           <div style={{ position: 'relative', flexShrink: 0 }}>
             <RoomViewTyping room={room} />
@@ -184,6 +195,8 @@ export function RoomView({ eventId }: { eventId?: string }) {
                     fileDropContainerRef={roomViewRef}
                     ref={roomInputRef}
                     onEditLastMessage={() => editLastMessageRef.current?.()}
+                    editId={editId}
+                    onCancelEdit={() => handleEdit(undefined)}
                   />
                 )}
                 {!canMessage && (

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -53,7 +53,7 @@ import { PowerIcon } from '$components/power';
 import { Info, menuIcon, userFallbackIcon } from '$components/icons/phosphor';
 import { getPowerTagIconSrc } from '$hooks/useMemberPowerTag';
 import { useSableCosmetics } from '$hooks/useSableCosmetics';
-import { SwipeableMessageWrapper } from '$components/SwipeableMessageWrapper';
+import { SwipeableMessageWrapper, type SwipeActionMode } from '$components/SwipeableMessageWrapper';
 import { mobileOrTablet } from '$utils/user-agent';
 import { useUserProfile } from '$hooks/useUserProfile';
 import { useRoomMemberHydration } from '$hooks/useRoomMemberHydration';
@@ -264,6 +264,7 @@ type WrappedMessageProps = {
   messageLayout?: MessageLayout;
   handleSwipeReply?: () => void;
   handleSwipeEdit?: () => void;
+  handleSwipeActionChange?: (mode: SwipeActionMode) => void;
   handleContextMenu: MouseEventHandler<HTMLDivElement>;
   align?: 'left' | 'right';
 };
@@ -274,6 +275,7 @@ function WrappedMessage({
   messageLayout,
   handleSwipeReply,
   handleSwipeEdit,
+  handleSwipeActionChange,
   handleContextMenu,
   align,
 }: WrappedMessageProps) {
@@ -281,7 +283,11 @@ function WrappedMessage({
 
   if (messageLayout === MessageLayout.Compact)
     return (
-      <SwipeableMessageWrapper onReply={handleSwipeReply} onEdit={handleSwipeEdit}>
+      <SwipeableMessageWrapper
+        onReply={handleSwipeReply}
+        onEdit={handleSwipeEdit}
+        onActionModeChange={handleSwipeActionChange}
+      >
         <CompactLayout before={headerJSX} onContextMenu={handleContextMenu}>
           {msgContentJSX}
         </CompactLayout>
@@ -289,7 +295,11 @@ function WrappedMessage({
     );
   if (messageLayout === MessageLayout.Bubble)
     return (
-      <SwipeableMessageWrapper onReply={handleSwipeReply} onEdit={handleSwipeEdit}>
+      <SwipeableMessageWrapper
+        onReply={handleSwipeReply}
+        onEdit={handleSwipeEdit}
+        onActionModeChange={handleSwipeActionChange}
+      >
         <BubbleLayout
           before={avatarJSX}
           header={headerJSX}
@@ -301,7 +311,11 @@ function WrappedMessage({
       </SwipeableMessageWrapper>
     );
   return (
-    <SwipeableMessageWrapper onReply={handleSwipeReply} onEdit={handleSwipeEdit}>
+    <SwipeableMessageWrapper
+      onReply={handleSwipeReply}
+      onEdit={handleSwipeEdit}
+      onActionModeChange={handleSwipeActionChange}
+    >
       <ModernLayout before={avatarJSX} onContextMenu={handleContextMenu}>
         {headerJSX}
         {msgContentJSX}
@@ -944,12 +958,15 @@ function MessageInternal(
         : undefined,
     [mx, mEvent, onEditId, edit]
   );
+  const [swipeActionMode, setSwipeActionMode] = useState<SwipeActionMode>('none');
 
   return (
     <MessageBase
       className={classNames(css.MessageBase, className, {
         [css.MessageBaseBubbleCollapsed]: messageLayout === MessageLayout.Bubble && collapse,
         [css.MessageForceHover]: isPressing || isEmoji || !!menuAnchor,
+        [css.MessageSwipeReply]: swipeActionMode === 'reply',
+        [css.MessageSwipeEdit]: swipeActionMode === 'edit',
       })}
       tabIndex={0}
       space={messageSpacing}
@@ -1008,6 +1025,7 @@ function MessageInternal(
           messageLayout={messageLayout}
           handleSwipeReply={handleSwipeReply}
           handleSwipeEdit={handleSwipeEdit}
+          handleSwipeActionChange={setSwipeActionMode}
           handleContextMenu={handleContextMenu}
           align={useRightBubbles && senderId === mx.getUserId() ? 'right' : 'left'}
         />

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -39,7 +39,7 @@ import {
   Username,
   UsernameBold,
 } from '$components/message';
-import { getEditedEvent, getMemberAvatarMxc } from '$utils/room';
+import { canEditEvent, getEditedEvent, getMemberAvatarMxc } from '$utils/room';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
 import type { MessageSpacing } from '$state/settings';
 import { getSettings, MessageLayout, settingsAtom } from '$state/settings';
@@ -263,6 +263,7 @@ type WrappedMessageProps = {
   msgContentJSX: JSX.Element;
   messageLayout?: MessageLayout;
   handleSwipeReply?: () => void;
+  handleSwipeEdit?: () => void;
   handleContextMenu: MouseEventHandler<HTMLDivElement>;
   align?: 'left' | 'right';
 };
@@ -272,6 +273,7 @@ function WrappedMessage({
   msgContentJSX,
   messageLayout,
   handleSwipeReply,
+  handleSwipeEdit,
   handleContextMenu,
   align,
 }: WrappedMessageProps) {
@@ -279,7 +281,7 @@ function WrappedMessage({
 
   if (messageLayout === MessageLayout.Compact)
     return (
-      <SwipeableMessageWrapper onReply={handleSwipeReply}>
+      <SwipeableMessageWrapper onReply={handleSwipeReply} onEdit={handleSwipeEdit}>
         <CompactLayout before={headerJSX} onContextMenu={handleContextMenu}>
           {msgContentJSX}
         </CompactLayout>
@@ -287,7 +289,7 @@ function WrappedMessage({
     );
   if (messageLayout === MessageLayout.Bubble)
     return (
-      <SwipeableMessageWrapper onReply={handleSwipeReply}>
+      <SwipeableMessageWrapper onReply={handleSwipeReply} onEdit={handleSwipeEdit}>
         <BubbleLayout
           before={avatarJSX}
           header={headerJSX}
@@ -299,7 +301,7 @@ function WrappedMessage({
       </SwipeableMessageWrapper>
     );
   return (
-    <SwipeableMessageWrapper onReply={handleSwipeReply}>
+    <SwipeableMessageWrapper onReply={handleSwipeReply} onEdit={handleSwipeEdit}>
       <ModernLayout before={avatarJSX} onContextMenu={handleContextMenu}>
         {headerJSX}
         {msgContentJSX}
@@ -762,7 +764,7 @@ function MessageInternal(
         </Chip>
       )}
       {reply}
-      {edit && onEditId ? (
+      {edit && onEditId && !mobileOrTablet() ? (
         <MessageEditor
           style={{
             maxWidth: '100%',
@@ -914,6 +916,9 @@ function MessageInternal(
   };
 
   const handleSwipeReply = () => {
+    if (onEditId) {
+      onEditId(undefined);
+    }
     const currentId = mEvent.getId();
     const targetId = activeReplyId === currentId ? null : currentId;
     const mockEvent = {
@@ -924,6 +929,21 @@ function MessageInternal(
 
     onReplyClick(mockEvent);
   };
+
+  const handleSwipeEdit = useMemo(
+    () =>
+      canEditEvent(mx, mEvent) && onEditId
+        ? () => {
+            const currentId = mEvent.getId();
+            if (edit) {
+              onEditId(undefined);
+            } else {
+              onEditId(currentId);
+            }
+          }
+        : undefined,
+    [mx, mEvent, onEditId, edit]
+  );
 
   return (
     <MessageBase
@@ -987,6 +1007,7 @@ function MessageInternal(
           msgContentJSX={msgContentJSX}
           messageLayout={messageLayout}
           handleSwipeReply={handleSwipeReply}
+          handleSwipeEdit={handleSwipeEdit}
           handleContextMenu={handleContextMenu}
           align={useRightBubbles && senderId === mx.getUserId() ? 'right' : 'left'}
         />

--- a/src/app/features/room/message/styles.css.ts
+++ b/src/app/features/room/message/styles.css.ts
@@ -13,6 +13,14 @@ export const MessageForceHover = style({
   backgroundColor: `${color.Surface.ContainerHover} !important`,
 });
 
+export const MessageSwipeReply = style({
+  backgroundColor: color.Surface.ContainerHover,
+});
+
+export const MessageSwipeEdit = style({
+  backgroundColor: color.Primary.Container,
+});
+
 export const MessageOptionsBase = style([
   DefaultReset,
   {

--- a/src/app/features/room/message/styles.css.ts
+++ b/src/app/features/room/message/styles.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { DefaultReset, FocusOutline, color, config, toRem } from 'folds';
 
 export const MessageBase = style({
@@ -106,15 +106,6 @@ export const MessageMobileOptionsContainer = style({
   flexDirection: 'column',
   justifyContent: 'flex-end',
   overflow: 'visible',
-  animation: `${keyframes({
-    from: { transform: 'translateY(100%)' },
-    to: { transform: 'translateY(0)' },
-  })} 250ms cubic-bezier(0.32, 0.72, 0, 1)`,
-  '@media': {
-    '(prefers-reduced-motion: reduce)': {
-      animation: 'none',
-    },
-  },
 });
 
 export const MessageMobileDragHandle = style({

--- a/src/app/hooks/useMessageEdit.ts
+++ b/src/app/hooks/useMessageEdit.ts
@@ -6,6 +6,7 @@ import { isEmptyEditor, moveCursor } from '$components/editor';
 export interface UseMessageEditOptions {
   onReset?: () => void;
   alive?: () => boolean;
+  focusOnCancel?: boolean;
 }
 
 /**
@@ -27,6 +28,8 @@ export function useMessageEdit(
   aliveRef.current = options?.alive;
   const onResetRef = useRef(options?.onReset);
   onResetRef.current = options?.onReset;
+  const focusOnCancelRef = useRef(options?.focusOnCancel ?? true);
+  focusOnCancelRef.current = options?.focusOnCancel ?? true;
 
   const handleEdit = useCallback(
     (targetEditId?: string) => {
@@ -35,6 +38,7 @@ export function useMessageEdit(
         return;
       }
       setEditId(undefined);
+      if (!focusOnCancelRef.current) return;
       requestAnimationFrame(() => {
         if (aliveRef.current && !aliveRef.current()) return;
         if (onResetRef.current && isEmptyEditor(editor)) onResetRef.current();

--- a/src/app/styles/overrides/TouchDevices.css
+++ b/src/app/styles/overrides/TouchDevices.css
@@ -12,7 +12,6 @@
   html body [class*='Chip']:active,
   html body [class*='MenuItem']:active {
     transform: none !important;
-    background-color: inherit !important;
   }
 
   html body button:hover,
@@ -21,7 +20,22 @@
   html body [class*='Chip']:hover,
   html body [class*='MenuItem']:hover {
     transform: none !important;
-    background-color: inherit !important;
+  }
+
+  html body input,
+  html body button,
+  html body label,
+  html body [role='button'],
+  html body [role='switch'],
+  html body [class*='Switch'] {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  html body label[htmlFor],
+  html body [role='switch'],
+  html body [class*='Switch'] {
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   html body [data-message-id][data-message-item]:hover {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Disables overscroll on swipe to reply
Adds editing if you keep swiping on reply
Opens keyboard automatically when editing
Hides the space tooltip when clicking on a space, it appears and lingers even when entering room, it shouldnt.

Larger change:
delete the motion crap for the swipe animation between room list and timeline, because it's fundamentally limited to 60 fps (or worse) on mobile and older devices, particularly on iOS webkit, and its annoying the hell out of me that its so stuttery compared to the rest of the ui

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
