### PR TITLE
fix(media): sniff decrypted image content type and harden encrypted media cache

### DIFF
--- a/.changeset/fix-encrypted-media-content-type.md
+++ b/.changeset/fix-encrypted-media-content-type.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix encrypted images and GIFs failing to render by sniffing the decrypted content type in the native media handler and skipping thumbnail requests for animated image formats.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3062,6 +3062,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4200d433cbd5178df7797c9c2e75b348b728e39631cf14520d1e2fc424201f4"
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,6 +5359,7 @@ dependencies = [
  "enigo",
  "futures-util",
  "gtk",
+ "infer 0.22.0",
  "jni 0.21.1",
  "libloading 0.8.9",
  "log",
@@ -6841,7 +6848,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "http 1.4.2",
- "infer",
+ "infer 0.19.0",
  "log",
  "minisign-verify",
  "osakit",
@@ -7000,7 +7007,7 @@ dependencies = [
  "glob",
  "html5ever 0.29.1",
  "http 1.4.2",
- "infer",
+ "infer 0.19.0",
  "json-patch",
  "kuchikiki",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ ts-rs = "12.0.0"
 sha2 = "0.10"
 aes = "0.8"
 ctr = "0.9"
+infer = { version = "0.22", default-features = false }
 percent-encoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 async-stream = "0.3"

--- a/src-tauri/src/network/media_protocol.rs
+++ b/src-tauri/src/network/media_protocol.rs
@@ -345,6 +345,9 @@ async fn ensure_cached_with_limits(
     if let Some(content_type) =
         read_content_type(body_path.clone(), content_type_path.clone()).await
     {
+        let content_type =
+            sniff_and_fix_content_type(body_path.clone(), content_type_path.clone(), content_type)
+                .await;
         return Ok((content_type, None, body_path));
     }
 
@@ -352,6 +355,12 @@ async fn ensure_cached_with_limits(
     if let Some(content_type) =
         read_content_type(temp_body_path.clone(), temp_content_type_path.clone()).await
     {
+        let content_type = sniff_and_fix_content_type(
+            temp_body_path.clone(),
+            temp_content_type_path.clone(),
+            content_type,
+        )
+        .await;
         return Ok((content_type, None, temp_body_path));
     }
 
@@ -362,6 +371,9 @@ async fn ensure_cached_with_limits(
     if let Some(content_type) =
         read_content_type(body_path.clone(), content_type_path.clone()).await
     {
+        let content_type =
+            sniff_and_fix_content_type(body_path.clone(), content_type_path.clone(), content_type)
+                .await;
         return Ok((content_type, None, body_path));
     }
 
@@ -369,6 +381,12 @@ async fn ensure_cached_with_limits(
     if let Some(content_type) =
         read_content_type(temp_body_path.clone(), temp_content_type_path.clone()).await
     {
+        let content_type = sniff_and_fix_content_type(
+            temp_body_path.clone(),
+            temp_content_type_path.clone(),
+            content_type,
+        )
+        .await;
         return Ok((content_type, None, temp_body_path));
     }
 
@@ -423,7 +441,7 @@ async fn fetch_and_cache(
     max_persistent_cache_bytes: u64,
     max_temp_cache_bytes: u64,
 ) -> Result<(String, Option<Arc<Vec<u8>>>, PathBuf), StatusCode> {
-    let _permit = state
+    let permit = state
         .semaphore
         .acquire()
         .await
@@ -462,6 +480,7 @@ async fn fetch_and_cache(
             Ok((decrypted_body, decrypted_ct)) => (decrypted_body, decrypted_ct),
             Err(status) => return Err(status),
         };
+    drop(permit);
 
     if body.len() as u64 > max_temp_cache_bytes {
         return Ok((content_type, Some(Arc::new(body)), temp_body_path));
@@ -499,6 +518,22 @@ async fn fetch_and_cache(
     }
 }
 
+/// Sniff the image MIME type from magic bytes of decrypted content.
+/// Restricted to an image allowlist and never returns SVG (which can carry scripts).
+/// Used as a fallback when the registered content type is missing or octet-stream.
+fn sniff_image_content_type(bytes: &[u8]) -> Option<&'static str> {
+    const ALLOWED: [&str; 5] = [
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/avif",
+    ];
+    infer::get(bytes)
+        .filter(|kind| ALLOWED.contains(&kind.mime_type()))
+        .map(|kind| kind.mime_type())
+}
+
 /// Decrypt the body if encryption params exist for this URL.
 fn decrypt_if_encrypted(
     state: &MediaSessionState,
@@ -524,7 +559,6 @@ fn decrypt_if_encrypted(
     hasher.update(&ciphertext);
     let actual_sha256 = hasher.finalize().to_vec();
     if actual_sha256 != params.expected_sha256 {
-        let _ = state.encryption.write().map(|mut guard| guard.remove(url));
         return Err(StatusCode::BAD_GATEWAY);
     }
 
@@ -545,7 +579,15 @@ fn decrypt_if_encrypted(
     // Remove encryption params — decrypted content is now cached on disk
     let _ = state.encryption.write().map(|mut guard| guard.remove(url));
 
-    Ok((plaintext, params.content_type))
+    let final_content_type =
+        if params.content_type.is_empty() || params.content_type == "application/octet-stream" {
+            sniff_image_content_type(&plaintext)
+                .map(|s| s.to_owned())
+                .unwrap_or(params.content_type)
+        } else {
+            params.content_type
+        };
+    Ok((plaintext, final_content_type))
 }
 
 async fn write_cache(
@@ -585,6 +627,34 @@ async fn read_content_type(body_path: PathBuf, content_type_path: PathBuf) -> Op
     })
     .await
     .unwrap_or(None)
+}
+
+/// On a cache hit where the stored content type is octet-stream, re-sniff the
+/// body file's magic bytes and rewrite the .ct file if a real image type is found.
+async fn sniff_and_fix_content_type(
+    body_path: PathBuf,
+    content_type_path: PathBuf,
+    stored_ct: String,
+) -> String {
+    if stored_ct != "application/octet-stream" {
+        return stored_ct;
+    }
+    let ct_for_closure = stored_ct.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut file = match fs::File::open(&body_path) {
+            Ok(f) => f,
+            Err(_) => return ct_for_closure,
+        };
+        let mut buf = [0u8; 64];
+        let n = file.read(&mut buf).unwrap_or(0);
+        if let Some(sniffed) = sniff_image_content_type(&buf[..n]) {
+            let _ = fs::write(&content_type_path, sniffed);
+            return sniffed.to_owned();
+        }
+        ct_for_closure
+    })
+    .await
+    .unwrap_or(stored_ct)
 }
 
 async fn read_full(body_path: PathBuf) -> Result<Vec<u8>, StatusCode> {
@@ -706,15 +776,17 @@ fn evict_directory_if_needed(dir: &Path, max_bytes: u64) {
 // Shared 200/206 headers. Media is content-addressed and the URL is session-scoped, so
 // it is safe to let the webview cache it as immutable and to advertise Range support.
 fn media_response_builder(status: StatusCode, content_type: &str) -> ResponseBuilder {
+    let cache_control = if content_type == "application/octet-stream" {
+        "no-store"
+    } else {
+        "private, max-age=31536000, immutable"
+    };
     Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, content_type)
         .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .header(header::ACCEPT_RANGES, "bytes")
-        .header(
-            header::CACHE_CONTROL,
-            "private, max-age=31536000, immutable",
-        )
+        .header(header::CACHE_CONTROL, cache_control)
         .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
         .header(
             header::CONTENT_SECURITY_POLICY,
@@ -955,5 +1027,47 @@ mod tests {
         let input = "https://matrix.example.org/_matrix/client/v1/media/download/matrix.org/abc123";
         let result = super::normalize_encryption_key(input);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sniff_detects_png() {
+        let png_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        assert_eq!(
+            super::sniff_image_content_type(&png_header),
+            Some("image/png")
+        );
+    }
+
+    #[test]
+    fn sniff_rejects_unknown() {
+        assert_eq!(super::sniff_image_content_type(&[0x00, 0x01, 0x02]), None);
+    }
+
+    #[test]
+    fn sniff_does_not_detect_svg() {
+        let svg = b"<svg xmlns='http://www.w3.org/2000/svg'>";
+        assert_eq!(super::sniff_image_content_type(svg), None);
+    }
+
+    #[test]
+    fn octet_stream_response_is_not_cached_immutable() {
+        let response = super::media_response_builder(StatusCode::OK, "application/octet-stream")
+            .body(Vec::<u8>::new())
+            .unwrap();
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
+    }
+
+    #[test]
+    fn image_response_is_cached_immutable() {
+        let response = super::media_response_builder(StatusCode::OK, "image/png")
+            .body(Vec::<u8>::new())
+            .unwrap();
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "private, max-age=31536000, immutable"
+        );
     }
 }

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -140,6 +140,7 @@ export const ImageContent = as<'div', ImageContentProps>(
 
     const [load, setLoad] = useState(false);
     const [error, setError] = useState(false);
+    const [useFullDownload, setUseFullDownload] = useState(false);
     const [viewer, setViewer] = useState(false);
     const [viewerFullSrc, setViewerFullSrc] = useState<string | null>(null);
     const [blurred, setBlurred] = useState(markedAsSpoiler ?? false);
@@ -154,11 +155,11 @@ export const ImageContent = as<'div', ImageContentProps>(
 
     const rawMediaUrl = useMemo(() => {
       if (url.startsWith('http')) return url;
-      if (encInfo) {
+      if (encInfo || isGif || useFullDownload) {
         return mxcUrlToHttp(mx, url, useAuthentication) ?? undefined;
       }
       return mxcUrlToHttp(mx, url, useAuthentication, 800, 600, 'scale') ?? undefined;
-    }, [mx, url, useAuthentication, encInfo]);
+    }, [mx, url, useAuthentication, encInfo, isGif, useFullDownload]);
 
     const resolvedMediaUrl = useRenderableMediaUrl(encInfo ? undefined : rawMediaUrl);
 
@@ -213,8 +214,12 @@ export const ImageContent = as<'div', ImageContentProps>(
 
     const handleRetry = () => {
       setError(false);
-      loadSrc();
+      setUseFullDownload(true);
     };
+
+    useEffect(() => {
+      if (useFullDownload) loadSrc();
+    }, [useFullDownload, loadSrc]);
 
     useEffect(() => {
       if (autoPlay) loadSrc();

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -96,8 +96,9 @@ export const UrlPreviewCard = as<
         const cached = clientCache.get(url);
         if (cached !== undefined) return cached;
         const previewResult = mx?.getUrlPreview(url, ts);
+        if (!previewResult) return Promise.resolve(null);
         clientCache.set(url, previewResult);
-        previewResult.finally(() => clientCache.delete(url));
+        previewResult.finally(() => clientCache.delete(url)).catch(() => {});
         return previewResult;
       }
       return Promise.resolve(bundle);

--- a/src/app/utils/fetch.ts
+++ b/src/app/utils/fetch.ts
@@ -173,5 +173,12 @@ export const fetch: AppFetch = async (input, init) => {
   }
 
   const tauriFetch = await getTauriFetch();
-  return tauriFetch(request, init);
+  try {
+    return await tauriFetch(request, init);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      return new Response(null, { status: 502, statusText: 'Bad Gateway' });
+    }
+    throw e;
+  }
 };


### PR DESCRIPTION


<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

- Sniff decrypted image MIME type from magic bytes when sender omits mimetype
- Keep encryption params on SHA-256 mismatch so transient network errors are retryable
- Use no-store Cache-Control for octet-stream responses to prevent cached broken render
- Self-heal existing cache entries with sniffed content type
- Release concurrency semaphore earlier after decrypt
- Skip thumbnail requests for animated images (GIF/APNG/AVIF/WebP)
- Fall back to full download when thumbnail fails on retry
- Swallow unhandled rejection on URL preview fetch (SABLE-167)
- Catch Tauri HTTP plugin SyntaxError on HTML error pages (SABLE-16F)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
