### PR TITLE
fix(call): bypass PNA for split-horizon DNS homeservers

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -199,7 +199,17 @@ pub fn show_or_create_main_window(app: &AppHandle<crate::BrowserEngine>) -> taur
                     settings.set_enable_media_stream(true);
                     settings.set_enable_mediasource(true);
                     settings.set_enable_media(true);
+                    // Enable inspector via SABLE_DEVTOOLS env var.
+                    if std::env::var("SABLE_DEVTOOLS").is_ok() {
+                        settings.set_enable_developer_extras(true);
+                    }
                 }
+
+                // Bypass CORS for HTTP(S) targets so Element Call's iframe
+                // fetches to split-horizon DNS homeservers aren't PNA-blocked.
+                // Same-origin policy and CSP remain enforced.
+                gtk_webview.set_cors_allowlist(&["http://*/*", "https://*/*"]);
+
                 gtk_webview.connect_permission_request(move |_wv, request| {
                     // Ask the user (once per permission type, then remember the choice)
                     // for the permissions Sable actually uses; deny anything else.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,19 +15,27 @@ fn main() {
                 "sable-media".into(),
             ],
             deep_link_schemes: vec!["moe.sable.app".into(), "sable".into()],
-            command_line_args: vec![
-                ("--disable-gpu-sandbox".into(), None),
-                ("--disable-font-subpixel-positioning".into(), None),
-                ("--enable-font-antialiasing".into(), None),
-                ("autoplay-policy".into(), Some("no-user-gesture-required".into())),
-                ("enable-features".into(), Some("SharedArrayBuffer".into())),
-                ("--disable-background-timer-throttling".into(), None),
-                ("--disable-renderer-backgrounding".into(), None),
-                ("--disable-backgrounding-occluded-windows".into(), None),
-                ("disable-features".into(), Some(
-                    "SpareRendererForSitePerProcess,IntensiveWakeUpThrottling,CalculateNativeWinOcclusion,AutofillActorMode,GlicActorUi,LensOverlay".into()
-                )),
-            ],
+            command_line_args: {
+                let mut args = vec![
+                    ("--disable-gpu-sandbox".into(), None),
+                    ("--disable-font-subpixel-positioning".into(), None),
+                    ("--enable-font-antialiasing".into(), None),
+                    ("autoplay-policy".into(), Some("no-user-gesture-required".into())),
+                    ("enable-features".into(), Some("SharedArrayBuffer".into())),
+                    ("--disable-background-timer-throttling".into(), None),
+                    ("--disable-renderer-backgrounding".into(), None),
+                    ("--disable-backgrounding-occluded-windows".into(), None),
+                    ("disable-features".into(), Some(
+                        "SpareRendererForSitePerProcess,IntensiveWakeUpThrottling,CalculateNativeWinOcclusion,AutofillActorMode,GlicActorUi,LensOverlay,LocalNetworkAccessChecks,LocalNetworkAccessChecksWebSocket,LocalNetworkAccessChecksWebRTC".into()
+                    )),
+                ];
+                // Remote debugging via SABLE_DEVTOOLS=port env var.
+                // Open chrome://inspect in Chrome to connect.
+                if let Ok(port) = std::env::var("SABLE_DEVTOOLS") {
+                    args.push(("--remote-debugging-port".into(), Some(port)));
+                }
+                args
+            },
             ..Default::default()
         });
 

--- a/src/app/components/tauri/DesktopShortcuts.tsx
+++ b/src/app/components/tauri/DesktopShortcuts.tsx
@@ -36,6 +36,8 @@ export function DesktopShortcuts() {
         if (key === ',') {
           event.preventDefault();
           openSettings();
+        } else if (key === 't') {
+          event.preventDefault();
         } else if (key === 'w') {
           event.preventDefault();
           getCurrentWindow()

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -170,7 +170,8 @@ export class CallEmbed {
     iframe.title = 'Call Embed';
     iframe.sandbox =
       'allow-forms allow-scripts allow-same-origin allow-popups allow-modals allow-downloads';
-    iframe.allow = 'microphone; camera; display-capture; autoplay; clipboard-write;';
+    iframe.allow =
+      'microphone; camera; display-capture; autoplay; clipboard-write; local-network-access;';
     iframe.src = url;
 
     iframe.style.width = '100%';


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

- wry: set_cors_allowlist for HTTP(S) targets so Element Call iframe fetches  to LAN-IP homeservers aren't PNA-blocked
- CEF: disable LocalNetworkAccessChecks feature flags
- Android/iOS: local-network-access added to iframe allow attribute

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
