### PR TITLE
fix(sentry): scrub homeserver host from Sentry data

### DIFF
--- a/docs/SENTRY_PRIVACY.md
+++ b/docs/SENTRY_PRIVACY.md
@@ -297,6 +297,24 @@ Matrix IDs are replaced with placeholder tokens before sending:
 **Code:** `src/instrument.ts` — `beforeSend` callback (applied to `event.message`
 and all `event.exception.values`)
 
+### Homeserver Host
+
+Any external http(s) origin (the Matrix homeserver, OIDC issuers, media
+redirectors) is replaced with `[HOMESERVER]` before sending. Only the scheme
+is kept (`https://[HOMESERVER]`). The path, query, and hash are preserved so
+routing and grouping still work.
+
+This applies to HTTP span descriptions and `span.data` URL fields, breadcrumb
+`data.url` / `data.from` / `data.to`, structured log attributes and message
+strings, error messages, exception values, and request URLs.
+
+The app's own origin and local dev hosts (`localhost`, `127.0.0.1`,
+`tauri.localhost`) are preserved. They identify the app shell, not a
+homeserver.
+
+**Code:** `src/app/utils/sentryScrubbers.ts` — `scrubExternalHosts`, applied
+inside `scrubMatrixIds` and `scrubMatrixUrl`
+
 ---
 
 ## User Controls

--- a/src/app/utils/sentryScrubbers.test.ts
+++ b/src/app/utils/sentryScrubbers.test.ts
@@ -5,7 +5,47 @@ import {
   scrubDataObject,
   sanitizeSentryPayload,
   scrubMatrixUrl,
+  scrubExternalHosts,
 } from './sentryScrubbers';
+
+// ─── scrubExternalHosts ───────────────────────────────────────────────────────
+
+describe('scrubExternalHosts', () => {
+  it('replaces an external https origin with [HOMESERVER]', () => {
+    expect(scrubExternalHosts('https://matrix.example.org/_matrix/client/v3/sync')).toBe(
+      'https://[HOMESERVER]/_matrix/client/v3/sync'
+    );
+  });
+
+  it('replaces an external http origin and drops the port', () => {
+    expect(scrubExternalHosts('http://hs.corp.local:8448/_matrix/')).toBe(
+      'http://[HOMESERVER]/_matrix/'
+    );
+  });
+
+  it('preserves localhost origins', () => {
+    const dev = 'http://localhost:1420/index.html#/home';
+    expect(scrubExternalHosts(dev)).toBe(dev);
+  });
+
+  it('preserves the tauri.localhost app origin', () => {
+    const app = 'https://tauri.localhost/index.html';
+    expect(scrubExternalHosts(app)).toBe(app);
+  });
+
+  it('leaves tauri:// scheme URLs untouched (non-http)', () => {
+    expect(scrubExternalHosts('tauri://localhost/index.html')).toBe('tauri://localhost/index.html');
+  });
+
+  it('leaves plain paths with no origin untouched', () => {
+    expect(scrubExternalHosts('/_matrix/client/v3/sync')).toBe('/_matrix/client/v3/sync');
+  });
+
+  it('scrubs multiple URLs in one string', () => {
+    const result = scrubExternalHosts('fetch https://hs.one/sync then https://hs.two/media');
+    expect(result).toBe('fetch https://[HOMESERVER]/sync then https://[HOMESERVER]/media');
+  });
+});
 
 // ─── scrubMatrixIds ───────────────────────────────────────────────────────────
 
@@ -186,6 +226,12 @@ describe('scrubMatrixUrl – Matrix C-S API paths', () => {
       '/_matrix/media/v3/download/[SERVER]/[MEDIA_ID]'
     );
   });
+
+  it('scrubs both the homeserver host and the room-id path of a full URL', () => {
+    expect(
+      scrubMatrixUrl('https://matrix.example.org/_matrix/client/v3/rooms/!abc:example.com/messages')
+    ).toBe('https://[HOMESERVER]/_matrix/client/v3/rooms/![ROOM_ID]/messages');
+  });
 });
 
 describe('scrubMatrixUrl – app route path segments', () => {
@@ -240,15 +286,15 @@ describe('scrubMatrixUrl – preview_url', () => {
 });
 
 describe('scrubMatrixUrl – auth callback credentials', () => {
-  it('redacts OAuth code and state query params', () => {
+  it('redacts OAuth code and state query params (and scrubs the external host)', () => {
     expect(scrubMatrixUrl('https://app.example/login/hs?code=abc123&state=xyz789')).toBe(
-      'https://app.example/login/hs?code=[REDACTED]&state=[REDACTED]'
+      'https://[HOMESERVER]/login/hs?code=[REDACTED]&state=[REDACTED]'
     );
   });
 
-  it('redacts params inside a hash-router fragment', () => {
+  it('redacts params inside a hash-router fragment (and scrubs the external host)', () => {
     expect(scrubMatrixUrl('https://app.example/#/login/hs?code=abc123')).toBe(
-      'https://app.example/#/login/hs?code=[REDACTED]'
+      'https://[HOMESERVER]/#/login/hs?code=[REDACTED]'
     );
   });
 

--- a/src/app/utils/sentryScrubbers.ts
+++ b/src/app/utils/sentryScrubbers.ts
@@ -5,14 +5,36 @@
  * of the Sentry initialisation side-effects.
  */
 
+/** Hosts that identify the app shell, not a user's homeserver. Never redacted. */
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', 'tauri.localhost']);
+
+// Also preserve the app's own origin so Sentry can show which page an error occurred on.
+if (typeof window !== 'undefined' && window.location) {
+  try {
+    const appHost = new URL(window.location.origin).hostname.toLowerCase();
+    if (appHost) LOCAL_HOSTS.add(appHost);
+  } catch {
+    /* invalid origin, ignore */
+  }
+}
+
+/** Replace the origin of any external http(s) URL with [HOMESERVER], keeping path/query/hash. */
+export function scrubExternalHosts(value: string): string {
+  return value.replace(/\bhttps?:\/\/[^/?#\s]+/gi, (match) => {
+    const schemeEnd = match.indexOf('://') + 3;
+    const hostname = (match.slice(schemeEnd).split(':')[0] ?? '').toLowerCase();
+    if (LOCAL_HOSTS.has(hostname)) return match;
+    return `${match.slice(0, schemeEnd)}[HOMESERVER]`;
+  });
+}
+
 /**
- * Scrub Matrix entity IDs and credential tokens from a plain string value.
- * Handles the sigil-prefixed forms: !roomId:server, @userId:server, $eventId,
- * #alias:server, and common credential token query-string / JSON patterns.
- * Used for structured log attribute values and breadcrumb data fields.
+ * Scrub Matrix entity IDs, credential tokens, and external http(s) hosts from a
+ * plain string value. Used for structured log attribute values and breadcrumb
+ * data fields.
  */
 export function scrubMatrixIds(value: string): string {
-  return value
+  return scrubExternalHosts(value)
     .replace(
       /(access_token|password|token|refresh_token|session_id|sync_token|next_batch)([=:\s]+)([^\s&]+)/gi,
       '$1$2[REDACTED]'
@@ -83,7 +105,7 @@ export function sanitizeSentryPayload(data: unknown): unknown {
  */
 export function scrubMatrixUrl(url: string): string {
   return (
-    url
+    scrubExternalHosts(url)
       // ── Matrix Client-Server API paths ──────────────────────────────────────────────
       // /rooms/!roomId:server/...
       .replace(/\/rooms\/![^/?#\s]*/g, '/rooms/![ROOM_ID]')

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -579,7 +579,6 @@ export class SlidingSyncManager {
 
   public attach(): void {
     debugLog.info('sync', 'Attaching sliding sync listeners', {
-      baseUrl: this.baseUrl,
       roomTimelineLimit: this.roomTimelineLimit,
       lists: this.listKeys,
     });
@@ -590,7 +589,6 @@ export class SlidingSyncManager {
       op: 'matrix.sync',
       attributes: {
         'sync.transport': 'sliding',
-        'sync.base_url': this.baseUrl,
       },
     });
 


### PR DESCRIPTION


<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Redact external http(s) origins (homeserver, OIDC issuers, media redirectors) to [HOMESERVER] before sending to Sentry. Preserve the app's own origin and local dev hosts. Also drop the sync.base_url span attribute and the baseUrl debug-log field that leaked the homeserver explicitly.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
