### PR TITLE
fix(ios): declare AudioServicesCreateSystemSoundID URL param as const pointer

### DIFF
--- a/src-tauri/src/ios.rs
+++ b/src-tauri/src/ios.rs
@@ -94,7 +94,7 @@ use objc2_foundation::{NSString, NSURL};
 
 extern "C" {
     fn AudioServicesCreateSystemSoundID(
-        in_file_url: *mut objc2::runtime::AnyObject,
+        in_file_url: *const objc2::runtime::AnyObject,
         out_sound_id: *mut u32,
     ) -> i32;
     fn AudioServicesPlaySystemSound(sound_id: u32);


### PR DESCRIPTION
… 

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
