### PR TITLE
Fix spoilers breaking when using a proxy tag/shorthand

### DIFF
--- a/.changeset/fix_spoilers_breaking_when_using_a_proxy_tagshorthand.md
+++ b/.changeset/fix_spoilers_breaking_when_using_a_proxy_tagshorthand.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix spoilers breaking when using a proxy tag/shorthand

--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -170,15 +170,20 @@ const SPOILEREDLINKDIRECTREGEX = new RegExp(`\\|\\|(${LINK_URL})\\|\\|`, 'g');
 export const toPlainText = (
   node: Descendant | Descendant[],
   stripNickname = false,
+  stripSpoilers = true,
   nickNameReplacement?: Map<RegExp, string>
 ): string => {
   if (Array.isArray(node))
-    return node.map((n) => toPlainText(n, stripNickname, nickNameReplacement)).join('');
+    return node
+      .map((n) => toPlainText(n, stripNickname, stripSpoilers, nickNameReplacement))
+      .join('');
   if (Text.isText(node)) {
     let { text } = node;
 
-    text = text.replaceAll(SPOILERINPUTREGEX, '[Spoiler]');
-    text = text.replaceAll(SPOILEREDLINKINPUTREGEX, '$1');
+    if (stripSpoilers) {
+      text = text.replaceAll(SPOILERINPUTREGEX, '[Spoiler]');
+      text = text.replaceAll(SPOILEREDLINKINPUTREGEX, '$1');
+    }
 
     if (stripNickname && nickNameReplacement) {
       for (const [key, replacement] of nickNameReplacement) {
@@ -189,7 +194,7 @@ export const toPlainText = (
   }
 
   const children = node.children
-    .map((n) => toPlainText(n, stripNickname, nickNameReplacement))
+    .map((n) => toPlainText(n, stripNickname, stripSpoilers, nickNameReplacement))
     .join('');
   return elementToPlainText(node, children);
 };

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -1253,7 +1253,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         serializedChildren = transform.apply(serializedChildren, outgoingTransformContext);
       });
 
-      let plainText = toPlainText(serializedChildren, true, nicknameReplacement).trim();
+      let plainText = toPlainText(serializedChildren, true, true, nicknameReplacement).trim();
 
       /**
        * the html we will send
@@ -1327,7 +1327,16 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         proxiedPerMessageProfile =
           await pluralkitProxyMessageHandler.getPmpBasedOnMessage(plainText);
         if (proxiedPerMessageProfile) {
-          const stripped = pluralkitProxyMessageHandler.stripProxyFromMessage(plainText);
+          // normal plainText has spoilers stripped, but this breaks spoilers with a proxy tag.
+          // here we get a new 'unsanitized' plainText without spoiler stripping
+          let unsanitizedPlainText = toPlainText(
+            serializedChildren,
+            true,
+            false,
+            nicknameReplacement
+          ).trim();
+
+          const stripped = pluralkitProxyMessageHandler.stripProxyFromMessage(unsanitizedPlainText);
           if (stripped !== undefined) {
             // Re-run the normal outgoing pipeline on the stripped content so the message
             // goes through the same transforms/parsers as any other message.
@@ -1338,7 +1347,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
               serializedChildren = transform.apply(serializedChildren, outgoingTransformContext);
             });
 
-            plainText = toPlainText(serializedChildren, true, nicknameReplacement).trim();
+            plainText = toPlainText(serializedChildren, true, true, nicknameReplacement).trim();
             customHtml = trimCustomHtml(
               toMatrixCustomHTML(serializedChildren, {
                 stripNickname: true,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fix spoilers sending as [Spoiler] when using proxy tags

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
