### PR TITLE
chore(tauri): make the devtools plugin opt-in behind a cargo feature

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,7 +69,7 @@ tauri-plugin-clipboard-manager = "2.3.2"
 # wry/tauri-runtime-wry/webkit2gtk.
 # Pinned to =2.0.0 because 2.1.0+ introduced an unconditional call to
 # tauri::webview_version() which is gated behind tauri's `wry` feature.
-tauri-plugin-devtools = { version = "=2.0.0", default-features = false }
+tauri-plugin-devtools = { version = "=2.0.0", default-features = false, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 enigo = "0.5.0"
@@ -135,6 +135,9 @@ wry = ["tauri/wry", "dep:webkit2gtk"]
 updater = ["dep:tauri-plugin-updater"]
 # CEF (Chromium) runtime. Build with --no-default-features --features cef.
 cef = ["dep:tauri-runtime-cef", "dep:cef"]
+# CrabNebula devtools. Off by default: its aggregator retains every metadata record for the
+# session, which costs hundreds of MB per minute once tauri-plugin-log feeds it.
+devtools = ["dep:tauri-plugin-devtools"]
 [patch.crates-io]
 tauri-typegen = { git = "https://github.com/SableClient/tauri-typegen", branch = "fix/nondeterministic-generation-cache" }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -415,13 +415,22 @@ pub fn run() {
 
             #[cfg(debug_assertions)]
             {
-                let (log_plugin, _level, logger) = tauri_plugin_log::Builder::default()
-                    .level(log::LevelFilter::Info)
-                    .split(app.handle())?;
-                let mut devtools = tauri_plugin_devtools::Builder::default();
-                devtools.attach_logger(logger);
-                app.handle().plugin(devtools.init())?;
-                app.handle().plugin(log_plugin)?;
+                #[cfg(feature = "devtools")]
+                {
+                    let (log_plugin, _level, logger) = tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .split(app.handle())?;
+                    let mut devtools = tauri_plugin_devtools::Builder::default();
+                    devtools.attach_logger(logger);
+                    app.handle().plugin(devtools.init())?;
+                    app.handle().plugin(log_plugin)?;
+                }
+                #[cfg(not(feature = "devtools"))]
+                app.handle().plugin(
+                    tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .build(),
+                )?;
             }
 
             Ok(())


### PR DESCRIPTION
### Description

`tauri-plugin-devtools` retains every metadata record for the session (`devtools-core`'s `Aggregator::all_metadata` is never trimmed, by design, so late-connecting clients get the full history). With `tauri-plugin-log` feeding it, a heapprofd capture showed 310 MB retained in 45 seconds; on Android the app reached ~1 GB within a minute and was OOM-killed repeatedly.

It is now behind a `devtools` cargo feature, off by default. Build with `--features devtools` to get the inspector back. `tauri-plugin-log` still initialises either way, so logcat output is unchanged.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->