### PR TITLE
fix(media): request our own video and audio with CORS so Firefox does not block it

### DIFF
--- a/.changeset/firefox-media-orb.md
+++ b/.changeset/firefox-media-orb.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix video and audio failing to play on Firefox with "no video with supported format and MIME type found".

--- a/src/app/components/message/content/AudioContent.tsx
+++ b/src/app/components/message/content/AudioContent.tsx
@@ -275,6 +275,12 @@ export function AudioContent({
         controls={false}
         autoPlay
         ref={audioRef}
+        // See VideoContent: CORS opts this Range-streamed media out of Firefox's ORB.
+        crossOrigin={
+          srcState.status === AsyncStatus.Success && !srcState.data.startsWith('blob:')
+            ? 'anonymous'
+            : undefined
+        }
         onVolumeChange={(e) => {
           localStorage.setItem(MEDIA_VOLUME_KEY, String((e.target as HTMLAudioElement).volume));
         }}

--- a/src/app/components/message/content/VideoContent.tsx
+++ b/src/app/components/message/content/VideoContent.tsx
@@ -45,6 +45,7 @@ type RenderVideoProps = {
   onError: () => void;
   autoPlay: boolean;
   controls: boolean;
+  crossOrigin?: 'anonymous';
 };
 type VideoContentProps = {
   body: string;
@@ -115,6 +116,11 @@ export const VideoContent = as<'div', VideoContentProps>(
         setError(false);
       }
     }, [srcState.status]);
+
+    const streamsAuthenticatedMedia =
+      srcState.status === AsyncStatus.Success &&
+      !url.startsWith('http') &&
+      !srcState.data.startsWith('blob:');
 
     const handleLoad = () => {
       setLoad(true);
@@ -195,6 +201,10 @@ export const VideoContent = as<'div', VideoContentProps>(
               onError: handleError,
               autoPlay: false,
               controls: true,
+              // Firefox blocks media Range responses it cannot sniff as audio/video (mozilla bug
+              // 1880289); requesting with CORS opts out. External URLs are left alone since we
+              // cannot assume they send Access-Control-Allow-Origin.
+              crossOrigin: streamsAuthenticatedMedia ? 'anonymous' : undefined,
             })}
           </Box>
         )}


### PR DESCRIPTION
### Description

Firefox blocks media Range responses whose URL it has not already sniffed as audio/video (mozilla bug 1880289), which homeservers serving `application/octet-stream` trip. The element then reports "no video with supported format and MIME type found" and the request shows as `NS_BINDING_ABORTED`. Requesting with CORS opts out of ORB.

Only applied to our own media, since external `og:video` URLs from link previews go through the same component and cannot be assumed to send `Access-Control-Allow-Origin`.

Verified on firefox

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->