### PR TITLE
fix(markdown): keep task list markers as text instead of checkbox input

### DIFF
--- a/.changeset/fix-markdown-task-list-rendering.md
+++ b/.changeset/fix-markdown-task-list-rendering.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix Markdown checklists rendering as raw `<input>` HTML

--- a/src/app/plugins/markdown/markdownToHtml.test.ts
+++ b/src/app/plugins/markdown/markdownToHtml.test.ts
@@ -217,6 +217,18 @@ describe('markdownToHtml', () => {
     expect(result).toContain('<div');
   });
 
+  it('keeps task list markers as literal text instead of checkbox inputs', () => {
+    const result = markdownToHtml('- [ ] one\n- [x] two');
+    expect(result).not.toContain('input');
+    expect(result).toBe('<ul>\n<li>[ ] one</li>\n<li>[x] two</li>\n</ul>\n');
+  });
+
+  it('round-trips task list markers back to markdown', () => {
+    expect(htmlToMarkdown(markdownToHtml('- [ ] one\n- [x] two')).trim()).toBe(
+      '- [ ] one\n- [x] two'
+    );
+  });
+
   it('does not parse k. as a list', () => {
     const result = markdownToHtml('k. Hello world');
     expect(result).not.toContain('<li>');

--- a/src/app/plugins/markdown/markdownToHtml.ts
+++ b/src/app/plugins/markdown/markdownToHtml.ts
@@ -23,6 +23,12 @@ import { escapeNonAllowlistedHtmlTags, MARKDOWN_ALLOWED_HTML_TAGS } from './allo
 // Configure marked with Matrix extensions
 const processor = marked.use({
   breaks: true,
+  renderer: {
+    // `input` is not a Matrix-permitted tag, keep the literal `[ ]`/`[x]` marker.
+    checkbox({ raw }) {
+      return raw;
+    },
+  },
   extensions: [
     matrixMfmColorExtension,
     matrixUnderlineExtension,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
it's not in the docs but well

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
