### PR TITLE
Remove unused exports and deduplicate editor and menu logic

### DIFF
--- a/.changeset/adopt-getMouseEventCords.md
+++ b/.changeset/adopt-getMouseEventCords.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Adopt the existing getMouseEventCords helper at the two remaining hand-rolled coordinate literals.

--- a/.changeset/extract-buildReplacementContent.md
+++ b/.changeset/extract-buildReplacementContent.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Extract buildReplacementContent so message edits assemble the replacement the same way in the composer and the editor.

--- a/.changeset/migrate-menus-onto-useMenuAnchor.md
+++ b/.changeset/migrate-menus-onto-useMenuAnchor.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Migrate the sidebar, space tab, space folder, and image viewer menus onto useMenuAnchor so they open on long-press as well as right-click.

--- a/.changeset/remove-more-unused-exports.md
+++ b/.changeset/remove-more-unused-exports.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Remove the remaining unused exports flagged by fallow across the codebase.

--- a/.changeset/remove-unused-exports.md
+++ b/.changeset/remove-unused-exports.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Remove unused exports flagged by fallow across notification transport, command barrel, and plugin barrels.

--- a/src/app/components/ActionUIA.tsx
+++ b/src/app/components/ActionUIA.tsx
@@ -7,9 +7,9 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { UIAFlowOverlay } from './UIAFlowOverlay';
 import { OAuthStage, PasswordStage, SSOStage } from './uia-stages';
 
-export const SUPPORTED_IN_APP_UIA_STAGES = [AuthType.Password, AuthType.Sso, AuthType.OAuth];
+const SUPPORTED_IN_APP_UIA_STAGES = [AuthType.Password, AuthType.Sso, AuthType.OAuth];
 
-export const pickUIAFlow = (uiaFlows: UIAFlow[]): UIAFlow | undefined => {
+const pickUIAFlow = (uiaFlows: UIAFlow[]): UIAFlow | undefined => {
   const passwordFlow = getUIAFlowForStages(uiaFlows, [AuthType.Password]);
   if (passwordFlow) return passwordFlow;
   const oauthFlow = getUIAFlowForStages(uiaFlows, [AuthType.OAuth]);

--- a/src/app/components/ClientConfigLoader.tsx
+++ b/src/app/components/ClientConfigLoader.tsx
@@ -14,7 +14,7 @@ export const FALLBACK_CLIENT_CONFIG: ClientConfig = {
   hashRouter: { enabled: false, basename: '/' },
 };
 
-export const getClientConfig = async (): Promise<ClientConfig> => {
+const getClientConfig = async (): Promise<ClientConfig> => {
   const preloaded = takePreloadedConfig();
   if (preloaded !== undefined) {
     const data = await preloaded.catch(() => undefined);

--- a/src/app/components/ManualVerification.tsx
+++ b/src/app/components/ManualVerification.tsx
@@ -12,7 +12,7 @@ import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { SettingTile } from './setting-tile';
 import { SecretStorageRecoveryKey, SecretStorageRecoveryPassphrase } from './SecretStorage';
 
-export enum ManualVerificationMethod {
+enum ManualVerificationMethod {
   RecoveryPassphrase = 'passphrase',
   RecoveryKey = 'key',
 }
@@ -20,7 +20,7 @@ type ManualVerificationMethodSwitcherProps = {
   value: ManualVerificationMethod;
   onChange: (value: ManualVerificationMethod) => void;
 };
-export function ManualVerificationMethodSwitcher({
+function ManualVerificationMethodSwitcher({
   value,
   onChange,
 }: ManualVerificationMethodSwitcherProps) {

--- a/src/app/components/RoomSummaryLoader.tsx
+++ b/src/app/components/RoomSummaryLoader.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from 'react';
-import { useCallback, useState } from 'react';
-import type { MatrixClient, Room, IHierarchyRoom } from '$types/matrix-sdk';
+import { useCallback } from 'react';
+import type { MatrixClient, Room } from '$types/matrix-sdk';
 import { useQuery } from '@tanstack/react-query';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import type { LocalRoomSummary } from '$hooks/useLocalRoomSummary';
 import { useLocalRoomSummary } from '$hooks/useLocalRoomSummary';
-import type { AsyncState } from '$hooks/useAsyncCallback';
-import { AsyncStatus } from '$hooks/useAsyncCallback';
 
 export type IRoomSummary = Awaited<ReturnType<MatrixClient['getRoomSummary']>>;
 
@@ -38,55 +36,4 @@ export function LocalRoomSummaryLoader({
   const summary = useLocalRoomSummary(room);
 
   return children(summary);
-}
-
-export function HierarchyRoomSummaryLoader({
-  roomId,
-  children,
-}: {
-  roomId: string;
-  children: (state: AsyncState<IHierarchyRoom, Error>) => ReactNode;
-}) {
-  const mx = useMatrixClient();
-
-  const fetchSummary = useCallback(() => mx.getRoomHierarchy(roomId, 1, 1), [mx, roomId]);
-  const [errorMemo, setError] = useState<Error>();
-
-  const { data, error } = useQuery({
-    queryKey: [roomId, `hierarchy`],
-    queryFn: fetchSummary,
-    retryOnMount: false,
-    refetchOnWindowFocus: false,
-    retry: (failureCount, err) => {
-      setError(err);
-      if (failureCount > 3) return false;
-      return true;
-    },
-  });
-
-  let state: AsyncState<IHierarchyRoom, Error> = {
-    status: AsyncStatus.Loading,
-  };
-  if (error) {
-    state = {
-      status: AsyncStatus.Error,
-      error,
-    };
-  }
-  if (errorMemo) {
-    state = {
-      status: AsyncStatus.Error,
-      error: errorMemo,
-    };
-  }
-
-  const summary = data?.rooms[0] ?? undefined;
-  if (summary) {
-    state = {
-      status: AsyncStatus.Success,
-      data: summary,
-    };
-  }
-
-  return children(state);
 }

--- a/src/app/components/SyncConnectionStatus.tsx
+++ b/src/app/components/SyncConnectionStatus.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { Box, config, Text } from 'folds';
 import { AnimatePresence, motion, useReducedMotion, type Variants } from 'framer-motion';
-import { SyncState } from '$types/matrix-sdk';
 import { type TitlebarStatusView } from '$state/titlebarStatus';
 import { ContainerColor } from '$styles/ContainerColor.css';
 
@@ -14,30 +13,6 @@ type SyncConnectionStatusProps = {
   onClick?: () => void;
   icon?: React.ReactNode;
 };
-
-export function getSyncConnectionStatusView(
-  current: SyncState | null,
-  previous: SyncState | null | undefined
-): TitlebarStatusView | null {
-  if (
-    (current === SyncState.Prepared ||
-      current === SyncState.Syncing ||
-      current === SyncState.Catchup) &&
-    previous !== SyncState.Syncing
-  ) {
-    return { text: 'Connecting...', variant: 'Success' };
-  }
-
-  if (current === SyncState.Reconnecting) {
-    return { text: 'Connection Lost! Reconnecting...', variant: 'Warning' };
-  }
-
-  if (current === SyncState.Error) {
-    return { text: 'Connection Lost!', variant: 'Critical' };
-  }
-
-  return null;
-}
 
 export function SyncConnectionStatusBanner({ status }: SyncConnectionStatusProps) {
   const shouldReduceMotion = useReducedMotion();

--- a/src/app/components/app-shell/index.ts
+++ b/src/app/components/app-shell/index.ts
@@ -1,2 +1,1 @@
 export { AppShell } from './AppShell';
-export { SystemBarShell } from './SystemBarShell';

--- a/src/app/components/code-highlight/index.ts
+++ b/src/app/components/code-highlight/index.ts
@@ -1,3 +1,2 @@
 export type { HighlightCodeDeps, HighlightCodeInput, HighlightResult } from '$plugins/arborium';
-export { highlightCode, useArboriumThemeStatus } from '$plugins/arborium';
 export { CodeHighlightRenderer } from './CodeHighlightRenderer';

--- a/src/app/components/create-room/utils.ts
+++ b/src/app/components/create-room/utils.ts
@@ -13,7 +13,7 @@ import { getMxIdServer } from '$utils/mxIdHelper';
 import { CreateRoomAccess } from './types';
 import * as prefix from '$unstable/prefixes';
 
-export const createRoomCreationContent = (
+const createRoomCreationContent = (
   type: RoomType | undefined,
   allowFederation: boolean,
   additionalCreators: string[] | undefined
@@ -32,7 +32,7 @@ export const createRoomCreationContent = (
   return content;
 };
 
-export const createRoomJoinRulesState = (
+const createRoomJoinRulesState = (
   access: CreateRoomAccess,
   parent: Room | undefined,
   knock: boolean
@@ -66,7 +66,7 @@ export const createRoomJoinRulesState = (
   };
 };
 
-export const createRoomParentState = (parent: Room) => ({
+const createRoomParentState = (parent: Room) => ({
   type: EventType.SpaceParent,
   state_key: parent.roomId,
   content: {
@@ -87,13 +87,13 @@ export const createRoomEncryptionState = () => ({
   },
 });
 
-export const createRoomCallState = () => ({
+const createRoomCallState = () => ({
   type: prefix.MATRIX_UNSTABLE_ROOM_TYPE_CALL_PROPERTY_NAME,
   state_key: '',
   content: {},
 });
 
-export const createVoiceRoomPowerLevelsOverride = () => ({
+const createVoiceRoomPowerLevelsOverride = () => ({
   events: {
     [EventType.GroupCallMemberPrefix]: 0,
   },

--- a/src/app/components/editor/Editor.css.ts
+++ b/src/app/components/editor/Editor.css.ts
@@ -119,7 +119,3 @@ export const EditorToolbarBase = style({
 export const EditorToolbar = style({
   padding: config.space.S100,
 });
-
-export const MarkdownBtnBox = style({
-  paddingRight: config.space.S100,
-});

--- a/src/app/components/editor/MarkdownToolbar.tsx
+++ b/src/app/components/editor/MarkdownToolbar.tsx
@@ -248,7 +248,7 @@ function MarkdownHeadingButton() {
   );
 }
 
-export function MarkdownToolbar() {
+function MarkdownToolbar() {
   const [shortcutOverrides] = useSetting(settingsAtom, 'shortcutOverrides');
 
   return (

--- a/src/app/components/editor/autocomplete/AutocompleteMenu.css.tsx
+++ b/src/app/components/editor/autocomplete/AutocompleteMenu.css.tsx
@@ -39,7 +39,7 @@ export const AutocompleteNotice = style([
   { color: color.SurfaceVariant.OnContainer },
 ]);
 
-export const AutocompleteMenuItems = style({});
+const AutocompleteMenuItems = style({});
 
 globalStyle(`${AutocompleteMenuItems} button[data-selected='true']`, {
   backgroundColor: color.SurfaceVariant.ContainerHover,

--- a/src/app/components/editor/autocomplete/autocompleteQuery.ts
+++ b/src/app/components/editor/autocomplete/autocompleteQuery.ts
@@ -24,7 +24,7 @@ export type AutocompleteQuery<TPrefix extends string> = {
   text: string;
 };
 
-export const getAutocompletePrefix = <TPrefix extends string>(
+const getAutocompletePrefix = <TPrefix extends string>(
   editor: Editor,
   queryRange: BaseRange,
   validPrefixes: readonly TPrefix[]
@@ -33,11 +33,8 @@ export const getAutocompletePrefix = <TPrefix extends string>(
   return validPrefixes.find((p) => world.startsWith(p));
 };
 
-export const getAutocompleteQueryText = (
-  editor: Editor,
-  queryRange: BaseRange,
-  prefix: string
-): string => Editor.string(editor, queryRange).slice(prefix.length);
+const getAutocompleteQueryText = (editor: Editor, queryRange: BaseRange, prefix: string): string =>
+  Editor.string(editor, queryRange).slice(prefix.length);
 
 export const getAutocompleteQuery = <TPrefix extends string = AutocompletePrefix>(
   editor: Editor,

--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -203,7 +203,7 @@ export const toPlainText = (
  * Convert slate internal representation to a raw plain text string without any replacements.
  * This is used for link extraction to ensure we have the full context for markdown blocks.
  */
-export const toRawText = (node: Descendant | Descendant[]): string => {
+const toRawText = (node: Descendant | Descendant[]): string => {
   if (Array.isArray(node)) return node.map(toRawText).join('');
   if (Text.isText(node)) return node.text;
 

--- a/src/app/components/editor/utils.ts
+++ b/src/app/components/editor/utils.ts
@@ -43,7 +43,7 @@ export const mentionNameForUserAutocomplete = (
 };
 
 /** Same #-prefix rule as {@link RoomMentionAutocomplete}. */
-export const formatRoomMentionDisplayName = (name: string): string => {
+const formatRoomMentionDisplayName = (name: string): string => {
   if (name === '@room') return '@room';
   return name.startsWith('#') ? name : `#${name}`;
 };
@@ -172,7 +172,7 @@ interface PointUntilCharOptions {
   match: (char: string) => boolean;
   reverse?: boolean;
 }
-export const getPointUntilChar = (
+const getPointUntilChar = (
   editor: Editor,
   cursorPoint: BasePoint,
   options: PointUntilCharOptions

--- a/src/app/components/emoji-board/components/Group.tsx
+++ b/src/app/components/emoji-board/components/Group.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import classNames from 'classnames';
 import * as css from './styles.css';
 
-export const getDOMGroupId = (id: string): string => `EmojiBoardGroup-${id}`;
+const getDOMGroupId = (id: string): string => `EmojiBoardGroup-${id}`;
 
 export const EmojiGroup = as<
   'div',

--- a/src/app/components/emoji-board/components/NoGifResults.tsx
+++ b/src/app/components/emoji-board/components/NoGifResults.tsx
@@ -1,7 +1,7 @@
 import { SmileySadIcon } from '@phosphor-icons/react';
 import { Box, toRem, config, Text } from 'folds';
 
-export function GifSearching() {
+function GifSearching() {
   return (
     <Box
       style={{ padding: `${toRem(60)} ${config.space.S500}` }}
@@ -15,7 +15,7 @@ export function GifSearching() {
   );
 }
 
-export function GifSearchError({ error }: { error: string }) {
+function GifSearchError({ error }: { error: string }) {
   return (
     <Box
       style={{ padding: `${toRem(60)} ${config.space.S500}` }}
@@ -29,7 +29,7 @@ export function GifSearchError({ error }: { error: string }) {
   );
 }
 
-export function NoGifResults() {
+function NoGifResults() {
   return (
     <Box
       style={{ padding: `${toRem(60)} ${config.space.S500}` }}

--- a/src/app/components/emoji-board/components/styles.css.ts
+++ b/src/app/components/emoji-board/components/styles.css.ts
@@ -188,21 +188,6 @@ export const StickerImg = style([
   },
 ]);
 
-export const GifContainer = style({
-  columnCount: 3,
-  columnGap: toRem(8),
-  padding: toRem(16),
-
-  '@media': {
-    '(max-width: 768px)': {
-      columnCount: 2,
-    },
-    '(max-width: 480px)': {
-      columnCount: 1,
-    },
-  },
-});
-
 export const GifItem = style([
   DefaultReset,
   FocusOutline,
@@ -221,13 +206,6 @@ export const GifItem = style([
     },
   },
 ]);
-
-export const GifImg = style({
-  width: '100%',
-  height: '100%',
-  objectFit: 'cover',
-  borderRadius: config.radii.R400,
-});
 
 export const TextLink = style({
   color: 'var(--tc-link)',

--- a/src/app/components/event-history/EventHistory.css.ts
+++ b/src/app/components/event-history/EventHistory.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { DefaultReset, color, config, toRem } from 'folds';
+import { DefaultReset, color, config } from 'folds';
 
 export const EventHistory = style([
   DefaultReset,
@@ -32,21 +32,6 @@ export const EventItem = style({
     },
   },
 });
-export const MessageOptionsBase = style([
-  DefaultReset,
-  {
-    position: 'absolute',
-    top: toRem(-30),
-    right: 0,
-    zIndex: 1,
-  },
-]);
-export const MessageOptionsBar = style([
-  DefaultReset,
-  {
-    padding: config.space.S100,
-  },
-]);
 export const MenuOptions = style({
   position: 'absolute',
   right: '0',

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -1,19 +1,7 @@
 import type { MouseEventHandler } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
-import {
-  Box,
-  Chip,
-  Header,
-  IconButton,
-  Menu,
-  MenuItem,
-  type RectCords,
-  Text,
-  as,
-  config,
-  toRem,
-} from 'folds';
+import { Box, Chip, Header, IconButton, Menu, MenuItem, Text, as, config, toRem } from 'folds';
 import {
   ArrowLeft,
   ArrowsClockwise,
@@ -26,7 +14,7 @@ import {
   sizedIcon,
 } from '$components/icons/phosphor';
 import { useImageGestures } from '$hooks/useImageGestures';
-import { useMobileLongPress } from '$hooks/useMobileLongPress';
+import { useMenuAnchor } from '$hooks/useMenuAnchor';
 import { useDismissOnBack } from '$utils/androidBack';
 import { useSetting } from '$state/hooks/settings';
 import { isPixelatedRendering, settingsAtom } from '$state/settings';
@@ -105,45 +93,21 @@ export const ImageViewer = as<'div', ImageViewerProps>(
       await saveFileToDevice(fileContent, getDownloadFilename(filename, alt, 'image'));
     };
 
-    const [menuAnchor, setMenuAnchor] = useState<RectCords>();
-
-    const {
-      onTouchStart,
-      onTouchEnd,
-      onTouchMove,
-      onTouchCancel,
-      firedRef: longPressFiredRef,
-    } = useMobileLongPress(() => {
-      setMenuAnchor({ x: 0, y: 0, width: 0, height: 0 });
-    });
+    const menu = useMenuAnchor<HTMLDivElement>();
 
     const handleContextMenu: MouseEventHandler<HTMLDivElement> = (evt) => {
       if (evt.altKey || !window.getSelection()?.isCollapsed) return;
       const tag = (evt.target as HTMLElement).tagName;
       if (typeof tag === 'string' && tag.toLowerCase() === 'a') return;
-
-      if (longPressFiredRef.current) {
-        evt.preventDefault();
-        longPressFiredRef.current = false;
-        return;
-      }
-
-      evt.preventDefault();
-      setMenuAnchor({
-        x: evt.clientX,
-        y: evt.clientY,
-        width: 0,
-        height: 0,
-      });
+      menu.triggerProps.onContextMenu(evt);
     };
 
     return (
       <>
         <ResponsiveMenu
-          anchor={menuAnchor}
-          requestClose={() => setMenuAnchor(undefined)}
-          align={menuAnchor?.width === 0 ? 'Start' : 'End'}
-          offset={menuAnchor?.width === 0 ? 0 : undefined}
+          anchor={menu.anchor}
+          requestClose={menu.close}
+          align="Start"
           menu={
             <Menu variant="Surface" style={{ maxWidth: toRem(160), width: '100vw' }}>
               <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
@@ -153,7 +117,7 @@ export const ImageViewer = as<'div', ImageViewerProps>(
                   size="300"
                   after={menuIcon(CopyIcon)}
                   onClick={async () => {
-                    setMenuAnchor(undefined);
+                    menu.close();
                     const fileContent = await downloadMedia(src);
                     await copyImageToClipboard(fileContent);
                   }}
@@ -168,7 +132,7 @@ export const ImageViewer = as<'div', ImageViewerProps>(
                   size="300"
                   after={menuIcon(DownloadIcon)}
                   onClick={() => {
-                    setMenuAnchor(undefined);
+                    menu.close();
                     handleDownload();
                   }}
                 >
@@ -349,10 +313,10 @@ export const ImageViewer = as<'div', ImageViewerProps>(
             style={{ overflow: 'hidden', touchAction: 'none', cursor }}
             onPointerDown={onPointerDown}
             onContextMenu={handleContextMenu}
-            onTouchStart={onTouchStart}
-            onTouchEnd={onTouchEnd}
-            onTouchMove={onTouchMove}
-            onTouchCancel={onTouchCancel}
+            onTouchStart={menu.triggerProps.onTouchStart}
+            onTouchEnd={menu.triggerProps.onTouchEnd}
+            onTouchMove={menu.triggerProps.onTouchMove}
+            onTouchCancel={menu.triggerProps.onTouchCancel}
           >
             <img
               className={classNames(css.ImageViewerImg, isPixelated && css.ImageViewerImgPixelated)}

--- a/src/app/components/message-preview/MessagePreview.tsx
+++ b/src/app/components/message-preview/MessagePreview.tsx
@@ -242,7 +242,7 @@ function renderTombstone(_ctx: MessagePreviewRendererContext, event: MatrixEvent
   return <Text>{event.getContent().body ?? 'This room has been replaced.'}</Text>;
 }
 
-export function useMessagePreviewRenderer(options: MessagePreviewRendererOptions) {
+function useMessagePreviewRenderer(options: MessagePreviewRendererOptions) {
   const mx = useMatrixClient();
   const context = useMemo<MessagePreviewRendererContext>(() => ({ ...options, mx }), [mx, options]);
   const handlers = useMemo(

--- a/src/app/components/message/MGallery.css.ts
+++ b/src/app/components/message/MGallery.css.ts
@@ -1,10 +1,5 @@
 import { recipe } from '@vanilla-extract/recipes';
-import { style } from '@vanilla-extract/css';
 import { DefaultReset, config, toRem } from 'folds';
-
-export const GalleryHolder = style({
-  marginTop: config.space.S200,
-});
 
 export const GalleryImageGrid = recipe({
   base: [

--- a/src/app/components/message/MsgTypeRenderers.css.tsx
+++ b/src/app/components/message/MsgTypeRenderers.css.tsx
@@ -1,10 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { color, config, toRem } from 'folds';
 
-export const ReplyBend = style({
-  flexShrink: 0,
-});
-
 export const LocationRendererBody = style({
   maxWidth: toRem(500),
   backgroundColor: color.SurfaceVariant.Container,

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -108,7 +108,7 @@ export function UnsupportedContent({ body }: BrokenContentProps) {
   );
 }
 
-export function BrokenContent({ body }: BrokenContentProps) {
+function BrokenContent({ body }: BrokenContentProps) {
   return (
     <Text>
       <MessageBrokenContent body={body} />

--- a/src/app/components/message/Reply.css.ts
+++ b/src/app/components/message/Reply.css.ts
@@ -1,10 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { config, toRem } from 'folds';
 
-export const ReplyBend = style({
-  flexShrink: 0,
-});
-
 export const ThreadIndicator = style({
   opacity: config.opacity.P300,
 

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -174,7 +174,7 @@ type ReplyLayoutProps = {
   mentioned: boolean;
   replyIcon?: JSX.Element;
 };
-export const ReplyLayout = as<'div', ReplyLayoutProps>(
+const ReplyLayout = as<'div', ReplyLayoutProps>(
   ({ username, userColor, icon, className, mentioned, children, replyIcon, ...props }, ref) => (
     <Box
       className={classNames(css.Reply, className)}

--- a/src/app/components/message/content/UploadedSableCssContent.tsx
+++ b/src/app/components/message/content/UploadedSableCssContent.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../../theme/themeLibrary';
 import { decryptFile, downloadEncryptedMedia, downloadMedia, mxcUrlToHttp } from '$utils/matrix';
 
-export const MAX_SABLE_CSS_ATTACHMENT_BYTES = 1024 * 1024;
+const MAX_SABLE_CSS_ATTACHMENT_BYTES = 1024 * 1024;
 
 type UploadedSableCssContentProps = {
   body: string;

--- a/src/app/components/message/layout/layout.css.ts
+++ b/src/app/components/message/layout/layout.css.ts
@@ -3,7 +3,7 @@ import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 import { DefaultReset, color, config, toRem } from 'folds';
 
-export const StickySection = style({
+const StickySection = style({
   position: 'sticky',
   top: config.space.S100,
 });

--- a/src/app/components/message/modals/Options.tsx
+++ b/src/app/components/message/modals/Options.tsx
@@ -80,7 +80,7 @@ type MessageQuickReactionsProps = {
   onReaction: ReactionHandler;
   count: number;
 };
-export const MessageQuickReactions = as<'div', MessageQuickReactionsProps>(
+const MessageQuickReactions = as<'div', MessageQuickReactionsProps>(
   ({ onReaction, count, ...props }, ref) => {
     const mx = useMatrixClient();
     const recentEmojis = useRecentEmoji(mx, count);
@@ -179,7 +179,7 @@ const MessageCopyTextItem = as<
   );
 });
 
-export const MessagePinItem = as<
+const MessagePinItem = as<
   'button',
   {
     room: Room;
@@ -219,7 +219,7 @@ export const MessagePinItem = as<
   );
 });
 
-export const MessageBookmarkItem = as<
+const MessageBookmarkItem = as<
   'button',
   {
     room: Room;
@@ -259,7 +259,7 @@ export const MessageBookmarkItem = as<
   );
 });
 
-export const MessageFavoriteGifItem = as<
+const MessageFavoriteGifItem = as<
   'button',
   {
     room: Room;
@@ -335,7 +335,7 @@ export type OptionEmojiMenuProps = {
   ActualMessage?: ReactNode;
   dragOpts?: DragOptsProps;
 };
-export function OptionsEmojiBoard({
+function OptionsEmojiBoard({
   mEvent,
   onReactionToggle,
   closeMenu,
@@ -567,7 +567,7 @@ export type OptionMenuProps = {
   dragOpts?: DragOptsProps;
 };
 
-export function OptionMenu({
+function OptionMenu({
   mEvent,
   room,
   closeMenu,

--- a/src/app/components/notification-banner/NotificationBanner.css.ts
+++ b/src/app/components/notification-banner/NotificationBanner.css.ts
@@ -112,11 +112,6 @@ export const BannerSubtitle = style({
   opacity: 0.7,
 });
 
-export const BannerRoomName = style({
-  color: color.Primary.Main,
-  fontWeight: 600,
-});
-
 // Caps tall previews and fades the bottom edge when content overflows.
 // Desktop: 25vh, mobile (≤768px): 35vh.
 export const BannerBody = style({

--- a/src/app/components/page/PersistentRoomHost.tsx
+++ b/src/app/components/page/PersistentRoomHost.tsx
@@ -16,7 +16,7 @@ export type DisplayedRoom = {
   eventId?: string;
 };
 
-export function useDisplayedRoom(section: SectionNav | null): DisplayedRoom | undefined {
+function useDisplayedRoom(section: SectionNav | null): DisplayedRoom | undefined {
   const location = useLocation();
   const lastRoom = useAtomValue(lastVisitedRoomAtom);
 

--- a/src/app/components/page/mobileSwipeCoordinator.ts
+++ b/src/app/components/page/mobileSwipeCoordinator.ts
@@ -1,6 +1,6 @@
-export const GESTURE_LOCK_THRESHOLD = 8;
-export const DRAWER_COMMIT_FRACTION = 0.22;
-export const DRAWER_VELOCITY_THRESHOLD = 0.45;
+const GESTURE_LOCK_THRESHOLD = 8;
+const DRAWER_COMMIT_FRACTION = 0.22;
+const DRAWER_VELOCITY_THRESHOLD = 0.45;
 
 export type MobileGestureMode = 'pending' | 'vertical' | 'drawer' | 'message' | 'chat' | 'blocked';
 

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -61,13 +61,13 @@ export const RoomCardBase = as<'div'>(({ className, ...props }, ref) => (
   />
 ));
 
-export const RoomCardName = as<'h6'>(({ children, ...props }, ref) => (
+const RoomCardName = as<'h6'>(({ children, ...props }, ref) => (
   <Text as="h6" size="H6" truncate {...props} ref={ref}>
     {children}
   </Text>
 ));
 
-export const RoomCardTopic = as<'p'>(({ children, className, ...props }, ref) => (
+const RoomCardTopic = as<'p'>(({ children, className, ...props }, ref) => (
   <Text
     as="p"
     size="T200"

--- a/src/app/components/sidebar/Sidebar.css.ts
+++ b/src/app/components/sidebar/Sidebar.css.ts
@@ -32,7 +32,7 @@ export const SidebarStack = style([
 ]);
 
 const DropLineDist = createVar();
-export const DropTarget = style({
+const DropTarget = style({
   vars: {
     [DropLineDist]: toRem(-8),
   },

--- a/src/app/components/sidebar/SidebarItem.tsx
+++ b/src/app/components/sidebar/SidebarItem.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps, ReactNode, RefCallback } from 'react';
 import { mobileOrTablet } from '$utils/user-agent';
 import * as css from './Sidebar.css';
 
-export const SidebarItemBottom = as<'div', css.SidebarItemVariants>(
+const SidebarItemBottom = as<'div', css.SidebarItemVariants>(
   ({ as: AsSidebarAvatarBox = 'div', className, active, ...props }, ref) => (
     <AsSidebarAvatarBox
       className={classNames(css.SidebarItemBottom({ active }), className)}

--- a/src/app/components/url-preview/ClientPreview.tsx
+++ b/src/app/components/url-preview/ClientPreview.tsx
@@ -47,7 +47,7 @@ export type EmbedHeaderProps = {
   source: string;
   after?: ReactNode;
 };
-export const EmbedHeader = as<'div', EmbedHeaderProps>(({ title, source, after }) => (
+const EmbedHeader = as<'div', EmbedHeaderProps>(({ title, source, after }) => (
   <AttachmentHeader>
     <Box alignItems="Center" gap="200" grow="Yes">
       <Box shrink="No">
@@ -70,7 +70,7 @@ export const EmbedHeader = as<'div', EmbedHeaderProps>(({ title, source, after }
 type EmbedOpenButtonProps = {
   url: string;
 };
-export function EmbedOpenButton({ url }: EmbedOpenButtonProps) {
+function EmbedOpenButton({ url }: EmbedOpenButtonProps) {
   return (
     <IconButton size="300" radii="300" onClick={() => window.open(url, '_blank')}>
       {sizedIcon(Link, '100')}
@@ -83,7 +83,7 @@ type YoutubeElementProps = {
   embedData: OEmbed;
 };
 
-export const YoutubeElement = as<'div', YoutubeElementProps>(({ videoInfo, embedData }) => {
+const YoutubeElement = as<'div', YoutubeElementProps>(({ videoInfo, embedData }) => {
   const thumbnailUrl = `https://i.ytimg.com/vi/${videoInfo.videoId}/hqdefault.jpg`;
 
   const timestamp = videoInfo.timestamp ? `&start=${videoInfo.timestamp}` : '';

--- a/src/app/components/url-preview/UrlPreview.css.tsx
+++ b/src/app/components/url-preview/UrlPreview.css.tsx
@@ -13,18 +13,6 @@ export const UrlPreview = style([
   },
 ]);
 
-export const UrlPreviewImg = style([
-  DefaultReset,
-  {
-    width: toRem(100),
-    height: toRem(100),
-    objectFit: 'cover',
-    objectPosition: 'center',
-    flexShrink: 0,
-    overflow: 'hidden',
-  },
-]);
-
 export const UrlPreviewMediaWell = style([
   DefaultReset,
   {

--- a/src/app/components/user-profile/styles.css.ts
+++ b/src/app/components/user-profile/styles.css.ts
@@ -1,15 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { color, config, toRem } from 'folds';
 
-export const UserHeader = style({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  zIndex: 1,
-  padding: config.space.S200,
-});
-
 export const UserHero = style({
   position: 'relative',
 });

--- a/src/app/features/bookmarks/bookmarkDomain.ts
+++ b/src/app/features/bookmarks/bookmarkDomain.ts
@@ -17,11 +17,11 @@ export function bookmarkItemEventType(bookmarkId: string): string {
   return `${MATRIX_SABLE_UNSTABLE_BOOKMARK_ITEM_EVENT_PREFIX}${bookmarkId}`;
 }
 
-export function buildMatrixURI(roomId: string, eventId: string): string {
+function buildMatrixURI(roomId: string, eventId: string): string {
   return `matrix:roomid/${encodeURIComponent(roomId)}/e/${encodeURIComponent(eventId)}`;
 }
 
-export function extractBodyPreview(mEvent: MatrixEvent, maxLength = 120): string {
+function extractBodyPreview(mEvent: MatrixEvent, maxLength = 120): string {
   const content = mEvent.getContent();
   const body = content?.body;
   if (typeof body !== 'string' || body.length === 0) return '';

--- a/src/app/features/call/CallMemberCard.tsx
+++ b/src/app/features/call/CallMemberCard.tsx
@@ -28,7 +28,7 @@ interface MemberWithMembershipData {
 type CallMemberCardProps = {
   member: CallMembership;
 };
-export function CallMemberCard({ member }: CallMemberCardProps) {
+function CallMemberCard({ member }: CallMemberCardProps) {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
   const room = useRoom();

--- a/src/app/features/call/Controls.tsx
+++ b/src/app/features/call/Controls.tsx
@@ -8,7 +8,6 @@ import {
   SpeakerSlash,
   VideoCamera,
   VideoCameraSlash,
-  ScreenShare,
 } from '$components/icons/phosphor';
 import { useAtom } from 'jotai';
 import * as css from './styles.css';
@@ -110,38 +109,6 @@ export function VideoButton({ enabled, onToggle }: VideoButtonProps) {
           outlined
         >
           {sizedIcon(enabled ? VideoCamera : VideoCameraSlash, '300', { filled: enabled })}
-        </IconButton>
-      )}
-    </TooltipProvider>
-  );
-}
-
-type ScreenShareButtonProps = {
-  enabled: boolean;
-  onToggle: () => void;
-};
-export function ScreenShareButton({ enabled, onToggle }: ScreenShareButtonProps) {
-  return (
-    <TooltipProvider
-      position="Top"
-      delay={500}
-      tooltip={
-        <Tooltip>
-          <Text size="T200">{enabled ? 'Stop Screenshare' : 'Start Screenshare'}</Text>
-        </Tooltip>
-      }
-    >
-      {(anchorRef) => (
-        <IconButton
-          ref={anchorRef}
-          variant={enabled ? 'Success' : 'Surface'}
-          fill="Soft"
-          radii="400"
-          size="400"
-          onClick={() => onToggle()}
-          outlined
-        >
-          {sizedIcon(ScreenShare, '300', { filled: enabled })}
         </IconButton>
       )}
     </TooltipProvider>

--- a/src/app/features/call/callToneSources.ts
+++ b/src/app/features/call/callToneSources.ts
@@ -56,15 +56,3 @@ export const resolveCallToneSources = async (
     },
   };
 };
-
-export const revokeUnusedCustomToneUrls = (
-  resolved: ResolvedCallToneSources,
-  activeSource: string | null
-): void => {
-  if (resolved.customRingtoneObjectUrl && resolved.customRingtoneObjectUrl !== activeSource) {
-    URL.revokeObjectURL(resolved.customRingtoneObjectUrl);
-  }
-  if (resolved.customRingbackObjectUrl && resolved.customRingbackObjectUrl !== activeSource) {
-    URL.revokeObjectURL(resolved.customRingbackObjectUrl);
-  }
-};

--- a/src/app/features/call/rtcNotificationParser.ts
+++ b/src/app/features/call/rtcNotificationParser.ts
@@ -1,5 +1,4 @@
 import {
-  MAX_CALL_NOTIFICATION_LIFETIME_MS,
   normalizeCallIntent,
   toCallNotificationType,
   type CallIntentKind,
@@ -12,8 +11,6 @@ export const REFERENCE_REL_TYPE = 'm.reference';
 
 export type NotificationType = CallNotificationType;
 export type NotificationIntentKind = CallIntentKind;
-
-export { MAX_CALL_NOTIFICATION_LIFETIME_MS };
 
 export type RtcNotificationEventLike = {
   type: string;

--- a/src/app/features/call/styles.css.ts
+++ b/src/app/features/call/styles.css.ts
@@ -47,10 +47,6 @@ export const CallMemberCard = style({
   padding: config.space.S300,
 });
 
-export const CallControlContainer = style({
-  padding: config.space.S400,
-});
-
 export const PrescreenMessage = style({
   padding: config.space.S200,
 });

--- a/src/app/features/common-settings/cosmetics/Cosmetics.tsx
+++ b/src/app/features/common-settings/cosmetics/Cosmetics.tsx
@@ -61,7 +61,7 @@ type CosmeticsSettingProps = {
   userId: string;
   room: Room;
 };
-export function CosmeticsAvatar({ profile, member, userId, room }: CosmeticsSettingProps) {
+function CosmeticsAvatar({ profile, member, userId, room }: CosmeticsSettingProps) {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
   const capabilities = useCapabilities();
@@ -184,7 +184,7 @@ export function CosmeticsAvatar({ profile, member, userId, room }: CosmeticsSett
   );
 }
 
-export function CosmeticsNickname({ profile, member, userId, room }: CosmeticsSettingProps) {
+function CosmeticsNickname({ profile, member, userId, room }: CosmeticsSettingProps) {
   const mx = useMatrixClient();
 
   const defaultDisplayName = member?.rawDisplayName ?? fallbackDisplayName(userId);
@@ -270,7 +270,7 @@ export function CosmeticsNickname({ profile, member, userId, room }: CosmeticsSe
   );
 }
 
-export function CosmeticsFont({
+function CosmeticsFont({
   room,
   isSpace,
   font,

--- a/src/app/features/common-settings/general/RoomProfile.tsx
+++ b/src/app/features/common-settings/general/RoomProfile.tsx
@@ -45,7 +45,7 @@ type RoomProfileEditProps = {
   isDm: boolean;
   onClose: () => void;
 };
-export function RoomProfileEdit({
+function RoomProfileEdit({
   canEditAvatar,
   canEditName,
   canEditTopic,

--- a/src/app/features/lobby/DnD.css.ts
+++ b/src/app/features/lobby/DnD.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { color, config, toRem } from 'folds';
 import { ContainerColor } from '$styles/ContainerColor.css';
 
-export const DragHandleWidth = toRem(24);
+const DragHandleWidth = toRem(24);
 const ReorderableContentInset = toRem(8);
 
 export const ReorderableContent = style({

--- a/src/app/features/lobby/LobbyHeader.css.ts
+++ b/src/app/features/lobby/LobbyHeader.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css';
-import { config } from 'folds';
 import { MOBILE_BREAKPOINT } from '$hooks/useScreenSize';
 
 export const Header = style({
@@ -13,12 +12,5 @@ export const ActionsBox = style({
       flexGrow: 0,
       flexBasis: 'auto',
     },
-  },
-});
-export const HeaderTopic = style({
-  ':hover': {
-    cursor: 'pointer',
-    opacity: config.opacity.P500,
-    textDecoration: 'underline',
   },
 });

--- a/src/app/features/lobby/SpaceNavItem.css.ts
+++ b/src/app/features/lobby/SpaceNavItem.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { config, toRem } from 'folds';
+import { config } from 'folds';
 import { recipe } from '@vanilla-extract/recipes';
 
 export const SpaceItemCard = recipe({
@@ -22,11 +22,3 @@ export const HeaderChip = style({
     },
   },
 });
-export const HeaderChipPlaceholder = style([
-  {
-    borderRadius: config.radii.R400,
-    paddingLeft: config.space.S100,
-    paddingRight: config.space.S300,
-    height: toRem(32),
-  },
-]);

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -309,7 +309,7 @@ const RoomNavItemMenu = forwardRef<HTMLDivElement, RoomNavItemMenuProps>(
   }
 );
 
-export const hideTextStyling = (isHidden: boolean | undefined) =>
+const hideTextStyling = (isHidden: boolean | undefined) =>
   isHidden ? { width: '100%', height: '100%', padding: '0', paddingTop: '0px' } : {};
 
 type RoomNavItemProps = {

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -31,7 +31,7 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useRoomUnread } from '$state/hooks/unread';
 import { roomToUnreadAtom } from '$state/room/roomToUnread';
 import { usePowerLevels } from '$hooks/usePowerLevels';
-import { copyToClipboard } from '$utils/dom';
+import { copyToClipboard, getMouseEventCords } from '$utils/dom';
 import { markAsRead } from '$utils/notifications';
 import { confirm } from '$components/confirm/confirm';
 import { showToast } from '$state/toast';
@@ -406,12 +406,7 @@ export function RoomNavItem({
     }
 
     evt.preventDefault();
-    setMenuAnchor({
-      x: evt.clientX,
-      y: evt.clientY,
-      width: 0,
-      height: 0,
-    });
+    setMenuAnchor(getMouseEventCords(evt.nativeEvent));
   };
 
   const handleOpenMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {

--- a/src/app/features/room/AudioMessageRecorder.css.ts
+++ b/src/app/features/room/AudioMessageRecorder.css.ts
@@ -11,14 +11,6 @@ const SlideOutLeft = keyframes({
   '100%': { transform: 'translateX(-100%)', opacity: 0 },
 });
 
-const Shake = keyframes({
-  '0%, 100%': { transform: 'translateX(0)' },
-  '20%': { transform: 'translateX(-4px)' },
-  '40%': { transform: 'translateX(4px)' },
-  '60%': { transform: 'translateX(-4px)' },
-  '80%': { transform: 'translateX(4px)' },
-});
-
 export const Container = style([
   DefaultReset,
   {
@@ -32,10 +24,6 @@ export const Container = style([
 
 export const ContainerCanceling = style({
   animation: `${SlideOutLeft} 200ms ease-out forwards`,
-});
-
-export const ContainerShake = style({
-  animation: `${Shake} 300ms ease-out`,
 });
 
 export const RecDot = style([
@@ -82,28 +70,6 @@ export const Timer = style([
     fontWeight: 600,
   },
 ]);
-
-export const CancelHint = style([
-  DefaultReset,
-  {
-    position: 'absolute',
-    left: config.space.S200,
-    top: 0,
-    bottom: 0,
-    display: 'flex',
-    alignItems: 'center',
-    color: color.Critical.Main,
-    fontSize: toRem(12),
-    fontWeight: 600,
-    opacity: 0,
-    transition: 'opacity 100ms ease-out',
-    pointerEvents: 'none',
-  },
-]);
-
-export const CancelHintVisible = style({
-  opacity: 1,
-});
 
 export const SrOnly = style([
   DefaultReset,

--- a/src/app/features/room/MembersDrawer.css.ts
+++ b/src/app/features/room/MembersDrawer.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { config, toRem } from 'folds';
 
 export const MembersDrawer = style({
@@ -18,24 +18,6 @@ export const MemberDrawerContentBase = style({
 
 export const MemberDrawerContent = style({
   padding: `${config.space.S200} 0`,
-});
-
-const ScrollBtnAnime = keyframes({
-  '0%': {
-    transform: `translate(-50%, -100%) scale(0)`,
-  },
-  '100%': {
-    transform: `translate(-50%, 0) scale(1)`,
-  },
-});
-
-export const DrawerScrollTop = style({
-  position: 'absolute',
-  top: config.space.S200,
-  left: '50%',
-  transform: 'translateX(-50%)',
-  zIndex: 1,
-  animation: `${ScrollBtnAnime} 100ms`,
 });
 
 export const DrawerGroup = style({

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -113,6 +113,7 @@ import type { EditorButtonId } from '$state/settings';
 import { settingsAtom } from '$state/settings';
 import { matchesShortcut } from '../../keyboard/shortcuts';
 import { getEditedEvent, getMentionContent, getThreadReplyEvents } from '$utils/room';
+import { buildReplacementContent } from './buildReplacementContent';
 import { htmlToMarkdown } from '$plugins/markdown';
 import { Command, SHRUG, TABLEFLIP, UNFLIP, useCommands } from '$hooks/useCommands';
 import { mobileOrTablet } from '$utils/user-agent';
@@ -1051,33 +1052,9 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         const eventId = editingEvent.getId();
         if (!eventId) return;
 
-        const msgtype = oldContent.msgtype ?? MsgType.Text;
-        const newContent: IContent = {
-          msgtype,
-          body: plainText,
-        };
-
         const rawPmp =
           currentContent['com.beeper.per_message_profile'] ??
           oldContent['com.beeper.per_message_profile'];
-        const pmpDisplayname =
-          rawPmp !== null &&
-          typeof rawPmp === 'object' &&
-          'displayname' in rawPmp &&
-          typeof rawPmp.displayname === 'string' &&
-          rawPmp.displayname.length > 0
-            ? rawPmp.displayname
-            : undefined;
-
-        if (pmpDisplayname) {
-          const bodyPrefix = `${pmpDisplayname}: `;
-          if (!plainText.startsWith(bodyPrefix)) plainText = bodyPrefix + plainText;
-
-          const htmlPrefix = `<strong data-mx-profile-fallback>${sanitizeText(pmpDisplayname)}: </strong>`;
-          if (!customHtml.startsWith(htmlPrefix)) customHtml = htmlPrefix + customHtml;
-          newContent.body = plainText;
-          newContent['com.beeper.per_message_profile'] = rawPmp;
-        }
 
         const mentionData = getMentions(mx, roomId, editor);
         const previousMentions = currentContent['m.mentions'];
@@ -1092,50 +1069,21 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           });
         }
         const mMentions = getMentionContent(Array.from(mentionData.users), mentionData.room);
-        newContent['m.mentions'] = mMentions;
 
-        const content: IContent = {
-          ...oldContent,
-          'm.relates_to': {
-            event_id: eventId,
-            rel_type: RelationType.Replace,
-          },
-          body: `* ${plainText}`,
-          'm.mentions': mMentions,
-          'm.new_content': newContent,
-        };
+        const linkPreviews =
+          getLinks(editor.children)?.map((matchedUrl) => ({
+            matched_url: matchedUrl,
+          })) ?? [];
 
-        if (pmpDisplayname || !customHtmlEqualsPlainText(customHtml, plainText)) {
-          newContent.format = 'org.matrix.custom.html';
-          newContent.formatted_body = customHtml;
-          content.format = 'org.matrix.custom.html';
-          content.formatted_body = `* ${customHtml}`;
-        } else {
-          delete content.format;
-          delete content.formatted_body;
-        }
-
-        if (oldContent.info !== undefined && oldContent.msgtype !== MsgType.Text) {
-          const filename = 'filename' in oldContent ? oldContent.filename : oldContent.body;
-          content.filename = filename;
-          newContent.filename = filename;
-          content.info = oldContent.info;
-          newContent.info = oldContent.info;
-          if (oldContent.file !== undefined) newContent.file = oldContent.file;
-          if (oldContent.url !== undefined) newContent.url = oldContent.url;
-
-          const spoilerKey = 'page.codeberg.everypizza.msc4193.spoiler';
-          if (oldContent[spoilerKey] !== undefined) {
-            content[spoilerKey] = oldContent[spoilerKey];
-            newContent[spoilerKey] = oldContent[spoilerKey];
-          }
-        }
-
-        const linkPreviews = getLinks(editor.children)?.map((matchedUrl) => ({
-          matched_url: matchedUrl,
-        }));
-        content['com.beeper.linkpreviews'] = linkPreviews ?? [];
-        newContent['com.beeper.linkpreviews'] = linkPreviews ?? [];
+        const content = buildReplacementContent(
+          oldContent,
+          plainText,
+          customHtml,
+          eventId,
+          mMentions,
+          linkPreviews,
+          rawPmp
+        );
 
         await mx.sendMessage(roomId, content as RoomMessageEventContent);
         onCancelEdit?.();

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -220,7 +220,7 @@ const LocationDialog = lazy(() =>
 
 // Returns the event ID of the most recent non-reaction/non-edit event in a thread,
 // falling back to the thread root if no replies exist yet.
-export const getLatestThreadEventId = (room: Room, threadRootId: string): string => {
+const getLatestThreadEventId = (room: Room, threadRootId: string): string => {
   const replies = getThreadReplyEvents(room, threadRootId);
   return replies.at(-1)?.getId() ?? threadRootId;
 };

--- a/src/app/features/room/buildReplacementContent.ts
+++ b/src/app/features/room/buildReplacementContent.ts
@@ -1,0 +1,94 @@
+import type { IContent, IMentions } from '$types/matrix-sdk';
+import { MsgType, RelationType } from '$types/matrix-sdk';
+import { customHtmlEqualsPlainText } from '$components/editor';
+import { sanitizeText } from '$utils/sanitize';
+
+/**
+ * Unified from RoomInput and MessageEditor, which had drifted: this keeps
+ * RoomInput's `delete content.format` branch that MessageEditor lacked.
+ */
+export function buildReplacementContent(
+  oldContent: IContent,
+  plainText: string,
+  customHtml: string,
+  eventId: string,
+  mMentions: IMentions,
+  linkPreviews: { matched_url: string }[],
+  perMessageProfile: unknown
+): IContent {
+  const pmpDisplayname =
+    perMessageProfile !== null &&
+    typeof perMessageProfile === 'object' &&
+    'displayname' in perMessageProfile &&
+    typeof perMessageProfile.displayname === 'string' &&
+    perMessageProfile.displayname.length > 0
+      ? perMessageProfile.displayname
+      : undefined;
+
+  let adjustedPlainText = plainText;
+  let adjustedCustomHtml = customHtml;
+
+  if (pmpDisplayname) {
+    const bodyPrefix = `${pmpDisplayname}: `;
+    if (!adjustedPlainText.startsWith(bodyPrefix))
+      adjustedPlainText = bodyPrefix + adjustedPlainText;
+
+    const htmlPrefix = `<strong data-mx-profile-fallback>${sanitizeText(pmpDisplayname)}: </strong>`;
+    if (!adjustedCustomHtml.startsWith(htmlPrefix))
+      adjustedCustomHtml = htmlPrefix + adjustedCustomHtml;
+  }
+
+  const msgtype = oldContent.msgtype ?? MsgType.Text;
+
+  const newContent: IContent = {
+    msgtype,
+    body: adjustedPlainText,
+    'm.mentions': mMentions,
+  };
+
+  if (pmpDisplayname) {
+    newContent['com.beeper.per_message_profile'] = perMessageProfile;
+  }
+
+  const content: IContent = {
+    ...oldContent,
+    'm.relates_to': {
+      event_id: eventId,
+      rel_type: RelationType.Replace,
+    },
+    body: `* ${adjustedPlainText}`,
+    'm.mentions': mMentions,
+    'm.new_content': newContent,
+  };
+
+  if (!customHtmlEqualsPlainText(adjustedCustomHtml, adjustedPlainText)) {
+    newContent.format = 'org.matrix.custom.html';
+    newContent.formatted_body = adjustedCustomHtml;
+    content.format = 'org.matrix.custom.html';
+    content.formatted_body = `* ${adjustedCustomHtml}`;
+  } else {
+    delete content.format;
+    delete content.formatted_body;
+  }
+
+  if (oldContent.info !== undefined && oldContent.msgtype !== MsgType.Text) {
+    const filename = 'filename' in oldContent ? (oldContent.filename as string) : oldContent.body;
+    content.filename = filename;
+    newContent.filename = filename;
+    content.info = oldContent.info;
+    newContent.info = oldContent.info;
+    if (oldContent.file !== undefined) newContent.file = oldContent.file;
+    if (oldContent.url !== undefined) newContent.url = oldContent.url;
+
+    const spoilerKey = 'page.codeberg.everypizza.msc4193.spoiler';
+    if (oldContent[spoilerKey] !== undefined) {
+      content[spoilerKey] = oldContent[spoilerKey];
+      newContent[spoilerKey] = oldContent[spoilerKey];
+    }
+  }
+
+  content['com.beeper.linkpreviews'] = linkPreviews;
+  newContent['com.beeper.linkpreviews'] = linkPreviews;
+
+  return content;
+}

--- a/src/app/features/room/location-modal/LocationDialog.tsx
+++ b/src/app/features/room/location-modal/LocationDialog.tsx
@@ -19,7 +19,7 @@ import markerIconPng from 'leaflet/dist/images/marker-icon.png';
 import { Icon } from 'leaflet';
 import { ModalOverlay } from '$components/modal-overlay/ModalOverlay';
 
-export const markerIcon = new Icon({
+const markerIcon = new Icon({
   iconUrl: markerIconPng,
   iconSize: [25, 41],
   iconAnchor: [12, 41],

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -41,6 +41,7 @@ import {
 } from '$components/message';
 import { canEditEvent, getEditedEvent, getMemberAvatarMxc } from '$utils/room';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
+import { getMouseEventCords } from '$utils/dom';
 import type { MessageSpacing } from '$state/settings';
 import { getSettings, MessageLayout, settingsAtom } from '$state/settings';
 import { useMatrixClient } from '$hooks/useMatrixClient';
@@ -912,12 +913,7 @@ function MessageInternal(
     }
 
     evt.preventDefault();
-    setMenuAnchor({
-      x: evt.clientX,
-      y: evt.clientY,
-      width: 0,
-      height: 0,
-    });
+    setMenuAnchor(getMouseEventCords(evt.nativeEvent));
   };
 
   const handleOpenMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {

--- a/src/app/features/room/message/MessageEditor.tsx
+++ b/src/app/features/room/message/MessageEditor.tsx
@@ -21,12 +21,11 @@ import type {
   IContent,
   IMentions,
   MatrixEvent,
-  ReplacementEvent,
   Room,
   RoomMessageEventContent,
   RoomMessageTextEventContent,
 } from '$types/matrix-sdk';
-import { RelationType, MsgType } from '$types/matrix-sdk';
+import { MsgType } from '$types/matrix-sdk';
 import { isKeyHotkey } from 'is-hotkey';
 import type { AutocompleteQuery } from '$components/editor';
 import {
@@ -63,6 +62,7 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useDismissOnBack } from '$utils/androidBack';
 import { nicknamesAtom } from '$state/nicknames';
 import { getEditedEvent, getMentionContent, trimReplyFromFormattedBody } from '$utils/room';
+import { buildReplacementContent } from '../buildReplacementContent';
 import { mobileOrTablet } from '$utils/user-agent';
 import { useComposingCheck } from '$hooks/useComposingCheck';
 import { floatingEditor } from '$styles/overrides/Composer.css';
@@ -75,7 +75,6 @@ import type { HTMLReactParserOptions } from 'html-react-parser';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
 import type { Opts as LinkifyOpts } from 'linkifyjs';
 import type { GetContentCallback } from '$types/matrix/room';
-import { sanitizeText } from '$utils/sanitize';
 import type { BundleContent } from '$components/message';
 import {
   readdAngleBracketsForHiddenPreviews,
@@ -261,11 +260,6 @@ export const MessageEditor = as<'div', MessageEditorProps>(
           }
         }
 
-        const newContent: IContent = {
-          msgtype,
-          body: plainText,
-        };
-
         const evtId = mEvent.getId();
         const evtTimeline = evtId ? room.getTimelineForEvent(evtId) : undefined;
         const editedEvent =
@@ -277,36 +271,6 @@ export const MessageEditor = as<'div', MessageEditorProps>(
           editedEvent?.getContent()?.['m.new_content']?.['com.beeper.per_message_profile'] ??
           mEvent.getContent()?.['com.beeper.per_message_profile'];
 
-        const pmpDisplayname =
-          rawPmp !== null &&
-          typeof rawPmp === 'object' &&
-          'displayname' in rawPmp &&
-          typeof rawPmp.displayname === 'string' &&
-          rawPmp.displayname.length > 0
-            ? (rawPmp.displayname as string)
-            : undefined;
-
-        if (pmpDisplayname) {
-          const bodyPrefix = `${pmpDisplayname}: `;
-          if (!plainText.startsWith(bodyPrefix)) {
-            plainText = bodyPrefix + plainText;
-          }
-
-          const escapedName = sanitizeText(pmpDisplayname);
-          const htmlPrefix = `<strong data-mx-profile-fallback>${escapedName}: </strong>`;
-          if (!customHtml.startsWith(htmlPrefix)) {
-            customHtml = htmlPrefix + customHtml;
-          }
-
-          newContent['com.beeper.per_message_profile'] = rawPmp;
-        }
-
-        const contentBody: IContent & Omit<ReplacementEvent<IContent>, 'm.relates_to'> = {
-          msgtype,
-          body: `* ${plainText}`,
-          'm.new_content': newContent,
-        };
-
         const mentionData = getMentions(mx, roomId, editor);
 
         prevMentions?.user_ids?.forEach((prevMentionId) => {
@@ -314,49 +278,21 @@ export const MessageEditor = as<'div', MessageEditorProps>(
         });
 
         const mMentions = getMentionContent(Array.from(mentionData.users), mentionData.room);
-        newContent['m.mentions'] = mMentions;
-        contentBody['m.mentions'] = mMentions;
 
-        const links = getLinks(editor.children);
+        const linkPreviews =
+          getLinks(editor.children)?.map((matchedUrl) => ({
+            matched_url: matchedUrl,
+          })) ?? [];
 
-        if (pmpDisplayname || !customHtmlEqualsPlainText(customHtml, plainText)) {
-          newContent.format = 'org.matrix.custom.html';
-          newContent.formatted_body = customHtml;
-          contentBody.format = 'org.matrix.custom.html';
-          contentBody.formatted_body = `* ${customHtml}`;
-        }
-
-        const content: IContent = {
-          ...oldContent,
-          'm.relates_to': {
-            event_id: eventId,
-            rel_type: RelationType.Replace,
-          },
-        };
-        content.body = contentBody.body;
-        content.format = contentBody.format;
-        content.formatted_body = contentBody.formatted_body;
-        content['m.new_content'] = newContent;
-        if (oldContent.info !== undefined && oldContent.msgtype !== 'm.text') {
-          content.filename = 'filename' in oldContent ? oldContent.filename : oldContent.body;
-          content['m.new_content'].filename =
-            'filename' in oldContent ? oldContent.filename : oldContent.body;
-          content.info = oldContent.info;
-          content['m.new_content'].info = oldContent.info;
-
-          if (oldContent.file !== undefined) content['m.new_content'].file = oldContent.file;
-          if (oldContent.url !== undefined) content['m.new_content'].url = oldContent.url;
-
-          if (oldContent['page.codeberg.everypizza.msc4193.spoiler'] !== undefined) {
-            content['page.codeberg.everypizza.msc4193.spoiler'] =
-              oldContent['page.codeberg.everypizza.msc4193.spoiler'];
-            content['m.new_content']['page.codeberg.everypizza.msc4193.spoiler'] =
-              oldContent['page.codeberg.everypizza.msc4193.spoiler'];
-          }
-        }
-        content['com.beeper.linkpreviews'] = [];
-        links?.forEach((link) => content['com.beeper.linkpreviews'].push({ matched_url: link }));
-        content['m.new_content']['com.beeper.linkpreviews'] = content['com.beeper.linkpreviews'];
+        const content = buildReplacementContent(
+          oldContent,
+          plainText,
+          customHtml,
+          eventId,
+          mMentions,
+          linkPreviews,
+          rawPmp
+        );
 
         return mx.sendMessage(roomId, content as RoomMessageEventContent);
       }, [mx, editor, roomId, mEvent, getPrevBodyAndFormattedBody, room])

--- a/src/app/features/room/message/styles.css.ts
+++ b/src/app/features/room/message/styles.css.ts
@@ -79,17 +79,6 @@ export const PreventSelect = style({
 //I have zero clue where these numbers and vars are from but they should be changed
 //I just copied the hardcoded value in a more correct place
 
-export const MessageNickEditor = style({
-  background: 'var(--mx-c-surface)',
-  color: 'var(--mx-c-on-surface)',
-  border: '1px solid var(--mx-c-outline)',
-  borderRadius: '6px',
-  padding: '4px 8px',
-  fontSize: '14px',
-  width: '100%',
-  outline: 'none',
-});
-
 export const MessageMobileOptionsWrapped = style({
   position: 'fixed',
   top: 0,

--- a/src/app/features/room/schedule-send/SchedulePickerDialog.css.ts
+++ b/src/app/features/room/schedule-send/SchedulePickerDialog.css.ts
@@ -1,11 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { config, toRem } from 'folds';
 
-export const SchedulePickerContent = style({
-  padding: config.space.S400,
-  minWidth: toRem(300),
-});
-
 export const SplitSendButton = style({
   borderRadius: `${config.radii.R300} 0 0 ${config.radii.R300}`,
 });

--- a/src/app/features/room/schedule-send/ScheduledMessagesList.css.ts
+++ b/src/app/features/room/schedule-send/ScheduledMessagesList.css.ts
@@ -23,10 +23,3 @@ export const ScheduledMessageRow = style({
     },
   },
 });
-
-export const MessagePreview = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  maxWidth: toRem(300),
-});

--- a/src/app/features/settings/Settings.tsx
+++ b/src/app/features/settings/Settings.tsx
@@ -47,7 +47,7 @@ import { useSettingsLinkBaseUrl } from './useSettingsLinkBaseUrl';
 import { Desktop } from './desktop';
 import { isDesktopTauri } from '$utils/platform';
 
-export enum SettingsPages {
+enum SettingsPages {
   GeneralPage,
   AccountPage,
   PerMessageProfilesPage,
@@ -71,7 +71,7 @@ export type SettingsMenuItem = {
   activeIcon?: PhosphorIcon;
 };
 
-export const settingsMenuIcons: Record<
+const settingsMenuIcons: Record<
   SettingsSectionId,
   Pick<SettingsMenuItem, 'icon' | 'activeIcon'>
 > = {

--- a/src/app/features/settings/about/About.tsx
+++ b/src/app/features/settings/about/About.tsx
@@ -25,7 +25,7 @@ type VersionResult =
   | { server: { name?: string; version?: string; compiler?: string } }
   | undefined;
 
-export function HomeserverInfo() {
+function HomeserverInfo() {
   const mx = useMatrixClient();
   const [federationUrl, setFederationUrl] = useState<string>(mx.baseUrl);
   const [version, setVersion] = useState<VersionResult>(undefined);

--- a/src/app/features/settings/cosmetics/LanguageSpecificPronouns.tsx
+++ b/src/app/features/settings/cosmetics/LanguageSpecificPronouns.tsx
@@ -9,7 +9,7 @@ export type LanguageSpecificPronounsConfig = {
   languages?: string[];
 };
 
-export const resolveLanguageSpecificPronounsEnabled = (
+const resolveLanguageSpecificPronounsEnabled = (
   enabled: LanguageSpecificPronounsConfig['enabled']
 ): boolean => {
   if (enabled === undefined) return false;

--- a/src/app/features/settings/cosmetics/ThemeCatalogOnboarding.tsx
+++ b/src/app/features/settings/cosmetics/ThemeCatalogOnboarding.tsx
@@ -10,7 +10,7 @@ type ThemeCatalogOnboardingProps = {
   onDecline: () => void;
 };
 
-export function ThemeCatalogOnboarding({ open, onEnable, onDecline }: ThemeCatalogOnboardingProps) {
+function ThemeCatalogOnboarding({ open, onEnable, onDecline }: ThemeCatalogOnboardingProps) {
   const suppressDeactivateDecline = useRef(false);
 
   const handleEnableClick = useCallback(() => {

--- a/src/app/features/settings/cosmetics/ThemeCatalogSettings.tsx
+++ b/src/app/features/settings/cosmetics/ThemeCatalogSettings.tsx
@@ -101,8 +101,6 @@ export type LocalTweakRow = ThemeRemoteTweakFavorite & {
 
 export type ThemeCatalogSettingsMode = 'local' | 'appearance';
 
-export { usePatchSettings } from './themeSettingsPatch';
-
 type ThemeCatalogSettingsProps = {
   mode: ThemeCatalogSettingsMode;
   onBrowseOpenChange?: (open: boolean) => void;

--- a/src/app/features/settings/general/CallSoundSettingsCards.tsx
+++ b/src/app/features/settings/general/CallSoundSettingsCards.tsx
@@ -15,7 +15,7 @@ export type CustomToneMetadata = {
   durationMs: number;
 };
 
-export function CustomToneMeta({
+function CustomToneMeta({
   metadata,
   emptyLabel,
 }: {

--- a/src/app/features/settings/notifications/NativePushNotifications.ts
+++ b/src/app/features/settings/notifications/NativePushNotifications.ts
@@ -113,7 +113,7 @@ export async function ensureNativePushRegistered(
   };
 }
 
-export async function ensureNativePushUnregistered(): Promise<void> {
+async function ensureNativePushUnregistered(): Promise<void> {
   const api = await getNativePushNotificationsApi();
   await api.unregisterForPushNotifications();
 }

--- a/src/app/features/settings/notifications/NotificationTransport.ts
+++ b/src/app/features/settings/notifications/NotificationTransport.ts
@@ -44,14 +44,7 @@ export type {
   NativePushRegistrationResult,
 } from './NativePushNotifications';
 
-export {
-  disableNativePush,
-  enableNativePush,
-  ensureNativePushRegistered,
-  ensureNativePushUnregistered,
-  isNativePushPermissionGranted,
-  requestNativePushPermission,
-} from './NativePushNotifications';
+export { disableNativePush, enableNativePush } from './NativePushNotifications';
 
 export function getSupportedNotificationTransportModes(
   platform: NotificationTransportPlatform

--- a/src/app/features/settings/notifications/SystemNotification.tsx
+++ b/src/app/features/settings/notifications/SystemNotification.tsx
@@ -76,10 +76,7 @@ function getBackgroundPushPlatform(isTauriRuntime: boolean): BackgroundPushPlatf
   return 'desktop';
 }
 
-export function deriveLegacyPushSync(input: {
-  enabled: boolean;
-  provider: BackgroundPushKind | null;
-}): {
+function deriveLegacyPushSync(input: { enabled: boolean; provider: BackgroundPushKind | null }): {
   usePushNotifications: boolean;
   useUnifiedPush: boolean;
 } {

--- a/src/app/features/settings/notifications/TauriNotificationsApiClient.ts
+++ b/src/app/features/settings/notifications/TauriNotificationsApiClient.ts
@@ -65,7 +65,7 @@ const transitionActionListener = (invokeFn: typeof invoke, active: boolean): Pro
   return actionListenerTransition;
 };
 
-export async function subscribeToNativeNotificationActions(
+async function subscribeToNativeNotificationActions(
   listener: (event: NotificationActionEvent) => void,
   dependencies: ActionListenerDependencies = { addListener: addPluginListener, invoke }
 ): Promise<NotificationPluginListener> {
@@ -115,7 +115,7 @@ export async function getTauriNotificationsApi(): Promise<TauriNotificationsApi>
 
 let permissionPromise: Promise<boolean> | null = null;
 
-export async function ensureTauriNotificationPermission(): Promise<boolean> {
+async function ensureTauriNotificationPermission(): Promise<boolean> {
   if (!permissionPromise) {
     permissionPromise = (async () => {
       const api = await getTauriNotificationsApi();

--- a/src/app/features/settings/notifications/UnifiedPushNotifications.ts
+++ b/src/app/features/settings/notifications/UnifiedPushNotifications.ts
@@ -13,10 +13,7 @@ import { getMxIdLocalPart } from '$utils/matrix';
 import { getStateEvent, getMemberAvatarMxc } from '$utils/room';
 import { createDebugLogger } from '$utils/debugLogger';
 import {
-  getUnifiedPushDistributor,
-  getUnifiedPushDistributors,
   registerUnifiedPushTransport,
-  saveUnifiedPushDistributor,
   type UnifiedPushRegistrationResult,
   unregisterUnifiedPushTransport,
 } from './UnifiedPushTransport';
@@ -36,8 +33,6 @@ import {
   withPushPayloadFormat,
   type PushPusherSettings,
 } from './PushPusherConfig';
-
-export { getUnifiedPushDistributors, getUnifiedPushDistributor, saveUnifiedPushDistributor };
 
 const UP_PUBLIC_GATEWAY = 'https://matrix.gateway.unifiedpush.org/_matrix/push/v1/notify';
 export const DEFAULT_UNIFIED_PUSH_APP_ID = 'moe.sable.up';

--- a/src/app/features/settings/notifications/UnifiedPushTransport.ts
+++ b/src/app/features/settings/notifications/UnifiedPushTransport.ts
@@ -115,17 +115,17 @@ export async function isUnifiedPushPermissionGranted(): Promise<boolean | null> 
   return api.isPermissionGranted();
 }
 
-export async function getUnifiedPushDistributors(): Promise<string[]> {
+async function getUnifiedPushDistributors(): Promise<string[]> {
   const api = await getUnifiedPushTransportApi();
   return api.listDistributors();
 }
 
-export async function getUnifiedPushDistributor(): Promise<{ distributor: string }> {
+async function getUnifiedPushDistributor(): Promise<{ distributor: string }> {
   const distributor = localStorage.getItem(DISTRIBUTUTOR_STORAGE_KEY) ?? '';
   return { distributor };
 }
 
-export async function saveUnifiedPushDistributor(distributor: string): Promise<void> {
+async function saveUnifiedPushDistributor(distributor: string): Promise<void> {
   localStorage.setItem(DISTRIBUTUTOR_STORAGE_KEY, distributor);
   const api = await getUnifiedPushTransportApi();
   await api.setDistributor(distributor);

--- a/src/app/hooks/commands/rainbow.ts
+++ b/src/app/hooks/commands/rainbow.ts
@@ -22,7 +22,7 @@ const getAllTextNodes = (root: Node): Node[] =>
         []
       );
 
-export const rainbowify = (htmlInput: string): string => {
+const rainbowify = (htmlInput: string): string => {
   const div = document.createElement('div');
   div.innerHTML = htmlInput;
   const textNodes = getAllTextNodes(div);

--- a/src/app/hooks/media/useMediaPlaybackRate.ts
+++ b/src/app/hooks/media/useMediaPlaybackRate.ts
@@ -1,40 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
-
 export type MediaPlaybackRateData = {
   playbackRate: number;
 };
 export type MediaPlaybackRateControl = {
   setPlaybackRate: (rate: number) => void;
-};
-
-export const useMediaPlaybackRate = (
-  getTargetElement: () => HTMLMediaElement | null
-): MediaPlaybackRateData & MediaPlaybackRateControl => {
-  const [rate, setRate] = useState(1.0);
-
-  const setPlaybackRate = useCallback(
-    (playbackRate: number) => {
-      const targetEl = getTargetElement();
-      if (!targetEl) return;
-      targetEl.playbackRate = playbackRate;
-    },
-    [getTargetElement]
-  );
-
-  useEffect(() => {
-    const targetEl = getTargetElement();
-    const handleChange = () => {
-      if (!targetEl) return;
-      setRate(targetEl.playbackRate);
-    };
-    targetEl?.addEventListener('ratechange', handleChange);
-    return () => {
-      targetEl?.removeEventListener('ratechange', handleChange);
-    };
-  }, [getTargetElement]);
-
-  return {
-    playbackRate: rate,
-    setPlaybackRate,
-  };
 };

--- a/src/app/hooks/router/useResolvedRoomId.ts
+++ b/src/app/hooks/router/useResolvedRoomId.ts
@@ -51,12 +51,6 @@ export const useResolvedRoomIdOrAlias = (roomIdOrAlias?: string): ResolvedRoomId
   return { resolving: true };
 };
 
-export const useResolvedSelectedRoom = (): ResolvedRoomId => {
-  const { roomIdOrAlias: encodedRoomIdOrAlias } = useParams();
-  const roomIdOrAlias = encodedRoomIdOrAlias && decodeURIComponent(encodedRoomIdOrAlias);
-  return useResolvedRoomIdOrAlias(roomIdOrAlias);
-};
-
 export const useResolvedSelectedSpace = (): ResolvedRoomId => {
   const { spaceIdOrAlias: encodedSpaceIdOrAlias } = useParams();
   const spaceIdOrAlias = encodedSpaceIdOrAlias && decodeURIComponent(encodedSpaceIdOrAlias);

--- a/src/app/hooks/router/useRouteSelected.ts
+++ b/src/app/hooks/router/useRouteSelected.ts
@@ -5,7 +5,6 @@ import {
   getDirectPath,
   getExploreFeaturedPath,
   getExplorePath,
-  getHomeJoinPath,
   getHomePath,
   getHomeSearchPath,
   getInboxBookmarksPath,
@@ -32,7 +31,6 @@ export const useExploreServer = (): string | undefined => useParams().server;
 
 export const useHomeSelected = (): boolean => useRouteSelected(getHomePath());
 export const useHomeCreateSelected = (): boolean => useRouteSelected(CREATE_ROOM_PATH);
-export const useHomeJoinSelected = (): boolean => useRouteSelected(getHomeJoinPath());
 export const useHomeSearchSelected = (): boolean => useRouteSelected(getHomeSearchPath());
 
 export const useInboxSelected = (): boolean => useRouteSelected(getInboxPath());

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -27,7 +27,7 @@ import {
   PAGINATION_LIMIT,
 } from '$utils/timeline';
 
-export const EVENT_TIMELINE_LOAD_TIMEOUT_MS = 12000;
+const EVENT_TIMELINE_LOAD_TIMEOUT_MS = 12000;
 
 export type PaginationStatus = 'idle' | 'loading' | 'error';
 

--- a/src/app/hooks/useAsyncSearch.ts
+++ b/src/app/hooks/useAsyncSearch.ts
@@ -44,7 +44,7 @@ const performMatch = (
   return matches ? normalizedTargetStr : undefined;
 };
 
-export const orderSearchItems = <TSearchItem extends object | string | number>(
+const orderSearchItems = <TSearchItem extends object | string | number>(
   query: string,
   items: TSearchItem[],
   getItemStr: SearchItemStrGetter<TSearchItem>,

--- a/src/app/hooks/useBookmarks.ts
+++ b/src/app/hooks/useBookmarks.ts
@@ -24,10 +24,6 @@ export function useBookmarkLoading(): boolean {
   return useAtomValue(bookmarkLoadingAtom);
 }
 
-export function useBookmarkRefreshError(): Error | undefined {
-  return useAtomValue(bookmarkRefreshErrorAtom);
-}
-
 export function useIsBookmarked(roomId: string, eventId: string): boolean {
   const idSet = useAtomValue(bookmarkIdSetAtom);
   return idSet.has(computeBookmarkId(roomId, eventId));

--- a/src/app/hooks/useCallEmbed.ts
+++ b/src/app/hooks/useCallEmbed.ts
@@ -30,7 +30,7 @@ export const useCallEmbed = (): CallEmbed | undefined => {
 
 const CallEmbedRefContext = createContext<RefObject<HTMLDivElement> | undefined>(undefined);
 export const CallEmbedRefContextProvider = CallEmbedRefContext.Provider;
-export const useCallEmbedRef = (): RefObject<HTMLDivElement> => {
+const useCallEmbedRef = (): RefObject<HTMLDivElement> => {
   const ref = useContext(CallEmbedRefContext);
   if (!ref) {
     throw new Error('CallEmbedRef is not provided!');
@@ -38,7 +38,7 @@ export const useCallEmbedRef = (): RefObject<HTMLDivElement> => {
   return ref;
 };
 
-export const createCallEmbed = (
+const createCallEmbed = (
   mx: MatrixClient,
   room: Room,
   dm: boolean,

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -22,14 +22,6 @@ import { createMiscCommands } from './commands/misc';
 export type { CommandExe, CommandContent, CommandRecord } from './commands/types';
 export { Command } from './commands/types';
 export { SHRUG, TABLEFLIP, UNFLIP } from './commands/fun';
-export { rainbowify } from './commands/rainbow';
-export {
-  parseFlags,
-  parseServers,
-  parseTimestampFlag,
-  parseUsers,
-  splitPayloadContentAndFlags,
-} from './commands/parsing';
 
 export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
   const { navigateRoom } = useRoomNavigate();

--- a/src/app/hooks/useFileDrop.ts
+++ b/src/app/hooks/useFileDrop.ts
@@ -1,15 +1,6 @@
-import type { DragEventHandler, RefObject } from 'react';
-import { useCallback, useState, useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { getDataTransferFiles } from '$utils/dom';
-
-export const useFileDropHandler = (onDrop: (file: File[]) => void): DragEventHandler =>
-  useCallback(
-    (evt) => {
-      const files = getDataTransferFiles(evt.dataTransfer);
-      if (files) onDrop(files);
-    },
-    [onDrop]
-  );
 
 export const useFileDropZone = (
   zoneRef: RefObject<HTMLElement>,

--- a/src/app/hooks/useKeyBackup.ts
+++ b/src/app/hooks/useKeyBackup.ts
@@ -10,9 +10,7 @@ import * as Sentry from '@sentry/react';
 import { useMatrixClient } from './useMatrixClient';
 import { useAlive } from './useAlive';
 
-export const useKeyBackupStatusChange = (
-  onChange: CryptoEventHandlerMap[CryptoEvent.KeyBackupStatus]
-) => {
+const useKeyBackupStatusChange = (onChange: CryptoEventHandlerMap[CryptoEvent.KeyBackupStatus]) => {
   const mx = useMatrixClient();
 
   useEffect(() => {
@@ -40,7 +38,7 @@ export const useKeyBackupStatus = (crypto: CryptoApi): boolean => {
   return status;
 };
 
-export const useKeyBackupSessionsRemainingChange = (
+const useKeyBackupSessionsRemainingChange = (
   onChange: CryptoEventHandlerMap[CryptoEvent.KeyBackupSessionsRemaining]
 ) => {
   const mx = useMatrixClient();
@@ -53,9 +51,7 @@ export const useKeyBackupSessionsRemainingChange = (
   }, [mx, onChange]);
 };
 
-export const useKeyBackupFailedChange = (
-  onChange: CryptoEventHandlerMap[CryptoEvent.KeyBackupFailed]
-) => {
+const useKeyBackupFailedChange = (onChange: CryptoEventHandlerMap[CryptoEvent.KeyBackupFailed]) => {
   const mx = useMatrixClient();
 
   useEffect(() => {

--- a/src/app/hooks/useMemberFilter.ts
+++ b/src/app/hooks/useMemberFilter.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { RoomMember } from '$types/matrix-sdk';
 import { KnownMembership } from '$types/matrix-sdk';
 
-export const MembershipFilter = {
+const MembershipFilter = {
   filterJoined: (m: RoomMember) => m.membership === KnownMembership.Join,
   filterInvited: (m: RoomMember) => m.membership === KnownMembership.Invite,
   filterLeaved: (m: RoomMember) =>

--- a/src/app/hooks/useMemberSort.ts
+++ b/src/app/hooks/useMemberSort.ts
@@ -1,7 +1,7 @@
 import type { RoomMember } from '$types/matrix-sdk';
 import { useCallback, useMemo } from 'react';
 
-export const MemberSort = {
+const MemberSort = {
   Ascending: (a: RoomMember, b: RoomMember) =>
     a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1,
   Descending: (a: RoomMember, b: RoomMember) =>

--- a/src/app/hooks/useMutationObserver.ts
+++ b/src/app/hooks/useMutationObserver.ts
@@ -2,11 +2,6 @@ import { useEffect, useMemo } from 'react';
 
 export type OnMutationCallback = (mutations: MutationRecord[]) => void;
 
-export const getMutationRecord = (
-  target: Node,
-  mutations: MutationRecord[]
-): MutationRecord | undefined => mutations.find((mutation) => mutation.target === target);
-
 export const useMutationObserver = (
   onMutationCallback: OnMutationCallback,
   observeElement?: Node | null | (() => Node | null),

--- a/src/app/hooks/useParsedLoginFlows.ts
+++ b/src/app/hooks/useParsedLoginFlows.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { ILoginFlow, IPasswordFlow, ISSOFlow, LoginFlow } from '$types/matrix-sdk';
 import { OAUTH_AWARE_PREFERRED_FLOW_FIELD } from '$types/matrix-sdk';
 
-export const getSSOFlow = (loginFlows: LoginFlow[]): ISSOFlow | undefined =>
+const getSSOFlow = (loginFlows: LoginFlow[]): ISSOFlow | undefined =>
   loginFlows.find((flow) => flow.type === 'm.login.sso' || flow.type === 'm.login.cas') as
     | ISSOFlow
     | undefined;
@@ -13,9 +13,9 @@ export const isOauthAwarePreferred = (ssoFlow: ISSOFlow | undefined): boolean =>
     ssoFlow?.[OAUTH_AWARE_PREFERRED_FLOW_FIELD.altName]
   );
 
-export const getPasswordFlow = (loginFlows: LoginFlow[]): IPasswordFlow | undefined =>
+const getPasswordFlow = (loginFlows: LoginFlow[]): IPasswordFlow | undefined =>
   loginFlows.find((flow) => flow.type === 'm.login.password') as IPasswordFlow;
-export const getTokenFlow = (loginFlows: LoginFlow[]): LoginFlow | undefined =>
+const getTokenFlow = (loginFlows: LoginFlow[]): LoginFlow | undefined =>
   loginFlows.find((flow) => flow.type === 'm.login.token') as ILoginFlow & {
     type: 'm.login.token';
   };

--- a/src/app/hooks/usePerMessageProfile.ts
+++ b/src/app/hooks/usePerMessageProfile.ts
@@ -466,27 +466,6 @@ export async function associateProxyWithProfile(
 }
 
 /**
- * get a profile based on a proxy
- * @param mx the matrix client
- * @param proxy the proxy to look for
- * @returns the profile, if any, associated with the prefix
- */
-export async function getProfileAssociatedWithProxy(
-  mx: MatrixClient,
-  proxy: string
-): Promise<PerMessageProfile | undefined> {
-  const profileId = getProxyAssociationMap(
-    mx
-      .getAccountData(
-        `${ACCOUNT_DATA_PREFIX}.proxyassociation` as Parameters<typeof mx.getAccountData>[0]
-      )
-      ?.getContent()
-  ).get(proxy)?.profileId;
-  if (!profileId) return undefined;
-  return getPerMessageProfileById(mx, profileId);
-}
-
-/**
  *
  *
  * @export
@@ -582,13 +561,6 @@ export async function renamePerMessageProfile(mx: MatrixClient, oldId: string, n
   const newProfile = { ...profile, id: newId };
   await addOrUpdatePerMessageProfile(mx, newProfile);
   await deletePerMessageProfile(mx, oldId);
-}
-
-export async function getListOfRoomsUsingProfile(
-  mx: MatrixClient,
-  profileId: string
-): Promise<string[]> {
-  return getRoomsUsingProfile(mx, profileId);
 }
 
 /**

--- a/src/app/hooks/usePowerLevels.ts
+++ b/src/app/hooks/usePowerLevels.ts
@@ -75,7 +75,7 @@ export function usePowerLevels(room: Room): IPowerLevels {
   return powerLevels;
 }
 
-export const PowerLevelsContext = createContext<IPowerLevels | null>(null);
+const PowerLevelsContext = createContext<IPowerLevels | null>(null);
 
 export const PowerLevelsContextProvider = PowerLevelsContext.Provider;
 

--- a/src/app/hooks/usePushRule.ts
+++ b/src/app/hooks/usePushRule.ts
@@ -33,7 +33,7 @@ export const makePushRuleData = (
   },
 });
 
-export const orderedPushRuleKinds: PushRuleKind[] = [
+const orderedPushRuleKinds: PushRuleKind[] = [
   PushRuleKind.Override,
   PushRuleKind.ContentSpecific,
   PushRuleKind.RoomSpecific,
@@ -41,10 +41,7 @@ export const orderedPushRuleKinds: PushRuleKind[] = [
   PushRuleKind.Underride,
 ];
 
-export const getPushRule = (
-  pushRules: IPushRules,
-  ruleId: RuleId | string
-): PushRuleData | undefined => {
+const getPushRule = (pushRules: IPushRules, ruleId: RuleId | string): PushRuleData | undefined => {
   const { global } = pushRules;
 
   let ruleData: PushRuleData | undefined;

--- a/src/app/hooks/useRoomCreators.ts
+++ b/src/app/hooks/useRoomCreators.ts
@@ -6,7 +6,7 @@ import { creatorsSupported } from '$utils/roomSupport';
 import { useStateEvent } from './useStateEvent';
 import { EventType } from '$types/matrix-sdk';
 
-export const getRoomCreators = (createEvent: MatrixEvent): Set<string> => {
+const getRoomCreators = (createEvent: MatrixEvent): Set<string> => {
   const createContent = createEvent.getContent<IRoomCreateContent>();
 
   const creators: Set<string> = new Set();

--- a/src/app/hooks/useRoomMeta.ts
+++ b/src/app/hooks/useRoomMeta.ts
@@ -7,7 +7,7 @@ import { mDirectAtom } from '$state/mDirectList';
 import { useStateEvent } from './useStateEvent';
 import { useNickname } from './useNickname';
 
-export const getRoomDisplayName = (
+const getRoomDisplayName = (
   roomName: string,
   stateName: unknown,
   isDmTagged: boolean,

--- a/src/app/hooks/useRoomsNotificationPreferences.ts
+++ b/src/app/hooks/useRoomsNotificationPreferences.ts
@@ -95,13 +95,6 @@ export const getRoomNotificationMode = (
 
   return RoomNotificationMode.Unset;
 };
-
-export const useRoomNotificationPreference = (
-  preferences: RoomsNotificationPreferences,
-  roomId: string
-): RoomNotificationMode =>
-  useMemo(() => getRoomNotificationMode(preferences, roomId), [preferences, roomId]);
-
 export const roomNotificationModeIcon = (
   mode?: RoomNotificationMode,
   props?: IconProps
@@ -121,7 +114,7 @@ export const roomNotificationModeChipIcon = (mode?: RoomNotificationMode): React
   return chipIcon(Bell);
 };
 
-export const setRoomNotificationPreference = async (
+const setRoomNotificationPreference = async (
   mx: MatrixClient,
   roomId: string,
   mode: RoomNotificationMode,

--- a/src/app/hooks/useScreenSize.ts
+++ b/src/app/hooks/useScreenSize.ts
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useState } from 'react';
 import { useElementSizeObserver } from './useElementSizeObserver';
 
-export const TABLET_BREAKPOINT = 1124;
+const TABLET_BREAKPOINT = 1124;
 export const MOBILE_BREAKPOINT = 750;
 
 export enum ScreenSize {
@@ -10,7 +10,7 @@ export enum ScreenSize {
   Mobile = 'Mobile',
 }
 
-export const getScreenSize = (width: number): ScreenSize => {
+const getScreenSize = (width: number): ScreenSize => {
   if (width > TABLET_BREAKPOINT) return ScreenSize.Desktop;
   if (width > MOBILE_BREAKPOINT) return ScreenSize.Tablet;
   return ScreenSize.Mobile;

--- a/src/app/hooks/useSecretStorage.ts
+++ b/src/app/hooks/useSecretStorage.ts
@@ -5,7 +5,7 @@ import type {
 
 import { useAccountData } from './useAccountData';
 
-export const getSecretStorageKeyEventType = (key: string): string => `m.secret_storage.key.${key}`;
+const getSecretStorageKeyEventType = (key: string): string => `m.secret_storage.key.${key}`;
 
 export const useSecretStorageDefaultKeyId = (): string | undefined => {
   const defaultKeyEvent = useAccountData('m.secret_storage.default_key');

--- a/src/app/hooks/useSlidingSyncActiveRoom.ts
+++ b/src/app/hooks/useSlidingSyncActiveRoom.ts
@@ -30,7 +30,7 @@ const decodeRoomRef = (value: string | undefined): string | undefined => {
   return isRoomId(decoded) || isRoomAlias(decoded) ? decoded : undefined;
 };
 
-export const getRouteRoomRefs = (pathname: string): RouteRoomRefs => {
+const getRouteRoomRefs = (pathname: string): RouteRoomRefs => {
   const homeRoomMatch = matchPath(HOME_ROOM_PATH, pathname);
   const directRoomMatch = matchPath(DIRECT_ROOM_PATH, pathname);
   const nonSpaceRoomMatch = homeRoomMatch ?? directRoomMatch;
@@ -76,7 +76,7 @@ const useAvailableSlidingSyncManager = () => {
   return manager;
 };
 
-export const useSlidingSyncRouteRooms = (): void => {
+const useSlidingSyncRouteRooms = (): void => {
   const manager = useAvailableSlidingSyncManager();
   const { pathname } = useLocation();
   const { roomIdOrAlias, spaceIdOrAlias } = getRouteRoomRefs(pathname);
@@ -98,7 +98,7 @@ export const useSlidingSyncRouteRooms = (): void => {
   }, [manager]);
 };
 
-export const useSlidingSyncSpaceSubscriptions = (): void => {
+const useSlidingSyncSpaceSubscriptions = (): void => {
   const manager = useAvailableSlidingSyncManager();
   const mx = useMatrixClient();
   const spaces = useSpaces(mx, allRoomsAtom);
@@ -112,7 +112,7 @@ export const useSlidingSyncSpaceSubscriptions = (): void => {
 
 // Subscribe pack rooms before the emoji board first opens so their
 // pack state is already available.
-export const useSlidingSyncImagePackSubscriptions = (): void => {
+const useSlidingSyncImagePackSubscriptions = (): void => {
   const manager = useAvailableSlidingSyncManager();
   const mx = useMatrixClient();
 

--- a/src/app/hooks/useUIAFlows.ts
+++ b/src/app/hooks/useUIAFlows.ts
@@ -1,5 +1,4 @@
 import type { IAuthData, MatrixError, UIAFlow } from '$types/matrix-sdk';
-import { AuthType } from '$types/matrix-sdk';
 import { useCallback, useMemo } from 'react';
 import {
   getSupportedUIAFlows,
@@ -10,16 +9,6 @@ import {
   getUIASession,
 } from '$utils/matrix-uia';
 
-export const SUPPORTED_FLOW_TYPES = [
-  AuthType.Dummy,
-  AuthType.Password,
-  AuthType.Email,
-  AuthType.Terms,
-  AuthType.Recaptcha,
-  AuthType.RegistrationToken,
-  AuthType.OAuth,
-] as const;
-
 export const useSupportedUIAFlows = (uiaFlows: UIAFlow[], supportedStages: string[]): UIAFlow[] =>
   useMemo(() => getSupportedUIAFlows(uiaFlows, supportedStages), [uiaFlows, supportedStages]);
 
@@ -29,14 +18,12 @@ export const useUIACompleted = (authData: IAuthData): string[] =>
 export const useUIAParams = (authData: IAuthData) =>
   useMemo(() => getUIAParams(authData), [authData]);
 
-export const useUIASession = (authData: IAuthData) =>
-  useMemo(() => getUIASession(authData), [authData]);
+const useUIASession = (authData: IAuthData) => useMemo(() => getUIASession(authData), [authData]);
 
-export const useUIAErrorCode = (authData: IAuthData) =>
+const useUIAErrorCode = (authData: IAuthData) =>
   useMemo(() => getUIAErrorCode(authData), [authData]);
 
-export const useUIAError = (authData: IAuthData) =>
-  useMemo(() => getUIAError(authData), [authData]);
+const useUIAError = (authData: IAuthData) => useMemo(() => getUIAError(authData), [authData]);
 
 export type StageInfo = Record<string, unknown>;
 export type AuthStageData = {

--- a/src/app/hooks/useVerificationRequest.ts
+++ b/src/app/hooks/useVerificationRequest.ts
@@ -23,7 +23,7 @@ export const useVerificationRequestReceived = (
   }, [mx, onRequest]);
 };
 
-export const useVerificationRequestChange = (
+const useVerificationRequestChange = (
   request: VerificationRequest,
   onChange: VerificationRequestEventHandlerMap[VerificationRequestEvent.Change]
 ) => {
@@ -68,18 +68,6 @@ export const useVerifierShowSas = (
     verifier.on(VerifierEvent.ShowSas, onCallback);
     return () => {
       verifier.removeListener(VerifierEvent.ShowSas, onCallback);
-    };
-  }, [verifier, onCallback]);
-};
-
-export const useVerifierShowReciprocateQr = (
-  verifier: Verifier,
-  onCallback: VerifierEventHandlerMap[VerifierEvent.ShowReciprocateQr]
-) => {
-  useEffect(() => {
-    verifier.on(VerifierEvent.ShowReciprocateQr, onCallback);
-    return () => {
-      verifier.removeListener(VerifierEvent.ShowReciprocateQr, onCallback);
     };
   }, [verifier, onCallback]);
 };

--- a/src/app/keyboard/shortcuts.ts
+++ b/src/app/keyboard/shortcuts.ts
@@ -225,8 +225,8 @@ export const SHORTCUTS: readonly ShortcutDefinition[] = [
   },
 ] as const;
 
-export const SHORTCUT_IDS = new Set<ShortcutId>(SHORTCUTS.map(({ id }) => id));
-export const SHORTCUT_BY_ID = new Map(SHORTCUTS.map((shortcut) => [shortcut.id, shortcut]));
+const SHORTCUT_IDS = new Set<ShortcutId>(SHORTCUTS.map(({ id }) => id));
+const SHORTCUT_BY_ID = new Map(SHORTCUTS.map((shortcut) => [shortcut.id, shortcut]));
 
 export const getShortcutBinding = (id: ShortcutId, overrides: ShortcutOverrides): string | null => {
   const override = overrides[id];

--- a/src/app/pages/auth/login/loginUtil.ts
+++ b/src/app/pages/auth/login/loginUtil.ts
@@ -23,7 +23,7 @@ import { autoDiscovery, specVersions } from '../../../cs-api';
 const log = createLogger('loginUtil');
 const debugLog = createDebugLogger('loginUtil');
 
-export enum GetBaseUrlError {
+enum GetBaseUrlError {
   NotAllow = 'NotAllow',
   NotFound = 'NotFound',
 }

--- a/src/app/pages/auth/login/oidcLoginUtil.ts
+++ b/src/app/pages/auth/login/oidcLoginUtil.ts
@@ -54,7 +54,7 @@ export const persistOauthContext = (state: string, ctx: OauthLoginContext): void
   sessionStorage.setItem(oauthContextKey(state), JSON.stringify(ctx));
 };
 
-export const consumeOauthContext = (state: string): OauthLoginContext | undefined => {
+const consumeOauthContext = (state: string): OauthLoginContext | undefined => {
   const key = oauthContextKey(state);
   const raw = sessionStorage.getItem(key);
   if (!raw) return undefined;
@@ -137,7 +137,7 @@ export const expiresInMsFromToken = (token: BearerTokenResponse): number | undef
   return undefined;
 };
 
-export const requireRefreshToken = (token: BearerTokenResponse): string => {
+const requireRefreshToken = (token: BearerTokenResponse): string => {
   if (!token.refresh_token) {
     throw new OidcLoginFailure(OidcLoginError.MissingRefreshToken);
   }

--- a/src/app/pages/client/SidebarNav.tsx
+++ b/src/app/pages/client/SidebarNav.tsx
@@ -1,7 +1,8 @@
 import type { MouseEventHandler } from 'react';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { Box, Checkbox, config, Line, Menu, MenuItem, Scroll, Text, toRem } from 'folds';
 import { ResponsiveMenu } from '$components/ResponsiveMenu';
+import { useMenuAnchor } from '$hooks/useMenuAnchor';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { Sidebar, SidebarContent, SidebarStack } from '$components/sidebar';
@@ -14,7 +15,7 @@ import { UserMenuTab } from './sidebar/UserMenuTab';
 
 export function SidebarNav() {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [menuAnchor, setMenuAnchor] = useState<DOMRect>();
+  const sidebarMenu = useMenuAnchor<HTMLDivElement>();
 
   const [uniformIcons, setUniformIcons] = useSetting(settingsAtom, 'uniformIcons');
   const [showUnreadCounts, setShowUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
@@ -29,22 +30,20 @@ export function SidebarNav() {
   const width = roomSidebarWidth + 66;
   const isCollapsed = compact ? false : width < 190 + 66;
 
-  const handleContextMenu: MouseEventHandler<HTMLDivElement> = (evt) => {
+  const handleSidebarContextMenu: MouseEventHandler<HTMLDivElement> = (evt) => {
     const target = evt.target as HTMLElement;
     if (target.closest('button, a, [role="button"]')) return;
-    evt.preventDefault();
-    const cords = new DOMRect(evt.clientX, evt.clientY, 0, 0);
-    setMenuAnchor((current) => (current ? undefined : cords));
+    sidebarMenu.triggerProps.onContextMenu(evt);
   };
 
   return (
     <>
-      <Sidebar onContextMenu={handleContextMenu}>
+      <Sidebar onContextMenu={handleSidebarContextMenu}>
         <ResponsiveMenu
-          anchor={menuAnchor}
+          anchor={sidebarMenu.anchor}
           position="Right"
           align="Start"
-          requestClose={() => setMenuAnchor(undefined)}
+          requestClose={sidebarMenu.close}
           menu={
             <Menu style={{ maxWidth: toRem(208), width: '100vw' }}>
               <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>

--- a/src/app/pages/client/explore/Explore.tsx
+++ b/src/app/pages/client/explore/Explore.tsx
@@ -57,7 +57,7 @@ type AddServerProps = {
   onAddServer: (server: string) => Promise<boolean>;
 };
 
-export function AddServer({ hideText, onAddServer }: AddServerProps) {
+function AddServer({ hideText, onAddServer }: AddServerProps) {
   const mx = useMatrixClient();
   const navigate = useNavigate();
   const [dialog, setDialog] = useState(false);

--- a/src/app/pages/client/inbox/Invites.tsx
+++ b/src/app/pages/client/inbox/Invites.tsx
@@ -106,7 +106,7 @@ export type InviteData = {
   isEncrypted: boolean;
 };
 
-export const makeInviteData = (
+const makeInviteData = (
   mx: MatrixClient,
   room: Room,
   useAuthentication: boolean,
@@ -394,7 +394,7 @@ function InviteCard({
   );
 }
 
-export enum InviteFilter {
+enum InviteFilter {
   Known,
   Unknown,
   Spam,

--- a/src/app/pages/client/sidebar/SpaceTabs.tsx
+++ b/src/app/pages/client/sidebar/SpaceTabs.tsx
@@ -2,7 +2,6 @@ import type { FormEventHandler, MouseEventHandler, ReactNode, RefObject, ChangeE
 import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
-import type { RectCords } from 'folds';
 import {
   Box,
   Button,
@@ -100,6 +99,7 @@ import { useMobileTapActivation } from '$hooks/useMobileTapActivation';
 import { ModalOverlay } from '$components/modal-overlay/ModalOverlay';
 import { useOpenRoomSettings } from '$state/hooks/roomSettings';
 import { ResponsiveMenu } from '$components/ResponsiveMenu';
+import { useMenuAnchor } from '$hooks/useMenuAnchor';
 
 type SpaceMenuProps = {
   room: Room;
@@ -561,16 +561,7 @@ function SpaceTab({
   const dropState = useDropTarget(spaceDraggable, targetRef, !isMobile);
   const dropType = dropState?.type;
 
-  const [menuAnchor, setMenuAnchor] = useState<RectCords>();
-
-  const handleContextMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
-    evt.preventDefault();
-    const cords = evt.currentTarget.getBoundingClientRect();
-    setMenuAnchor((currentState) => {
-      if (currentState) return undefined;
-      return cords;
-    });
-  };
+  const menu = useMenuAnchor<HTMLButtonElement>();
 
   return (
     <RoomUnreadProvider roomId={space.roomId}>
@@ -591,7 +582,11 @@ function SpaceTab({
                 data-id={space.roomId}
                 ref={triggerRef}
                 size={folder ? '300' : '400'}
-                onContextMenu={handleContextMenu}
+                onContextMenu={menu.triggerProps.onContextMenu}
+                onTouchStart={menu.triggerProps.onTouchStart}
+                onTouchEnd={menu.triggerProps.onTouchEnd}
+                onTouchMove={menu.triggerProps.onTouchMove}
+                onTouchCancel={menu.triggerProps.onTouchCancel}
                 {...mobileTapActivation}
               >
                 <SpaceAvatar
@@ -610,17 +605,11 @@ function SpaceTab({
             />
           )}
           <ResponsiveMenu
-            anchor={menuAnchor}
+            anchor={menu.anchor}
             position="Right"
             align="Start"
-            requestClose={() => setMenuAnchor(undefined)}
-            menu={
-              <SpaceMenu
-                room={space}
-                requestClose={() => setMenuAnchor(undefined)}
-                onUnpin={onUnpin}
-              />
-            }
+            requestClose={menu.close}
+            menu={<SpaceMenu room={space} requestClose={menu.close} onUnpin={onUnpin} />}
           />
         </SidebarItemLeft>
       )}
@@ -770,22 +759,18 @@ export function SpaceTabs({ scrollRef }: Readonly<SpaceTabsProps>) {
   const [openedFolder, setOpenedFolder] = useAtom(useOpenedSidebarFolderAtom());
   const setLastSpaceId = useSetAtom(lastVisitedSpaceIdAtom);
   const [draggingItem, setDraggingItem] = useState<SidebarDraggable>();
-  const [folderMenuState, setFolderMenuState] = useState<{
-    folder: ISidebarFolder;
-    anchor: RectCords;
-  }>();
+  const folderMenu = useMenuAnchor<HTMLDivElement>();
+  const [folderMenuTarget, setFolderMenuTarget] = useState<ISidebarFolder>();
   const [renameTargetFolder, setRenameTargetFolder] = useState<ISidebarFolder>();
 
   const handleFolderContextMenu = useCallback(
     (folder: ISidebarFolder): MouseEventHandler =>
       (evt) => {
         evt.preventDefault();
-        setFolderMenuState({
-          folder,
-          anchor: evt.currentTarget.getBoundingClientRect(),
-        });
+        setFolderMenuTarget(folder);
+        folderMenu.openAt(evt.currentTarget as HTMLElement);
       },
-    []
+    [folderMenu]
   );
 
   const handleRenameFolderApply = useCallback(
@@ -980,15 +965,21 @@ export function SpaceTabs({ scrollRef }: Readonly<SpaceTabsProps>) {
   return (
     <>
       <ResponsiveMenu
-        anchor={folderMenuState?.anchor}
+        anchor={folderMenu.anchor}
         position="Right"
         align="Start"
-        requestClose={() => setFolderMenuState(undefined)}
+        requestClose={() => {
+          folderMenu.close();
+          setFolderMenuTarget(undefined);
+        }}
         menu={
-          folderMenuState && (
+          folderMenuTarget && (
             <FolderMenu
-              requestClose={() => setFolderMenuState(undefined)}
-              onRename={() => setRenameTargetFolder(folderMenuState.folder)}
+              requestClose={() => {
+                folderMenu.close();
+                setFolderMenuTarget(undefined);
+              }}
+              onRename={() => setRenameTargetFolder(folderMenuTarget)}
             />
           )
         }

--- a/src/app/pages/client/sidebar/useSidebarDirectRoomIds.ts
+++ b/src/app/pages/client/sidebar/useSidebarDirectRoomIds.ts
@@ -10,7 +10,7 @@ import { factoryRoomIdByActivity } from '$utils/sort';
 import { useSyncState } from '$hooks/useSyncState';
 
 /** Maximum number of individual DM avatars shown in the sidebar. */
-export const MAX_SIDEBAR_DMS = 3;
+const MAX_SIDEBAR_DMS = 3;
 
 /**
  * Returns the room IDs of DMs currently displayed as individual avatars in the

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -421,7 +421,7 @@ function SpaceHeader({ hideText, mx }: { hideText?: boolean; mx: MatrixClient })
 }
 
 type SpaceTombstoneProps = { roomId: string; replacementRoomId: string };
-export function SpaceTombstone({ roomId, replacementRoomId }: SpaceTombstoneProps) {
+function SpaceTombstone({ roomId, replacementRoomId }: SpaceTombstoneProps) {
   const mx = useMatrixClient();
   const { navigateSpace } = useRoomNavigate();
 

--- a/src/app/pages/client/space/styles.css.ts
+++ b/src/app/pages/client/space/styles.css.ts
@@ -40,11 +40,6 @@ export const RoomCover = style({
   overflow: 'hidden',
 });
 
-export const RoomCoverFallback = style({
-  filter: 'blur(16px) brightness(50%)',
-  transform: 'scale(2)',
-});
-
 export const RoomCoverImage = style({
   objectFit: 'cover',
   width: '100%',

--- a/src/app/pages/pathUtils.ts
+++ b/src/app/pages/pathUtils.ts
@@ -21,7 +21,6 @@ import {
   INBOX_PATH,
   REGISTER_PATH,
   RESET_PASSWORD_PATH,
-  ROOT_PATH,
   SETTINGS_PATH,
   SPACE_LOBBY_PATH,
   SPACE_PATH,
@@ -81,8 +80,6 @@ export const getAppPathFromHref = (baseUrl: string, href: string): string => {
   const { pathname, search } = new URL(href);
   return pathname + search;
 };
-
-export const getRootPath = (): string => ROOT_PATH;
 
 export const getLoginPath = (server?: string): string => {
   const params = server ? { server: encodeURIComponent(server) } : undefined;

--- a/src/app/pages/paths.ts
+++ b/src/app/pages/paths.ts
@@ -94,15 +94,11 @@ export const INBOX_NOTIFICATIONS_PATH = `/inbox/${NOTIFICATIONS_PATH_SEGMENT}`;
 export const INBOX_INVITES_PATH = `/inbox/${INVITES_PATH_SEGMENT}`;
 export const INBOX_BOOKMARKS_PATH = `/inbox/${BOOKMARKS_PATH_SEGMENT}`;
 
-export const TO_PATH = '/to';
+const TO_PATH = '/to';
 // Deep-link route used by push notification click-back URLs.
 // Format: /to/:user_id/:room_id/:event_id?
 // e.g.  /to/%40alice%3Aserver/%21room%3Aserver/%24event%3Aserver
 export const TO_ROOM_EVENT_PATH = `${TO_PATH}/:user_id/:room_id/:event_id?`;
-
-export const SPACE_SETTINGS_PATH = '/space-settings/';
-
-export const ROOM_SETTINGS_PATH = '/room-settings/';
 
 export const SSO_CALLBACK_PATH = '/lp/sso-callback';
 export const SETTINGS_PATH = '/settings/:section?/';

--- a/src/app/plugins/arborium/index.ts
+++ b/src/app/plugins/arborium/index.ts
@@ -4,7 +4,6 @@ export { ArboriumThemeBridge, useArboriumThemeStatus } from './ArboriumThemeBrid
 export {
   DEFAULT_ARBORIUM_DARK_THEME,
   DEFAULT_ARBORIUM_LIGHT_THEME,
-  getArboriumThemeHref,
   getArboriumThemeLabel,
   getArboriumThemeOptions,
 } from './themes';

--- a/src/app/plugins/bad-words.ts
+++ b/src/app/plugins/bad-words.ts
@@ -7,7 +7,7 @@ const fullBadWordList = additionalBadWords.concat(
   badWords.array.filter((word) => !additionalBadWords.includes(word))
 );
 
-export const BAD_WORDS_REGEX = new RegExp(
+const BAD_WORDS_REGEX = new RegExp(
   `(\\b|_)(${fullBadWordList.map((word) => sanitizeForRegex(word)).join('|')})(\\b|_)`,
   'g'
 );

--- a/src/app/plugins/call/hooks.ts
+++ b/src/app/plugins/call/hooks.ts
@@ -1,9 +1,5 @@
-import type {
-  ClientWidgetApi,
-  IWidgetApiAcknowledgeResponseData,
-  IWidgetApiRequestData,
-} from 'matrix-widget-api';
-import { useCallback, useEffect, useState } from 'react';
+import type { ClientWidgetApi } from 'matrix-widget-api';
+import { useEffect, useState } from 'react';
 import type { CallControl } from './CallControl';
 import { CallControlEvent } from './CallControl';
 import type { CallControlState } from './CallControlState';
@@ -19,18 +15,6 @@ export const useClientWidgetApiEvent = <T>(
       api?.off(`action:${type}`, callback);
     };
   }, [api, type, callback]);
-};
-
-export const useSendClientWidgetApiAction = (api: ClientWidgetApi) => {
-  const sendWidgetAction = useCallback(
-    async (
-      action: string,
-      data: IWidgetApiRequestData
-    ): Promise<IWidgetApiAcknowledgeResponseData> => api.transport.send(action, data),
-    [api]
-  );
-
-  return sendWidgetAction;
 };
 
 export const useCallControlState = (control: CallControl): CallControlState => {

--- a/src/app/plugins/custom-emoji/utils.ts
+++ b/src/app/plugins/custom-emoji/utils.ts
@@ -29,7 +29,7 @@ export function packMetaEqual(a: PackMetaReader, b: PackMetaReader): boolean {
   );
 }
 
-export function makeImagePacks(packEvents: MatrixEvent[]): ImagePack[] {
+function makeImagePacks(packEvents: MatrixEvent[]): ImagePack[] {
   return packEvents.reduce<ImagePack[]>((imagePacks, packEvent) => {
     const packId = packEvent.getId();
     if (!packId) return imagePacks;

--- a/src/app/plugins/emoji.ts
+++ b/src/app/plugins/emoji.ts
@@ -25,7 +25,7 @@ export type IEmojiGroup = {
   emojis: IEmoji[];
 };
 
-export const getShortcodesFor = (hexcode: string): string[] | string | undefined =>
+const getShortcodesFor = (hexcode: string): string[] | string | undefined =>
   joypixels[hexcode] || emojibase[hexcode];
 
 export const getShortcodeFor = (hexcode: string): string | undefined => {

--- a/src/app/plugins/markdown/allowedHtmlTags.ts
+++ b/src/app/plugins/markdown/allowedHtmlTags.ts
@@ -38,7 +38,7 @@ export const MARKDOWN_ALLOWED_HTML_TAGS = new Set([
 ]);
 
 /** Void elements that do not require a separate closing tag. */
-export const VOID_HTML_TAGS = new Set(['br', 'hr', 'img']);
+const VOID_HTML_TAGS = new Set(['br', 'hr', 'img']);
 
 export const isAllowedHtmlTag = (tagName: string): boolean =>
   MARKDOWN_ALLOWED_HTML_TAGS.has(tagName.toLowerCase());

--- a/src/app/plugins/markdown/extensions/matrix-math.ts
+++ b/src/app/plugins/markdown/extensions/matrix-math.ts
@@ -1,14 +1,14 @@
 import type { TokenizerExtension, RendererExtension } from 'marked';
 
 /** Private-use char so math extensions do not match `$` / `$$` inside code spans. Not U+E000–U+E002 (emoticon placeholders). {@link shieldDollarRunsForMarked} uses U+E021–U+E022. */
-export const MATH_CODE_DOLLAR_MASK = '\uE020';
+const MATH_CODE_DOLLAR_MASK = '\uE020';
 
 /**
  * Replaces the `-` of line-start `-# …` inside markdown code so the Matrix subscript block
  * extension does not match before marked's `fences` rule (custom block extensions run first).
  * {@link unmaskSubscriptCodeLinePlaceholders} restores output HTML.
  */
-export const SUBSCRIPT_CODE_LINE_MASK = '\uE023';
+const SUBSCRIPT_CODE_LINE_MASK = '\uE023';
 
 function maskSubscriptLineStartsInCodeInner(inner: string): string {
   return inner.replace(/(^|\n)-#( +)/g, `$1${SUBSCRIPT_CODE_LINE_MASK}#$2`);

--- a/src/app/plugins/markdown/utils.ts
+++ b/src/app/plugins/markdown/utils.ts
@@ -13,7 +13,7 @@ const CAP_INLINE_SEQ = `${URL_NEG_LB}${INLINE_SEQUENCE_SET}`;
  * @param text - The input markdown plain-text containing escape characters (e.g., `"some \*italic\*"`)
  * @returns The plain-text with markdown escape sequences removed (e.g., `"some *italic*"`)
  */
-export const unescapeMarkdownInlineSequences = (text: string): string => {
+const unescapeMarkdownInlineSequences = (text: string): string => {
   const escapePattern = new RegExp(`${URL_NEG_LB}\\\\(${INLINE_SEQUENCE_SET})`, 'g');
   const parts = findAndReplace(
     text,

--- a/src/app/plugins/matrix-to.ts
+++ b/src/app/plugins/matrix-to.ts
@@ -141,7 +141,7 @@ const tryDecodeUriComponent = (s: string): string => {
 /**
  * Normalized Matrix permalink fragment (path after `#/`, lowercased), for comparing href vs anchor text.
  */
-export const matrixPermalinkFragmentKey = (url: string): string | undefined => {
+const matrixPermalinkFragmentKey = (url: string): string | undefined => {
   const trimmed = url.trim();
   const decoded = tryDecodeUriComponent(trimmed);
   const candidate = testMatrixTo(trimmed) ? trimmed : testMatrixTo(decoded) ? decoded : undefined;

--- a/src/app/state/callEmbed.ts
+++ b/src/app/state/callEmbed.ts
@@ -74,7 +74,6 @@ export type AutoJoinCallIntent = {
 };
 
 export const incomingCallAtom = atom<IncomingCall | null>(null);
-export const incomingCallRoomIdAtom = atom((get) => get(incomingCallAtom)?.roomId ?? null);
 export const autoJoinCallIntentAtom = atom<AutoJoinCallIntent | null>(null);
 export const mutedCallRoomIdAtom = atom<string | null>(null);
 export const callSoundBlockedAtom = atom(false);

--- a/src/app/state/closedLobbyCategories.ts
+++ b/src/app/state/closedLobbyCategories.ts
@@ -9,5 +9,3 @@ export const makeClosedLobbyCategoriesAtom = (userId: string): ClosedLobbyCatego
   makeStringSetAtom(`${CLOSED_LOBBY_CATEGORY}${userId}`);
 
 export const makeLobbyCategoryId = (...args: string[]): string => args.join('|');
-
-export const getLobbyCategoryIdParts = (categoryId: string): string[] => categoryId.split('|');

--- a/src/app/state/closedNavCategories.ts
+++ b/src/app/state/closedNavCategories.ts
@@ -9,6 +9,3 @@ export const makeClosedNavCategoriesAtom = (userId: string): ClosedNavCategories
   makeStringSetAtom(`${CLOSED_NAV_CATEGORY}${userId}`);
 
 export const makeNavCategoryId = (...args: string[]): string => args.join('|');
-
-export const getNavCategoryIdParts = (categoryId: string): [string, string] =>
-  categoryId.split('|') as [string, string];

--- a/src/app/state/debugLogger.ts
+++ b/src/app/state/debugLogger.ts
@@ -25,19 +25,9 @@ export const debugLoggerEnabledAtom = atom(
 );
 
 /**
- * Atom for filtered logs
- */
-export const filteredDebugLogsAtom = atom((get) => get(debugLogsAtom));
-
-/**
  * Action to clear all debug logs
  */
 export const clearDebugLogsAtom = atom(null, (_, set) => {
   debugLogger.clear();
   set(debugLogsAtom);
 });
-
-/**
- * Action to export debug logs
- */
-export const exportDebugLogsAtom = atom(null, () => debugLogger.exportLogs());

--- a/src/app/state/desktopSettings.ts
+++ b/src/app/state/desktopSettings.ts
@@ -33,7 +33,7 @@ export function desktopSettingsDefaultsForPlatform(platform: DesktopPlatform): D
 }
 export type DesktopSettingKey = keyof DesktopSettings;
 
-export const DEFAULT_DESKTOP_RUNTIME_STATE: DesktopRuntimeState = {
+const DEFAULT_DESKTOP_RUNTIME_STATE: DesktopRuntimeState = {
   trayAvailable: true,
 };
 

--- a/src/app/state/hooks/desktopSettings.ts
+++ b/src/app/state/hooks/desktopSettings.ts
@@ -26,7 +26,7 @@ function resolveDesktopSettingValue<K extends DesktopSettingKey>(
   return value;
 }
 
-export const useSetDesktopSetting = <K extends DesktopSettingKey>(key: K) => {
+const useSetDesktopSetting = <K extends DesktopSettingKey>(key: K) => {
   const setterAtom = useMemo(
     () =>
       atom<null, [DesktopSettingSetter<K>], Promise<void>>(null, (get, set, value) => {

--- a/src/app/state/hooks/roomList.ts
+++ b/src/app/state/hooks/roomList.ts
@@ -3,19 +3,19 @@ import { useAtomValue } from 'jotai';
 import { selectAtom } from 'jotai/utils';
 import type { MatrixClient } from '$types/matrix-sdk';
 import { useCallback, useMemo } from 'react';
-import { getAllParents, isRoom, isSpace, isUnsupportedRoom } from '$utils/room';
+import { getAllParents, isRoom, isSpace } from '$utils/room';
 import type { RoomToParents } from '$types/matrix/room';
 import { compareRoomsEqual } from '$state/room-list/utils';
 
 export type RoomsAtom = Atom<string[]>;
 export type RoomSelector = (roomId: string) => boolean | undefined;
 
-export const selectedRoomsAtom = (
+const selectedRoomsAtom = (
   roomsAtom: RoomsAtom,
   selector: (roomId: string) => boolean | undefined
 ) => selectAtom(roomsAtom, (rooms) => rooms.filter(selector), compareRoomsEqual);
 
-export const useSelectedRooms = (roomsAtom: RoomsAtom, selector: RoomSelector) => {
+const useSelectedRooms = (roomsAtom: RoomsAtom, selector: RoomSelector) => {
   const anAtom = useMemo(() => selectedRoomsAtom(roomsAtom, selector), [roomsAtom, selector]);
 
   return useAtomValue(anAtom);
@@ -35,16 +35,6 @@ export const useRecursiveChildScopeFactory = (
     [mx, roomToParents]
   );
 
-export const useChildSpaceScopeFactory = (
-  mx: MatrixClient,
-  roomToParents: RoomToParents
-): SpaceChildSelectorFactory =>
-  useCallback(
-    (parentId: string) => (roomId) =>
-      isSpace(mx.getRoom(roomId)) && roomToParents.get(roomId)?.has(parentId),
-    [mx, roomToParents]
-  );
-
 export const useRecursiveChildSpaceScopeFactory = (
   mx: MatrixClient,
   roomToParents: RoomToParents
@@ -57,19 +47,6 @@ export const useRecursiveChildSpaceScopeFactory = (
     [mx, roomToParents]
   );
 
-export const useChildRoomScopeFactory = (
-  mx: MatrixClient,
-  mDirects: Set<string>,
-  roomToParents: RoomToParents
-): SpaceChildSelectorFactory =>
-  useCallback(
-    (parentId: string) => (roomId) =>
-      isRoom(mx.getRoom(roomId)) &&
-      !mDirects.has(roomId) &&
-      roomToParents.get(roomId)?.has(parentId),
-    [mx, mDirects, roomToParents]
-  );
-
 export const useRecursiveChildRoomScopeFactory = (
   mx: MatrixClient,
   mDirects: Set<string>,
@@ -79,33 +56,6 @@ export const useRecursiveChildRoomScopeFactory = (
     (parentId: string) => (roomId) =>
       isRoom(mx.getRoom(roomId)) &&
       !mDirects.has(roomId) &&
-      roomToParents.has(roomId) &&
-      getAllParents(roomToParents, roomId).has(parentId),
-    [mx, mDirects, roomToParents]
-  );
-
-export const useChildDirectScopeFactory = (
-  mx: MatrixClient,
-  mDirects: Set<string>,
-  roomToParents: RoomToParents
-): SpaceChildSelectorFactory =>
-  useCallback(
-    (parentId: string) => (roomId) =>
-      isRoom(mx.getRoom(roomId)) &&
-      mDirects.has(roomId) &&
-      roomToParents.get(roomId)?.has(parentId),
-    [mx, mDirects, roomToParents]
-  );
-
-export const useRecursiveChildDirectScopeFactory = (
-  mx: MatrixClient,
-  mDirects: Set<string>,
-  roomToParents: RoomToParents
-): SpaceChildSelectorFactory =>
-  useCallback(
-    (parentId: string) => (roomId) =>
-      isRoom(mx.getRoom(roomId)) &&
-      mDirects.has(roomId) &&
       roomToParents.has(roomId) &&
       getAllParents(roomToParents, roomId).has(parentId),
     [mx, mDirects, roomToParents]
@@ -169,14 +119,6 @@ export const useDirects = (mx: MatrixClient, roomsAtom: RoomsAtom, mDirects: Set
   const selector: RoomSelector = useCallback(
     (roomId) => isRoom(mx.getRoom(roomId)) && mDirects.has(roomId),
     [mx, mDirects]
-  );
-  return useSelectedRooms(roomsAtom, selector);
-};
-
-export const useUnsupportedRooms = (mx: MatrixClient, roomsAtom: RoomsAtom) => {
-  const selector: RoomSelector = useCallback(
-    (roomId) => isUnsupportedRoom(mx.getRoom(roomId)),
-    [mx]
   );
   return useSelectedRooms(roomsAtom, selector);
 };

--- a/src/app/state/hooks/settings.ts
+++ b/src/app/state/hooks/settings.ts
@@ -14,7 +14,7 @@ export type ResolvedHiddenEventSettings = {
   hiddenEventOther: boolean;
 };
 
-export const resolveHiddenEventSettings = (settings: Settings): ResolvedHiddenEventSettings => {
+const resolveHiddenEventSettings = (settings: Settings): ResolvedHiddenEventSettings => {
   const { showHiddenEvents } = settings;
   return {
     showHiddenEvents,
@@ -29,7 +29,7 @@ export const resolveHiddenEventSettings = (settings: Settings): ResolvedHiddenEv
   };
 };
 
-export const isResolvedHiddenEventSettingsEqual = (
+const isResolvedHiddenEventSettingsEqual = (
   a: ResolvedHiddenEventSettings,
   b: ResolvedHiddenEventSettings
 ): boolean =>

--- a/src/app/state/nativeNotificationReplies.ts
+++ b/src/app/state/nativeNotificationReplies.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai';
 
-export const NATIVE_REPLY_MAX = 8;
+const NATIVE_REPLY_MAX = 8;
 export const NATIVE_REPLY_EXPIRY_MS = 120_000;
 export type NativeNotificationReply = {
   key: string;

--- a/src/app/state/nicknames.ts
+++ b/src/app/state/nicknames.ts
@@ -2,8 +2,6 @@ import { atom } from 'jotai';
 import type { MatrixClient } from '$types/matrix-sdk';
 import { CustomAccountDataEvent } from '$types/matrix/accountData';
 
-export const NICKNAMES_KEY = 'sableNicknames';
-
 export type Nicknames = Record<string, string>;
 
 export const nicknamesAtom = atom<Nicknames>({});

--- a/src/app/state/room/roomToUnread.ts
+++ b/src/app/state/room/roomToUnread.ts
@@ -40,7 +40,7 @@ export type RoomToUnreadAction =
       roomId: string;
     };
 
-export const unreadInfoToUnread = (unreadInfo: UnreadInfo): Unread => ({
+const unreadInfoToUnread = (unreadInfo: UnreadInfo): Unread => ({
   highlight: unreadInfo.highlight,
   total: unreadInfo.total,
   from: null,

--- a/src/app/state/sessions.ts
+++ b/src/app/state/sessions.ts
@@ -60,7 +60,7 @@ export function setFallbackSession(
   localStorage.setItem('cinny_hs_base_url', baseUrl);
   notifySessionChanged();
 }
-export const removeFallbackSession = () => {
+const removeFallbackSession = () => {
   localStorage.removeItem('cinny_hs_base_url');
   localStorage.removeItem('cinny_user_id');
   localStorage.removeItem('cinny_device_id');

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -46,7 +46,7 @@ export type JumboEmojiSize = 'none' | 'extraSmall' | 'small' | 'normal' | 'large
 
 /** Reorderable inline trigger buttons in the message composer. */
 export type EditorButtonId = 'gif' | 'sticker' | 'emoji';
-export const EDITOR_BUTTON_ORDER_DEFAULT: EditorButtonId[] = ['gif', 'sticker', 'emoji'];
+const EDITOR_BUTTON_ORDER_DEFAULT: EditorButtonId[] = ['gif', 'sticker', 'emoji'];
 const EDITOR_BUTTON_ORDER_VALUES = new Set<EditorButtonId>(EDITOR_BUTTON_ORDER_DEFAULT);
 export const CALL_TONE_IDS = [
   'sable-default',
@@ -788,7 +788,7 @@ export function resetRuntimeSettingsDefaults(): void {
   runtimeSettingsDefaults = {};
 }
 
-export const baseSettings = atom<Settings>(cloneDefaultSettings());
+const baseSettings = atom<Settings>(cloneDefaultSettings());
 
 export function bootstrapSettingsStore(store: Store, rawSettingsDefaults: unknown): void {
   const sanitized = sanitizeSettingsDefaults(rawSettingsDefaults);

--- a/src/app/theme/cache.ts
+++ b/src/app/theme/cache.ts
@@ -107,7 +107,7 @@ function getDb(): Promise<IDBDatabase> {
   return pending;
 }
 
-export async function hashThemeCss(cssText: string): Promise<string> {
+async function hashThemeCss(cssText: string): Promise<string> {
   try {
     const bytes = new TextEncoder().encode(cssText);
     const digest = await crypto.subtle.digest('SHA-256', bytes);
@@ -123,7 +123,7 @@ export async function hashThemeCss(cssText: string): Promise<string> {
   }
 }
 
-export async function getCachedThemeEntry(url: string): Promise<CachedThemeEntry | undefined> {
+async function getCachedThemeEntry(url: string): Promise<CachedThemeEntry | undefined> {
   const db = await getDb();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE, 'readonly');
@@ -218,71 +218,4 @@ export async function revalidateCachedThemeCss(
       error: error instanceof Error ? error.message : 'Theme update check failed.',
     };
   }
-}
-
-export async function clearThemeCache(): Promise<void> {
-  const db = await getDb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE, 'readwrite');
-    tx.objectStore(STORE).clear();
-    tx.addEventListener('complete', () => resolve());
-    tx.addEventListener('error', () => reject(tx.error));
-  });
-}
-
-export async function getThemeCacheStats(): Promise<ThemeCacheStats> {
-  const db = await getDb();
-  const entries = await new Promise<CachedThemeEntry[]>((resolve, reject) => {
-    const tx = db.transaction(STORE, 'readonly');
-    const req = tx.objectStore(STORE).getAll();
-    req.addEventListener('error', () => reject(req.error));
-    req.addEventListener('success', () => resolve(req.result as CachedThemeEntry[]));
-  });
-  const stats: ThemeCacheStats = {
-    entries: entries.length,
-    localEntries: 0,
-    remoteEntries: 0,
-    totalBytes: 0,
-    localBytes: 0,
-    remoteBytes: 0,
-  };
-  entries.forEach((entry) => {
-    const bytes = new TextEncoder().encode(entry.cssText).byteLength;
-    const local = entry.url.startsWith('sable-import://');
-    stats.totalBytes += bytes;
-    if (local) {
-      stats.localEntries += 1;
-      stats.localBytes += bytes;
-    } else {
-      stats.remoteEntries += 1;
-      stats.remoteBytes += bytes;
-      const checkedAt = entry.checkedAt ?? entry.cachedAt;
-      if (!stats.lastCheckedAt || checkedAt > stats.lastCheckedAt) stats.lastCheckedAt = checkedAt;
-    }
-  });
-  return stats;
-}
-
-/** Clears only refetchable network CSS. Uploaded local theme packages are preserved. */
-export async function clearRemoteThemeCache(): Promise<number> {
-  const db = await getDb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE, 'readwrite');
-    const store = tx.objectStore(STORE);
-    const req = store.openCursor();
-    let removed = 0;
-    req.addEventListener('error', () => reject(req.error));
-    req.addEventListener('success', () => {
-      const cursor = req.result;
-      if (!cursor) return;
-      const entry = cursor.value as CachedThemeEntry;
-      if (!entry.url.startsWith('sable-import://')) {
-        cursor.delete();
-        removed += 1;
-      }
-      cursor.continue();
-    });
-    tx.addEventListener('complete', () => resolve(removed));
-    tx.addEventListener('error', () => reject(tx.error));
-  });
 }

--- a/src/app/theme/catalog.ts
+++ b/src/app/theme/catalog.ts
@@ -189,11 +189,3 @@ export async function listThemePairsFromCatalog(
   const bundle = await fetchThemeCatalogBundle(baseUrl, options);
   return bundle.themes;
 }
-
-export async function listTweakEntriesFromCatalog(
-  baseUrl: string,
-  options?: ListThemeCatalogOptions
-): Promise<TweakCatalogEntry[]> {
-  const bundle = await fetchThemeCatalogBundle(baseUrl, options);
-  return bundle.tweaks;
-}

--- a/src/app/theme/legacyToCatalogMap.ts
+++ b/src/app/theme/legacyToCatalogMap.ts
@@ -2,7 +2,7 @@ import { REMOTE_THEME_ID } from '$hooks/useTheme';
 import type { Settings } from '$state/settings';
 import { trimTrailingSlash } from '$utils/common';
 
-export const BUILTIN_THEME_IDS = new Set(['light-theme', 'dark-theme']);
+const BUILTIN_THEME_IDS = new Set(['light-theme', 'dark-theme']);
 
 export function isLegacyThemeId(themeId: string | undefined): boolean {
   if (!themeId || themeId.trim() === '') return false;

--- a/src/app/theme/localImportUrls.ts
+++ b/src/app/theme/localImportUrls.ts
@@ -1,5 +1,5 @@
-export const SABLE_LOCAL_THEME_PREFIX = 'sable-import://theme/';
-export const SABLE_LOCAL_TWEAK_PREFIX = 'sable-import://tweak/';
+const SABLE_LOCAL_THEME_PREFIX = 'sable-import://theme/';
+const SABLE_LOCAL_TWEAK_PREFIX = 'sable-import://tweak/';
 
 export function isLocalImportThemeUrl(url: string): boolean {
   return url.startsWith(SABLE_LOCAL_THEME_PREFIX);

--- a/src/app/utils/androidBack.ts
+++ b/src/app/utils/androidBack.ts
@@ -7,7 +7,7 @@ export type AndroidBackHandler = () => boolean;
 
 const handlers: AndroidBackHandler[] = [];
 
-export function pushAndroidBackHandler(handler: AndroidBackHandler): () => void {
+function pushAndroidBackHandler(handler: AndroidBackHandler): () => void {
   handlers.push(handler);
   return () => {
     const index = handlers.lastIndexOf(handler);

--- a/src/app/utils/debug.ts
+++ b/src/app/utils/debug.ts
@@ -8,8 +8,7 @@
  *   localStorage.removeItem('sable_debug'); location.reload();
  */
 
-export const isDebug = (): boolean =>
-  import.meta.env.DEV || localStorage.getItem('sable_debug') === '1';
+const isDebug = (): boolean => import.meta.env.DEV || localStorage.getItem('sable_debug') === '1';
 
 type LogLevel = 'log' | 'warn' | 'error';
 

--- a/src/app/utils/delayedEvents.ts
+++ b/src/app/utils/delayedEvents.ts
@@ -95,10 +95,6 @@ export async function cancelDelayedEvent(mx: MatrixClient, delayId: string): Pro
   await mx._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Cancel);
 }
 
-export async function sendDelayedEventNow(mx: MatrixClient, delayId: string): Promise<void> {
-  await mx._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Send);
-}
-
 export function computeDelayMs(targetDate: Date): number {
   const delay = targetDate.getTime() - Date.now();
   if (delay <= 0) throw new Error('Scheduled time must be in the future');

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -1,6 +1,5 @@
 import { isTauri } from '@tauri-apps/api/core';
 import { fetchMediaBlob, type MediaTransportOptions } from './mediaTransport';
-import { fetch } from './fetch';
 
 export const targetFromEvent = (evt: Event, selector: string): Element | undefined => {
   const targets = evt.composedPath() as Element[];
@@ -15,39 +14,9 @@ export const editableActiveElement = (): boolean =>
     document.activeElement.getAttribute('role') === 'input' ||
     document.activeElement.getAttribute('role') === 'textarea');
 
-export const isIntersectingScrollView = (
-  scrollElement: HTMLElement,
-  childElement: HTMLElement
-): boolean => {
-  const scrollTop = scrollElement.offsetTop + scrollElement.scrollTop;
-  const scrollBottom = scrollTop + scrollElement.offsetHeight;
-
-  const childTop = childElement.offsetTop;
-  const childBottom = childTop + childElement.clientHeight;
-
-  if (childTop >= scrollTop && childTop < scrollBottom) return true;
-  if (childBottom > scrollTop && childBottom <= scrollBottom) return true;
-  if (childTop < scrollTop && childBottom > scrollBottom) return true;
-  return false;
-};
-
-export const isInScrollView = (scrollElement: HTMLElement, childElement: HTMLElement): boolean => {
-  const scrollTop = scrollElement.offsetTop + scrollElement.scrollTop;
-  const scrollBottom = scrollTop + scrollElement.offsetHeight;
-  return (
-    childElement.offsetTop >= scrollTop &&
-    childElement.offsetTop + childElement.offsetHeight <= scrollBottom
-  );
-};
-
-export const canFitInScrollView = (
-  scrollElement: HTMLElement,
-  childElement: HTMLElement
-): boolean => childElement.offsetHeight < scrollElement.offsetHeight;
-
 export type FilesOrFile<T extends boolean | undefined = undefined> = T extends true ? File[] : File;
 
-export const getFilesFromFileList = (fileList: FileList): File[] => {
+const getFilesFromFileList = (fileList: FileList): File[] => {
   const files: File[] = [];
 
   for (let i = 0; i < fileList.length; i += 1) {
@@ -92,12 +61,6 @@ export const getDataTransferFiles = (dataTransfer: DataTransfer): File[] | undef
 
 export const renameFile = (file: File, name: string): File =>
   new File([file], name, { type: file.type });
-
-export const getImageUrlBlob = async (url: string) => {
-  const res = await fetch(url);
-  const blob = await res.blob();
-  return blob;
-};
 
 export const getImageFileUrl = (fileOrBlob: File | Blob) => URL.createObjectURL(fileOrBlob);
 
@@ -169,21 +132,6 @@ export const getThumbnail = (
       resolve(thumbnail ?? undefined);
     }, thumbnailMimeType ?? 'image/jpeg');
   });
-
-export type ScrollInfo = {
-  offsetTop: number;
-  top: number;
-  height: number;
-  viewHeight: number;
-  scrollable: boolean;
-};
-export const getScrollInfo = (target: HTMLElement): ScrollInfo => ({
-  offsetTop: Math.round(target.offsetTop),
-  top: Math.round(target.scrollTop),
-  height: Math.round(target.scrollHeight),
-  viewHeight: Math.round(target.offsetHeight),
-  scrollable: target.scrollHeight > target.offsetHeight,
-});
 
 export const scrollToBottom = (scrollEl: HTMLElement, behavior?: 'auto' | 'instant' | 'smooth') => {
   scrollEl.scrollTo({

--- a/src/app/utils/download.ts
+++ b/src/app/utils/download.ts
@@ -22,7 +22,7 @@ export const getAttachmentFilename = (
   fallback = 'download'
 ): string => nonEmptyString(filename) ?? nonEmptyString(body) ?? fallback;
 
-export const sanitizeDownloadFilename = (filename: string, fallback = 'download'): string => {
+const sanitizeDownloadFilename = (filename: string, fallback = 'download'): string => {
   let safeName = filename
     .replace(INVALID_FILENAME_CHARS, '_')
     .replace(CONTROL_CHARS, '_')

--- a/src/app/utils/emojiDetection.ts
+++ b/src/app/utils/emojiDetection.ts
@@ -22,7 +22,7 @@ export type EmojiTextPart =
       value: string;
     };
 
-export const getFirstGrapheme = (text: string): string => {
+const getFirstGrapheme = (text: string): string => {
   const first = graphemeSegmenter.segment(text)[Symbol.iterator]().next();
   return first.done ? '' : first.value.segment;
 };

--- a/src/app/utils/klipy.ts
+++ b/src/app/utils/klipy.ts
@@ -1,4 +1,4 @@
-export function toBase64Url(value: string): string {
+function toBase64Url(value: string): string {
   const bytes = new TextEncoder().encode(value);
   let binary = '';
 
@@ -9,7 +9,7 @@ export function toBase64Url(value: string): string {
   return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
 }
 
-export function toMatrixID(fname: string, urlPrefix: string): string {
+function toMatrixID(fname: string, urlPrefix: string): string {
   const base64 = toBase64Url(fname);
   return urlPrefix + base64;
 }

--- a/src/app/utils/mediaTransport.ts
+++ b/src/app/utils/mediaTransport.ts
@@ -88,7 +88,7 @@ function isMatrixMediaPath(pathname: string): boolean {
   return MATRIX_MEDIA_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
-export function isTrustedMatrixMediaUrl(url: string, baseUrl: string | undefined): boolean {
+function isTrustedMatrixMediaUrl(url: string, baseUrl: string | undefined): boolean {
   if (!baseUrl) return false;
 
   try {
@@ -141,7 +141,7 @@ export function getActiveMediaSession():
 
 let cachedSessionScope: string | undefined;
 
-export const invalidateMediaSessionScope = (): void => {
+const invalidateMediaSessionScope = (): void => {
   cachedSessionScope = undefined;
 };
 

--- a/src/app/utils/mimeTypes.ts
+++ b/src/app/utils/mimeTypes.ts
@@ -1,4 +1,4 @@
-export const IMAGE_MIME_TYPES = [
+const IMAGE_MIME_TYPES = [
   'image/jpeg',
   'image/gif',
   'image/png',
@@ -8,9 +8,9 @@ export const IMAGE_MIME_TYPES = [
   'image/svg+xml',
 ];
 
-export const VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+const VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
 
-export const AUDIO_MIME_TYPES = [
+const AUDIO_MIME_TYPES = [
   'audio/mp4',
   'audio/x-m4a',
   'audio/webm',
@@ -25,7 +25,7 @@ export const AUDIO_MIME_TYPES = [
   'audio/x-flac',
 ];
 
-export const APPLICATION_MIME_TYPES = [
+const APPLICATION_MIME_TYPES = [
   'application/pdf',
   'application/json',
   'application/x-sh',
@@ -35,7 +35,7 @@ export const APPLICATION_MIME_TYPES = [
   'application/xml',
 ];
 
-export const TEXT_MIME_TYPE = [
+const TEXT_MIME_TYPE = [
   'text/plain',
   'text/html',
   'text/css',
@@ -97,7 +97,7 @@ export const READABLE_EXT_TO_MIME_TYPE: Record<string, string> = {
   sql: 'text/sql',
 };
 
-export const ALLOWED_BLOB_MIME_TYPES = [
+const ALLOWED_BLOB_MIME_TYPES = [
   ...IMAGE_MIME_TYPES,
   ...VIDEO_MIME_TYPES,
   ...AUDIO_MIME_TYPES,

--- a/src/app/utils/notificationStyle.ts
+++ b/src/app/utils/notificationStyle.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_NOTIFICATION_ICON = '/public/res/logo-maskable/logo-maskable-180x180.png';
 export const DEFAULT_NOTIFICATION_BADGE = '/public/res/logo-maskable/logo-maskable-72x72.png';
-export const DEFAULT_MESSAGE_PREVIEW = 'new message';
+const DEFAULT_MESSAGE_PREVIEW = 'new message';
 export const ENCRYPTED_MESSAGE_PREVIEW = 'Encrypted message';
 
 type RoomMessageNotificationInput = {

--- a/src/app/utils/presence.ts
+++ b/src/app/utils/presence.ts
@@ -9,7 +9,7 @@ const PRESENCE_TO_SET_PRESENCE: Record<Presence, SetPresence> = {
   [Presence.Offline]: SetPresence.Offline,
 };
 
-export const presenceToSetPresence = (presence: Presence): SetPresence =>
+const presenceToSetPresence = (presence: Presence): SetPresence =>
   PRESENCE_TO_SET_PRESENCE[presence];
 
 export const setUserPresence = async (

--- a/src/app/utils/regex.ts
+++ b/src/app/utils/regex.ts
@@ -4,7 +4,7 @@
 export const sanitizeForRegex = (unsafeText: string): string =>
   unsafeText.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 
-export const HTTP_URL_PATTERN = `https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
+const HTTP_URL_PATTERN = `https?:\\/\\/(?:www\\.)?(?:[^\\s)]*)(?<![.,:;!/?()[\\]\\s]+)`;
 
 export const URL_REG = new RegExp(HTTP_URL_PATTERN, 'g');
 

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -610,23 +610,6 @@ export const trimReplyFromFormattedBody = (formattedBody: string): string => {
   return formattedBody.slice(i + suffix.length);
 };
 
-export const parseReplyBody = (userId: string, body: string) =>
-  `> <${userId}> ${body.replace(/\n/g, '\n> ')}\n\n`;
-
-export const parseReplyFormattedBody = (
-  roomId: string,
-  userId: string,
-  eventId: string,
-  formattedBody: string
-): string => {
-  const replyToLink = `<a href="https://matrix.to/#/${encodeURIComponent(
-    roomId
-  )}/${encodeURIComponent(eventId)}">In reply to</a>`;
-  const userLink = `<a href="https://matrix.to/#/${encodeURIComponent(userId)}">${userId}</a>`;
-
-  return `<mx-reply><blockquote>${replyToLink}${userLink}<br />${formattedBody}</blockquote></mx-reply>`;
-};
-
 export const getMemberDisplayName = (
   room: Room,
   userId: string,
@@ -695,7 +678,7 @@ export const getEventReactions = (timelineSet: EventTimelineSet, eventId: string
 export const getEventEdits = (timelineSet: EventTimelineSet, eventId: string, eventType: string) =>
   timelineSet.relations.getChildEventsForEvent(eventId, RelationType.Replace, eventType);
 
-export const getLatestEdit = (
+const getLatestEdit = (
   targetEvent: MatrixEvent,
   editEvents: MatrixEvent[]
 ): MatrixEvent | undefined => {
@@ -789,11 +772,6 @@ export const getReactionAnnotationTargetId = (reactionEvent: MatrixEvent): strin
   }
 
   return undefined;
-};
-
-export const getRedactionActorId = (mEvent: MatrixEvent): string | undefined => {
-  const sender = mEvent.getUnsigned()?.redacted_because?.sender;
-  return typeof sender === 'string' && sender.length > 0 ? sender : undefined;
 };
 
 export const getRedactionReason = (mEvent: MatrixEvent): string | undefined => {
@@ -991,7 +969,7 @@ export const getPreviousEditId = (
   return allEvents[idx - 1]?.getId();
 };
 
-export const getPreviousEditEvent = (
+const getPreviousEditEvent = (
   currentEditEvent: MatrixEvent,
   chain: { original: MatrixEvent; edits: MatrixEvent[] }
 ): MatrixEvent | undefined => {
@@ -1006,7 +984,7 @@ export const getPreviousEditEvent = (
 
 const EDIT_DIFF_MSGTYPES = new Set<string>([MsgType.Text, MsgType.Emote, MsgType.Notice]);
 
-export const getMessageVersionBody = (mEvent: MatrixEvent): string | undefined => {
+const getMessageVersionBody = (mEvent: MatrixEvent): string | undefined => {
   const content = mEvent.getContent();
   const wireContent = mEvent.getWireContent?.() as Record<string, unknown> | undefined;
 
@@ -1081,19 +1059,6 @@ export const canEditEvent = (mx: MatrixClient, mEvent: MatrixEvent) => {
       content.msgtype === MsgType.Audio ||
       content.msgtype === MsgType.File)
   );
-};
-
-export const getLatestEditableEvt = (
-  timeline: EventTimeline,
-  canEdit: (mEvent: MatrixEvent) => boolean
-): MatrixEvent | undefined => {
-  const events = timeline.getEvents();
-
-  for (let i = events.length - 1; i >= 0; i -= 1) {
-    const evt = events[i];
-    if (evt && canEdit(evt)) return evt;
-  }
-  return undefined;
 };
 
 export const reactionOrEditEvent = (mEvent: MatrixEvent): boolean => {
@@ -1307,7 +1272,7 @@ export const bannedInRooms = (mx: MatrixClient, rooms: string[], otherUserId: st
     return room.hasMembershipState(otherUserId, KnownMembership.Ban);
   });
 
-export const getAllVersionsRoomCreator = (room: Room): Set<string> => {
+const getAllVersionsRoomCreator = (room: Room): Set<string> => {
   const creators = new Set<string>();
 
   const createEvent = getStateEvent(room, EventType.RoomCreate);

--- a/src/app/utils/sentryScrubbers.ts
+++ b/src/app/utils/sentryScrubbers.ts
@@ -61,7 +61,7 @@ export function scrubDataObject(data: unknown): unknown {
 }
 
 /** Structured fields that should never be sent to Sentry, even redacted. */
-export const SENTRY_IDENTIFIER_KEYS = new Set([
+const SENTRY_IDENTIFIER_KEYS = new Set([
   'roomId',
   'notificationEventId',
   'refEventId',

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -32,7 +32,7 @@ export const NON_SYNCABLE_KEYS = new Set<keyof Settings>([
 ]);
 
 export const SETTINGS_SYNC_VERSION = 1;
-export const MAX_SYNCED_LOCAL_TWEAK_CSS_BYTES = 256 * 1024;
+const MAX_SYNCED_LOCAL_TWEAK_CSS_BYTES = 256 * 1024;
 const MAX_SYNCED_TWEAK_URL_LENGTH = 8192;
 
 export type SettingsSyncContent = {
@@ -45,7 +45,7 @@ export type PreparedSettingsSync = {
   excludedLocalTweakUrls: string[];
 };
 
-export function sanitizeThemeRemoteEnabledTweakFullUrls(val: unknown): string[] | undefined {
+function sanitizeThemeRemoteEnabledTweakFullUrls(val: unknown): string[] | undefined {
   if (!Array.isArray(val)) return undefined;
   return val.flatMap((url) => {
     if (typeof url !== 'string') return [];

--- a/src/app/utils/tauriMediaAuth.ts
+++ b/src/app/utils/tauriMediaAuth.ts
@@ -33,7 +33,7 @@ export const updateTauriMediaSession = (
   return write;
 };
 
-export const syncTauriMediaSession = (): Promise<void> => {
+const syncTauriMediaSession = (): Promise<void> => {
   const session = getActiveMediaSession();
   return updateTauriMediaSession(session?.baseUrl, session?.accessToken, session?.userId);
 };

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -9,15 +9,6 @@ export const today = (ts: number): boolean => dayjs(ts).isToday();
 
 export const yesterday = (ts: number): boolean => dayjs(ts).isYesterday();
 
-export const timeHour = (ts: number, hour24Clock: boolean): string =>
-  dayjs(ts).format(hour24Clock ? 'HH' : 'hh');
-export const timeMinute = (ts: number): string => dayjs(ts).format('mm');
-export const timeAmPm = (ts: number): string => dayjs(ts).format('A');
-export const timeDay = (ts: number): string => dayjs(ts).format('D');
-export const timeMon = (ts: number): string => dayjs(ts).format('MMM');
-export const timeMonth = (ts: number): string => dayjs(ts).format('MMMM');
-export const timeYear = (ts: number): string => dayjs(ts).format('YYYY');
-
 export const timeHourMinute = (ts: number, hour24Clock: boolean): string =>
   dayjs(ts).format(hour24Clock ? 'HH:mm' : 'hh:mm A');
 

--- a/src/app/utils/timeline.ts
+++ b/src/app/utils/timeline.ts
@@ -1,11 +1,6 @@
 import type { EventTimeline, MatrixEvent, Room } from '$types/matrix-sdk';
 import { Direction } from '$types/matrix-sdk';
-import {
-  isThreadRelationEvent,
-  reactionOrEditEvent,
-  roomHaveNotification,
-  roomHaveUnread,
-} from '$utils/room';
+import { roomHaveNotification, roomHaveUnread } from '$utils/room';
 
 export const PAGINATION_LIMIT = 60;
 
@@ -38,7 +33,7 @@ export const getLinkedTimelines = (timeline: EventTimeline): EventTimeline[] => 
   return result;
 };
 
-export const timelineToEventsCount = (t: EventTimeline) => {
+const timelineToEventsCount = (t: EventTimeline) => {
   if (!t) return 0;
   const events = t.getEvents();
   return events ? events.length : 0;
@@ -50,48 +45,6 @@ export const getTimelinesEventsCount = (timelines: EventTimeline[]): number => {
   return (timelines || [])
     .filter(Boolean)
     .reduce((accumulator, element) => timelineEventCountReducer(accumulator, element), 0);
-};
-
-export const getTimelineAndBaseIndex = (
-  timelines: EventTimeline[],
-  index: number
-): [EventTimeline | undefined, number] => {
-  const validTimelines = (timelines || []).filter(Boolean);
-
-  const result = validTimelines.reduce<{
-    found?: EventTimeline;
-    baseIndex: number;
-  }>(
-    (acc, timeline) => {
-      if (acc.found) return acc;
-
-      const events = timeline.getEvents();
-      const len = events ? events.length : 0;
-
-      if (index < acc.baseIndex + len) {
-        acc.found = timeline;
-        return acc;
-      }
-
-      acc.baseIndex += len;
-      return acc;
-    },
-    { baseIndex: 0 }
-  );
-
-  return [result.found, result.found ? result.baseIndex : 0];
-};
-
-export const getTimelineRelativeIndex = (absoluteIndex: number, timelineBaseIndex: number) =>
-  absoluteIndex - timelineBaseIndex;
-
-export const getTimelineEvent = (
-  timeline: EventTimeline,
-  index: number
-): MatrixEvent | undefined => {
-  if (!timeline) return undefined;
-  const events = timeline.getEvents();
-  return events ? events[index] : undefined;
 };
 
 export const getEventIdAbsoluteIndex = (
@@ -155,20 +108,4 @@ export const getRoomUnreadInfo = (room: Room, scrollTo = false) => {
     inLiveTimeline: latestTimeline === room.getLiveTimeline(),
     scrollTo,
   };
-};
-
-export const getThreadReplyCount = (room: Room, mEventId: string): number => {
-  const thread = room.getThread(mEventId);
-  if (thread) return thread.length;
-
-  const linkedTimelines = getLinkedTimelines(getLiveTimeline(room));
-  return linkedTimelines.reduce((acc, tl) => {
-    const threadEvents = tl
-      .getEvents()
-      .filter(
-        (ev) =>
-          ev.getId() !== mEventId && !reactionOrEditEvent(ev) && isThreadRelationEvent(ev, mEventId)
-      );
-    return acc + threadEvents.length;
-  }, 0);
 };

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -27,7 +27,6 @@ const normalizeMacName = (os?: string) => {
 
 const isMac = result.os.name === 'Mac OS' || result.os.name === 'macOS';
 
-export const ua = () => result;
 export const isMacOS = () => isMac;
 export const mobileOrTablet = () => isMobileOrTablet;
 

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -28,12 +28,11 @@ import { SlidingSyncSidebarCache } from './slidingSyncSidebarCache';
 const log = createLogger('slidingSync');
 const debugLog = createDebugLogger('slidingSync');
 
-export const LIST_JOINED = 'joined';
-export const LIST_INVITES = 'invites';
-export const LIST_UPDATES = 'updates';
-export const LIST_SEARCH = 'search';
-export const LIST_ROOM_SEARCH = 'room_search';
-export const LIST_SPACE = 'space';
+const LIST_JOINED = 'joined';
+const LIST_INVITES = 'invites';
+const LIST_UPDATES = 'updates';
+const LIST_ROOM_SEARCH = 'room_search';
+const LIST_SPACE = 'space';
 const LIST_TIMELINE_LIMIT = 1;
 const LIST_PAGE_SIZE = 30;
 const STEADY_STATE_DETAILED_ROOMS = 3;


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Removes 258 unused exports flagged by fallow. Extracts buildReplacementContent so the composer and the message editor assemble edits identically. Migrates the sidebar, space and image-viewer menus onto useMenuAnchor and adopts the existing getMouseEventCords helper.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
