### PR TITLE
fix: ensure timeline continues fetching when hidden events are disabled

### DIFF
--- a/.changeset/fix-timeline-pagination-hidden-events.md
+++ b/.changeset/fix-timeline-pagination-hidden-events.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed timeline pagination becoming stuck when hidden events are disabled.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react';
 import type { Editor } from 'slate';
 import { useAtomValue, useSetAtom, useStore } from 'jotai';
-import type { Room } from '$types/matrix-sdk';
+import type { Room, MatrixEvent, EventTimelineSet } from '$types/matrix-sdk';
 import { Direction, EventType } from '$types/matrix-sdk';
 import classNames from 'classnames';
 import type { VListHandle } from 'virtua';
@@ -35,7 +35,16 @@ import {
   factoryRenderLinkifyWithMention,
 } from '$plugins/react-custom-html-parser';
 import { today, yesterday, timeDayMonthYear } from '$utils/time';
-import { unwrapRelationJumpTarget } from '$utils/room';
+import {
+  unwrapRelationJumpTarget,
+  isEditEvent,
+  isReactionEvent,
+  isRedactableMessageType,
+  isMembershipChanged,
+  isThreadRelationEvent,
+  getRedactionTargetEvent,
+  shouldShowRedactionTimelineEvent,
+} from '$utils/room';
 import { useMemberEventParser } from '$hooks/useMemberEventParser';
 import { usePowerLevelsContext } from '$hooks/usePowerLevels';
 import { useRoomCreators } from '$hooks/useRoomCreators';
@@ -72,6 +81,7 @@ import { useTimelineActions } from '$hooks/timeline/useTimelineActions';
 import {
   useProcessedTimeline,
   getProcessedRowIndexForRawTimelineIndex,
+  STANDARD_RENDERED_EVENT_TYPES,
   type ProcessedEvent,
 } from '$hooks/timeline/useProcessedTimeline';
 import { useTimelineEventRenderer } from '$hooks/timeline/useTimelineEventRenderer';
@@ -512,6 +522,90 @@ export function RoomTimeline({
     setUnreadInfo,
     hideReadsRef,
     readUptoEventIdRef,
+    isEventVisible: useCallback(
+      (mEvent: MatrixEvent, timelineSet: EventTimelineSet) => {
+        const type = mEvent.getType();
+        const isEdit = isEditEvent(mEvent);
+        const isReaction = isReactionEvent(mEvent);
+        const isRedactionEvt = mEvent.isRedaction();
+
+        if (hideMemberInReadOnly && isReadOnly) {
+          if (isReaction) return false;
+          if (
+            isRedactionEvt &&
+            getRedactionTargetEvent(timelineSet, mEvent)?.getType() ===
+              (EventType.Reaction as string)
+          ) {
+            return false;
+          }
+        }
+
+        if (mEvent.isRedacted()) {
+          const showMessageTombstone =
+            hiddenEvents.showTombstoneEvents && isRedactableMessageType(type);
+          const showReactionTombstone = hiddenEvents.hiddenEventReactionTombstone && isReaction;
+          if (!showMessageTombstone && !showReactionTombstone) return false;
+        }
+
+        if (type === 'm.room.member') {
+          const membershipChanged = isMembershipChanged(mEvent);
+          if (hideMemberInReadOnly && isReadOnly) return false;
+          if (membershipChanged && hideMembershipEvents) return false;
+          if (!membershipChanged && hideNickAvatarEvents) return false;
+        }
+
+        const allowSpecificHiddenEvent =
+          (isEdit && hiddenEvents.hiddenEventEdits) ||
+          (isReaction && !mEvent.isRedacted() && hiddenEvents.hiddenEventReactions) ||
+          (isReaction && mEvent.isRedacted() && hiddenEvents.hiddenEventReactionTombstone) ||
+          (isRedactionEvt &&
+            shouldShowRedactionTimelineEvent(
+              mEvent,
+              timelineSet,
+              hiddenEvents.hiddenEventRedactionTimeline,
+              hiddenEvents.hiddenEventReactionRedactionTimeline
+            ));
+
+        if (!(hiddenEvents.showHiddenEvents && hiddenEvents.hiddenEventOther)) {
+          const isStandardRendered = STANDARD_RENDERED_EVENT_TYPES.has(type);
+          if (!isStandardRendered && !allowSpecificHiddenEvent) {
+            return false;
+          }
+        }
+
+        const threadRootId = mEvent.threadRootId;
+        if (
+          threadRootId !== undefined &&
+          threadRootId !== mEvent.getId() &&
+          isThreadRelationEvent(mEvent, threadRootId)
+        ) {
+          return false;
+        }
+
+        if (isEdit && !hiddenEvents.hiddenEventEdits) return false;
+        if (isReaction) {
+          if (mEvent.isRedacted()) {
+            if (!hiddenEvents.hiddenEventReactionTombstone) return false;
+          } else if (!hiddenEvents.hiddenEventReactions) {
+            return false;
+          }
+        }
+        if (
+          isRedactionEvt &&
+          !shouldShowRedactionTimelineEvent(
+            mEvent,
+            timelineSet,
+            hiddenEvents.hiddenEventRedactionTimeline,
+            hiddenEvents.hiddenEventReactionRedactionTimeline
+          )
+        ) {
+          return false;
+        }
+
+        return true;
+      },
+      [hiddenEvents, hideMemberInReadOnly, isReadOnly, hideMembershipEvents, hideNickAvatarEvents]
+    ),
   });
 
   timelineSyncRef.current = timelineSync;

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -75,7 +75,7 @@ const MESSAGE_EVENT_TYPES = new Set([
   'm.room.encrypted',
 ]);
 
-const STANDARD_RENDERED_EVENT_TYPES = new Set([
+export const STANDARD_RENDERED_EVENT_TYPES = new Set([
   'm.room.message',
   'm.room.message.encrypted',
   'm.sticker',
@@ -453,12 +453,8 @@ const processTimelineItems = (
 
     if (!(showHiddenEvents && hiddenEventOther)) {
       const isStandardRendered = STANDARD_RENDERED_EVENT_TYPES.has(type);
-      if (!isStandardRendered) {
-        if (Object.keys(mEvent.getContent()).length === 0 && !allowSpecificHiddenEvent) continue;
-        if (!allowSpecificHiddenEvent) {
-          if (mEvent.getRelation()) continue;
-          if (mEvent.isRedaction()) continue;
-        }
+      if (!isStandardRendered && !allowSpecificHiddenEvent) {
+        continue;
       }
     }
 

--- a/src/app/hooks/timeline/useTimelineSync.ts
+++ b/src/app/hooks/timeline/useTimelineSync.ts
@@ -7,6 +7,7 @@ import type {
   Room,
   MatrixEvent,
   EventTimeline,
+  EventTimelineSet,
   EventTimelineSetHandlerMap,
   IRoomTimelineData,
   RoomEventHandlerMap,
@@ -103,7 +104,8 @@ const useTimelinePagination = (
   mx: MatrixClient,
   timeline: TimelineState,
   setTimeline: Dispatch<SetStateAction<TimelineState>>,
-  limit: number
+  limit: number,
+  isEventVisible?: (mEvent: MatrixEvent, timelineSet: EventTimelineSet) => boolean
 ) => {
   const timelineRef = useRef(timeline);
   timelineRef.current = timeline;
@@ -183,8 +185,19 @@ const useTimelinePagination = (
           const countAfter = getTimelinesEventsCount(getLinkedTimelines(firstTimeline));
           const fetched = countAfter - countBefore;
 
+          let visibleFetched = fetched;
+          if (isEventVisible && fetched > 0) {
+            const afterEvents = getLinkedTimelines(firstTimeline).flatMap((t) =>
+              (t.getEvents() || []).map((ev) => ({ ev, ts: t.getTimelineSet() }))
+            );
+            const newEvents = backwards
+              ? afterEvents.slice(0, fetched)
+              : afterEvents.slice(afterEvents.length - fetched);
+            visibleFetched = newEvents.filter(({ ev, ts }) => isEventVisible(ev, ts)).length;
+          }
+
           let willContinue = false;
-          if (fetched > 0 && fetched < 5) {
+          if (fetched > 0 && visibleFetched < 5) {
             const checkTimeline = backwards
               ? freshLTimelines[0]
               : freshLTimelines[freshLTimelines.length - 1];
@@ -223,7 +236,7 @@ const useTimelinePagination = (
         }
       }
     };
-  }, [mx, alive, setTimeline, limit, setBackwardStatus, setForwardStatus]);
+  }, [mx, alive, setTimeline, limit, setBackwardStatus, setForwardStatus, isEventVisible]);
 
   return { paginate, backwardStatus, forwardStatus };
 };
@@ -357,6 +370,7 @@ export interface UseTimelineSyncOptions {
   setUnreadInfo: Dispatch<SetStateAction<ReturnType<typeof getRoomUnreadInfo>>>;
   hideReadsRef: React.MutableRefObject<boolean>;
   readUptoEventIdRef: React.MutableRefObject<string | undefined>;
+  isEventVisible?: (mEvent: MatrixEvent, timelineSet: EventTimelineSet) => boolean;
 }
 
 export function useTimelineSync({
@@ -370,6 +384,7 @@ export function useTimelineSync({
   setUnreadInfo,
   hideReadsRef,
   readUptoEventIdRef,
+  isEventVisible,
 }: UseTimelineSyncOptions) {
   const alive = useAlive();
 
@@ -402,7 +417,7 @@ export function useTimelineSync({
     paginate: handleTimelinePagination,
     backwardStatus,
     forwardStatus,
-  } = useTimelinePagination(mx, timeline, setTimeline, PAGINATION_LIMIT);
+  } = useTimelinePagination(mx, timeline, setTimeline, PAGINATION_LIMIT, isEventVisible);
 
   const prevEventsLengthRef = useRef(eventsLength);
   useEffect(() => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Ensures the timeline continues paginating back by removing the arbitrary limit and ensures the room creating info is shown at the top.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
