### PR TITLE
Persona picker style tweaks

### DIFF
--- a/.changeset/persona_picker_style_tweaks.md
+++ b/.changeset/persona_picker_style_tweaks.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Persona Picker style tweaks

--- a/src/app/components/ResponsiveMenu.tsx
+++ b/src/app/components/ResponsiveMenu.tsx
@@ -19,6 +19,7 @@ type ResponsiveMenuProps = {
   position?: ComponentPosition;
   align?: ComponentAlign;
   offset?: number;
+  alignOffset?: number;
   /** Set true for menus whose trigger should regain focus when they close. */
   returnFocusOnDeactivate?: boolean;
   /** `both` also maps Left/Right, for menus laid out horizontally. */
@@ -38,6 +39,7 @@ export function ResponsiveMenu({
   position = 'Bottom',
   align = 'End',
   offset,
+  alignOffset,
   returnFocusOnDeactivate = false,
   arrowNavigation = 'vertical',
 }: ResponsiveMenuProps) {
@@ -93,6 +95,7 @@ export function ResponsiveMenu({
       position={position}
       align={align}
       offset={offset}
+      alignOffset={alignOffset}
       content={
         // Gated so a call site that builds its menu inline does that work on open,
         // not on every render of the trigger.

--- a/src/app/features/room/persona-picker/PersonaPicker.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.tsx
@@ -4,6 +4,7 @@ import {
   menuIcon,
   User as UserIcon,
 } from '$components/icons/phosphor';
+import { ResponsiveMenu } from '$components/ResponsiveMenu';
 import { UserAvatar } from '$components/user-avatar/UserAvatar.tsx';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication.ts';
 import {
@@ -14,10 +15,8 @@ import {
   getCurrentlyUsedPerMessageProfileForAccount,
   setCurrentlyUsedPerMessageProfileIdForAccount,
 } from '$hooks/usePerMessageProfile';
-import { stopPropagation } from '$utils/keyboard';
 import { mxcUrlToHttp } from '$utils/matrix.ts';
 import { isMobileOrTablet } from '$utils/platform';
-import FocusTrap from 'focus-trap-react';
 import { nameInitials } from '$utils/common';
 import {
   Avatar,
@@ -27,7 +26,6 @@ import {
   Input,
   Menu,
   MenuItem,
-  PopOut,
   type RectCords,
   Scroll,
   Text,
@@ -39,6 +37,10 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import * as css from './PersonaPicker.css.ts';
 import { InfoCard } from '$components/info-card/InfoCard.tsx';
 import { InfoIcon } from '@phosphor-icons/react';
+
+const pillStyles = {
+  cursor: 'pointer',
+} as const;
 
 export enum PersonaPickerTab {
   Global = 'Global',
@@ -78,8 +80,6 @@ export function PersonaPicker({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [showPersonaPicker, setShowPersonaPicker] = useState(false);
-
   const [filteredProfiles, setFilteredProfiles] = useState<PerMessageProfile[] | undefined>(
     undefined
   );
@@ -142,224 +142,201 @@ export function PersonaPicker({
   );
 
   return (
-    <>
-      <PopOut
-        anchor={AddPersonaMenuAnchor}
-        position="Top"
-        align="Start"
-        offset={5}
-        content={
-          <FocusTrap
-            focusTrapOptions={{
-              initialFocus: false,
-              onActivate: () => {
-                // HACK: getAllPerMessageProfiles returns [] on Sable first load.
-                // BUG: On the third render the list returns empty in testing.
-                if (profiles?.length === 0) {
-                  fetchProfiles(mx);
-                }
-              },
-              onDeactivate: () => {
-                setAddPersonaMenuAnchor(undefined);
-                setShowPersonaPicker(false);
-                clearFilterInput();
-              },
-              clickOutsideDeactivates: true,
-              escapeDeactivates: stopPropagation,
-            }}
+    <ResponsiveMenu
+      anchor={AddPersonaMenuAnchor}
+      position="Top"
+      align="Start"
+      offset={16}
+      alignOffset={-44}
+      requestClose={() => {
+        setAddPersonaMenuAnchor(undefined);
+        clearFilterInput();
+      }}
+      menu={
+        <Menu>
+          <Box
+            direction="Column"
+            gap="100"
+            style={{ padding: config.space.S200, minWidth: '18rem' }}
           >
-            <Menu>
-              <Box
-                direction="Column"
-                gap="100"
-                style={{ padding: config.space.S200, minWidth: '18rem' }}
+            <Box gap="100">
+              <Badge
+                style={pillStyles}
+                as="button"
+                variant="Secondary"
+                fill={tab == PersonaPickerTab.Global ? 'Solid' : 'None'}
+                size="500"
+                onClick={() => onTabChange(PersonaPickerTab.Global)}
               >
-                <Box gap="100">
-                  <Badge
-                    as="button"
-                    variant="Secondary"
-                    fill={tab == PersonaPickerTab.Global ? 'Solid' : 'None'}
-                    size="500"
-                    onClick={() => onTabChange(PersonaPickerTab.Global)}
-                  >
-                    <Text as="span" size="L400">
-                      Global
-                    </Text>
-                  </Badge>
-                  <Badge
-                    as="button"
-                    variant="Secondary"
-                    fill={tab == PersonaPickerTab.PerRoom ? 'Solid' : 'None'}
-                    size="500"
-                    onClick={() => onTabChange(PersonaPickerTab.PerRoom)}
-                  >
-                    <Text as="span" size="L400">
-                      Per-room
-                    </Text>
-                  </Badge>
-                </Box>
+                <Text as="span" size="L400">
+                  Global
+                </Text>
+              </Badge>
+              <Badge
+                style={pillStyles}
+                as="button"
+                variant="Secondary"
+                fill={tab == PersonaPickerTab.PerRoom ? 'Solid' : 'None'}
+                size="500"
+                onClick={() => onTabChange(PersonaPickerTab.PerRoom)}
+              >
+                <Text as="span" size="L400">
+                  Per-room
+                </Text>
+              </Badge>
+            </Box>
 
-                <>
-                  <Input
-                    ref={searchInputRef}
-                    variant="SurfaceVariant"
-                    size="400"
-                    placeholder="Search"
-                    maxLength={50}
-                    autoFocus={!isMobileOrTablet()}
-                    onChange={filter}
-                    before={menuIcon(MagnifyingGlass)}
-                  />
-
-                  <Scroll
-                    hideTrack
-                    visibility="Hover"
-                    ref={scrollRef}
-                    size="400"
-                    style={{ maxHeight: '10rem', paddingRight: 0 }}
-                  >
-                    {filteredProfiles?.map((profile) => (
-                      <MenuItem
-                        key={profile.id}
-                        size="400"
-                        radii="300"
-                        className={css.PersonaPickerMenuItem}
-                        aria-selected={isPickerMenuItemSelected(profile)}
-                        onClick={async () => {
-                          const isGlobal = tab === PersonaPickerTab.Global;
-                          const selectedPersona = isGlobal
-                            ? selectedGlobalPersona
-                            : selectedRoomPersona;
-                          const disabling = profile.id === selectedPersona?.id;
-
-                          if (!disabling) {
-                            if (isGlobal) {
-                              setSelectedGlobalPersona(profile);
-                              await setCurrentlyUsedPerMessageProfileIdForAccount(mx, profile.id);
-                            } else {
-                              setSelectedRoomPersona(profile);
-                              await setCurrentlyUsedPerMessageProfileIdForRoom(
-                                mx,
-                                roomId,
-                                profile.id
-                              );
-                            }
-                          } else {
-                            if (isGlobal) {
-                              setSelectedGlobalPersona(null);
-                              await setCurrentlyUsedPerMessageProfileIdForAccount(
-                                mx,
-                                undefined,
-                                undefined,
-                                true
-                              );
-                            } else {
-                              setSelectedRoomPersona(null);
-                              await setCurrentlyUsedPerMessageProfileIdForRoom(
-                                mx,
-                                roomId,
-                                undefined,
-                                undefined,
-                                true
-                              );
-                            }
-                          }
-                        }}
-                        before={
-                          <Avatar
-                            size="300"
-                            radii="400"
-                            style={{
-                              width: 28,
-                              height: 28,
-                              marginLeft: -6,
-                            }}
-                            aria-label="Profile avatar"
-                          >
-                            <UserAvatar
-                              userId={profile.id}
-                              src={avatarUrl(profile)}
-                              renderFallback={() => (
-                                <Text as="span" size="H4" aria-label="Avatar fallback">
-                                  {nameInitials(profile.name)}
-                                </Text>
-                              )}
-                              alt={`Avatar for profile ${profile.id}`}
-                            />
-                          </Avatar>
-                        }
-                      >
-                        <Text truncate style={{ maxWidth: toRem(150) }}>
-                          {profile.name}
-                        </Text>
-                      </MenuItem>
-                    ))}
-                  </Scroll>
-                  <InfoCard
-                    before={menuIcon(InfoIcon, { weight: 'fill' })}
-                    variant="Primary"
-                    description={
-                      selectedRoomPersona ? (
-                        <>
-                          Message will use your <em>per-room</em> persona.
-                        </>
-                      ) : selectedGlobalPersona ? (
-                        <>
-                          Message will use your <em>global</em> persona.
-                        </>
-                      ) : (
-                        <>No persona chosen.</>
-                      )
-                    }
-                  />
-                </>
-              </Box>
-            </Menu>
-          </FocusTrap>
-        }
-      />
-      {
-        <IconButton
-          aria-pressed={showPersonaPicker}
-          onClick={(evt) => {
-            setShowPersonaPicker(true);
-            setAddPersonaMenuAnchor(evt.currentTarget.getBoundingClientRect());
-          }}
-          onPointerDown={suppressEditorRefocus}
-          variant="SurfaceVariant"
-          size="300"
-          style={{ backgroundColor: 'transparent' }}
-          title="Switch persona"
-          aria-label="Switch persona"
-        >
-          {(selectedRoomPersona ?? selectedGlobalPersona) ? (
-            <Avatar
-              size="200"
-              radii="300"
-              className={
-                showPersonaPicker
-                  ? css.SelectedPersonaPickerButtonAvatar
-                  : css.PersonaPickerButtonAvatar
-              }
-              aria-label="Profile avatar"
-            >
-              <UserAvatar
-                className={css.PersonaPickerButtonAvatarImage}
-                userId={defactoPersona()!.id}
-                src={avatarUrl(defactoPersona()!)}
-                renderFallback={() => (
-                  <Text as="span" size="H6" aria-label="Avatar fallback">
-                    {nameInitials(defactoPersona()!.name)}
-                  </Text>
-                )}
-                alt={`Avatar for profile ${defactoPersona()!.id}`}
+            <>
+              <Input
+                ref={searchInputRef}
+                variant="SurfaceVariant"
+                size="400"
+                placeholder="Search"
+                maxLength={50}
+                autoFocus={!isMobileOrTablet()}
+                onChange={filter}
+                before={menuIcon(MagnifyingGlass)}
               />
-            </Avatar>
-          ) : (
-            composerIcon(UserIcon, { weight: showPersonaPicker ? 'fill' : 'regular' })
-          )}
-        </IconButton>
+
+              <Scroll hideTrack ref={scrollRef} size="400" style={{ maxHeight: '10rem' }}>
+                {filteredProfiles?.map((profile) => (
+                  <MenuItem
+                    key={profile.id}
+                    size="400"
+                    radii="300"
+                    className={css.PersonaPickerMenuItem}
+                    aria-selected={isPickerMenuItemSelected(profile)}
+                    onClick={async () => {
+                      const isGlobal = tab === PersonaPickerTab.Global;
+                      const selectedPersona = isGlobal
+                        ? selectedGlobalPersona
+                        : selectedRoomPersona;
+                      const disabling = profile.id === selectedPersona?.id;
+
+                      if (!disabling) {
+                        if (isGlobal) {
+                          setSelectedGlobalPersona(profile);
+                          await setCurrentlyUsedPerMessageProfileIdForAccount(mx, profile.id);
+                        } else {
+                          setSelectedRoomPersona(profile);
+                          await setCurrentlyUsedPerMessageProfileIdForRoom(mx, roomId, profile.id);
+                        }
+                      } else {
+                        if (isGlobal) {
+                          setSelectedGlobalPersona(null);
+                          await setCurrentlyUsedPerMessageProfileIdForAccount(
+                            mx,
+                            undefined,
+                            undefined,
+                            true
+                          );
+                        } else {
+                          setSelectedRoomPersona(null);
+                          await setCurrentlyUsedPerMessageProfileIdForRoom(
+                            mx,
+                            roomId,
+                            undefined,
+                            undefined,
+                            true
+                          );
+                        }
+                      }
+                    }}
+                    before={
+                      <Avatar
+                        size="300"
+                        radii="400"
+                        style={{
+                          width: 28,
+                          height: 28,
+                          marginLeft: -6,
+                        }}
+                        aria-label="Profile avatar"
+                      >
+                        <UserAvatar
+                          userId={profile.id}
+                          src={avatarUrl(profile)}
+                          renderFallback={() => (
+                            <Text as="span" size="H4" aria-label="Avatar fallback">
+                              {nameInitials(profile.name)}
+                            </Text>
+                          )}
+                          alt={`Avatar for profile ${profile.id}`}
+                        />
+                      </Avatar>
+                    }
+                  >
+                    <Text truncate style={{ maxWidth: toRem(150) }}>
+                      {profile.name}
+                    </Text>
+                  </MenuItem>
+                ))}
+              </Scroll>
+              <InfoCard
+                before={menuIcon(InfoIcon, { weight: 'fill' })}
+                variant="Primary"
+                description={
+                  selectedRoomPersona ? (
+                    <>
+                      Message will use your <em>per-room</em> persona.
+                    </>
+                  ) : selectedGlobalPersona ? (
+                    <>
+                      Message will use your <em>global</em> persona.
+                    </>
+                  ) : (
+                    <>No persona chosen.</>
+                  )
+                }
+              />
+            </>
+          </Box>
+        </Menu>
       }
-    </>
+    >
+      <IconButton
+        aria-pressed={!!AddPersonaMenuAnchor}
+        onClick={(evt) => {
+          // getAllPerMessageProfiles can return an empty list during initial startup.
+          if (profiles?.length === 0) {
+            fetchProfiles(mx);
+          }
+          setAddPersonaMenuAnchor(evt.currentTarget.getBoundingClientRect());
+        }}
+        onPointerDown={suppressEditorRefocus}
+        variant="SurfaceVariant"
+        size="300"
+        style={{ backgroundColor: 'transparent' }}
+        title="Switch persona"
+        aria-label="Switch persona"
+      >
+        {(selectedRoomPersona ?? selectedGlobalPersona) ? (
+          <Avatar
+            size="200"
+            radii="300"
+            className={
+              AddPersonaMenuAnchor
+                ? css.SelectedPersonaPickerButtonAvatar
+                : css.PersonaPickerButtonAvatar
+            }
+            aria-label="Profile avatar"
+          >
+            <UserAvatar
+              className={css.PersonaPickerButtonAvatarImage}
+              userId={defactoPersona()!.id}
+              src={avatarUrl(defactoPersona()!)}
+              renderFallback={() => (
+                <Text as="span" size="H6" aria-label="Avatar fallback">
+                  {nameInitials(defactoPersona()!.name)}
+                </Text>
+              )}
+              alt={`Avatar for profile ${defactoPersona()!.id}`}
+            />
+          </Avatar>
+        ) : (
+          composerIcon(UserIcon, { weight: AddPersonaMenuAnchor ? 'fill' : 'regular' })
+        )}
+      </IconButton>
+    </ResponsiveMenu>
   );
 }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Persona picker now becomes a full-width `Overlay` on touch devices
- Tab buttons set `cursor: pointer`
- Popout is left-aligned to `RoomInput`, mirroring `EmojiBoard`

Part of #1279

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
