### PR TITLE
fix(ios): fall back to native clipboard for empty paste events in composer

### DIFF
--- a/.changeset/fix-ios-composer-paste.md
+++ b/.changeset/fix-ios-composer-paste.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix pasting text into the message composer on iOS, where the webview hands the paste event an empty clipboard and nothing got inserted.

--- a/src/app/components/editor/Editor.test.tsx
+++ b/src/app/components/editor/Editor.test.tsx
@@ -1,13 +1,25 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { Transforms } from 'slate';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Node, Transforms } from 'slate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEditor, CustomEditor } from './Editor';
 import { BlockType } from './types';
 import * as css from './Editor.css';
 
 let shouldWrapToggleHarness = false;
 let measurementCacheScrollHeightReads = 0;
+let isIosApp = false;
+let nativeClipboardText = '';
+
+vi.mock(import('$utils/user-agent'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  iosApp: () => isIosApp,
+}));
+
+vi.mock(import('$utils/dom'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  readClipboardText: () => Promise.resolve(nativeClipboardText),
+}));
 
 function EditorHarness() {
   const editor = useEditor();
@@ -177,6 +189,29 @@ function MeasurementCacheHarness() {
   );
 }
 
+let pasteFallbackEditor: ReturnType<typeof useEditor> | undefined;
+
+function PasteFallbackHarness() {
+  const editor = useEditor();
+  pasteFallbackEditor = editor;
+
+  return <CustomEditor editableName="PasteFallbackHarness" editor={editor} />;
+}
+
+const pastedLines = () => (pasteFallbackEditor?.children ?? []).map((node) => Node.string(node));
+
+const pasteIntoFallbackHarness = () => {
+  render(<PasteFallbackHarness />);
+  const editable = document.querySelector('[data-editable-name="PasteFallbackHarness"]');
+  const editor = pasteFallbackEditor;
+  if (!editable || !editor) throw new Error('paste fallback harness did not mount');
+
+  act(() => {
+    Transforms.select(editor, { path: [0, 0], offset: 0 });
+  });
+  fireEvent.paste(editable, { clipboardData: { files: [], getData: () => '' } });
+};
+
 const createResizeObserverStub = (
   observedElements: Set<Element>,
   onCreate: (callback: ResizeObserverCallback) => void
@@ -197,6 +232,10 @@ const createResizeObserverStub = (
     };
   } as unknown as typeof ResizeObserver;
 
+const nativeIsContentEditable = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'isContentEditable'
+);
 const nativeScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
 const nativeOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
 const nativeClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
@@ -209,6 +248,16 @@ const nativeResizeObserver = globalThis.ResizeObserver;
 beforeEach(() => {
   shouldWrapToggleHarness = false;
   measurementCacheScrollHeightReads = 0;
+  isIosApp = false;
+  nativeClipboardText = '';
+  pasteFallbackEditor = undefined;
+
+  Object.defineProperty(HTMLElement.prototype, 'isContentEditable', {
+    configurable: true,
+    get(): boolean {
+      return (this as HTMLElement).getAttribute('contenteditable') === 'true';
+    },
+  });
 
   Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
     configurable: true,
@@ -289,6 +338,12 @@ afterEach(() => {
   globalThis.requestAnimationFrame = nativeGlobalRequestAnimationFrame;
   globalThis.cancelAnimationFrame = nativeGlobalCancelAnimationFrame;
   globalThis.ResizeObserver = nativeResizeObserver;
+  if (nativeIsContentEditable) {
+    Object.defineProperty(HTMLElement.prototype, 'isContentEditable', nativeIsContentEditable);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, 'isContentEditable');
+  }
+
   if (nativeScrollHeight) {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', nativeScrollHeight);
   } else {
@@ -479,6 +534,27 @@ describe('CustomEditor', () => {
 
     expect(queuedFrames.size).toBe(0);
     expect(scroll).not.toHaveClass(css.EditorTextareaScrollMultiline);
+  });
+
+  it('reads the native clipboard when the ios webview delivers an empty paste event', async () => {
+    isIosApp = true;
+    nativeClipboardText = 'first line\nsecond line';
+
+    pasteIntoFallbackHarness();
+
+    await waitFor(() => {
+      expect(pastedLines()).toEqual(['first line', 'second line']);
+    });
+  });
+
+  it('leaves an empty paste event alone outside the ios webview', async () => {
+    nativeClipboardText = 'should not be pasted';
+
+    pasteIntoFallbackHarness();
+
+    await waitFor(() => {
+      expect(pastedLines()).toEqual(['']);
+    });
   });
 
   it('reuses the cached measurement when resize observer fires without changing the single-line width', async () => {

--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -7,11 +7,13 @@ import type {
 import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Box, Scroll, Text } from 'folds';
 import type { Descendant, Editor } from 'slate';
-import { Node, createEditor } from 'slate';
+import { Node, Transforms, createEditor } from 'slate';
 import type { RenderLeafProps, RenderElementProps, RenderPlaceholderProps } from 'slate-react';
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
 import { withHistory } from 'slate-history';
-import { mobileOrTablet } from '$utils/user-agent';
+import { iosApp, mobileOrTablet } from '$utils/user-agent';
+import { readClipboardText } from '$utils/dom';
+import { createLogger } from '$utils/debug';
 import { BlockType } from './types';
 import { RenderElement, RenderLeaf } from './Elements';
 import type { CustomElement } from './slate';
@@ -44,6 +46,18 @@ const withVoid = (editor: Editor): Editor => {
 export const useEditor = (): Editor => {
   const [editor] = useState(() => withInline(withVoid(withReact(withHistory(createEditor())))));
   return editor;
+};
+
+const log = createLogger('Editor');
+
+const hasPasteData = (data: DataTransfer): boolean =>
+  data.files.length > 0 || data.getData('text/plain') !== '' || data.getData('text/html') !== '';
+
+const insertPastedText = (editor: Editor, text: string): void => {
+  text.split(/\r\n|\r|\n/).forEach((line, index) => {
+    if (index > 0) Transforms.splitNodes(editor, { always: true });
+    Transforms.insertText(editor, line);
+  });
 };
 
 export type EditorChangeHandler = (value: Descendant[]) => void;
@@ -398,6 +412,23 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
       [editor, onKeyDown, shortcutOverrides]
     );
 
+    const handlePaste: ClipboardEventHandler = useCallback(
+      (evt) => {
+        onPaste?.(evt);
+        if (evt.isDefaultPrevented() || !iosApp() || hasPasteData(evt.clipboardData)) return;
+
+        evt.preventDefault();
+        readClipboardText()
+          .then((text) => {
+            if (text) insertPastedText(editor, text);
+          })
+          .catch((err: unknown) => {
+            log.warn('Failed to read the native clipboard on paste:', err);
+          });
+      },
+      [editor, onPaste]
+    );
+
     const renderPlaceholder = useCallback(
       ({ attributes, children }: RenderPlaceholderProps) => (
         <span {...attributes} className={css.EditorPlaceholderContainer}>
@@ -451,7 +482,7 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
                 renderLeaf={renderLeaf}
                 onKeyDown={handleKeydown}
                 onKeyUp={onKeyUp}
-                onPaste={onPaste}
+                onPaste={handlePaste}
                 // Defer to OS capitalization setting (respects iOS sentence-case toggle).
                 autoCapitalize="sentences"
                 autoCorrect="on"

--- a/src/app/utils/user-agent.ts
+++ b/src/app/utils/user-agent.ts
@@ -27,7 +27,17 @@ const normalizeMacName = (os?: string) => {
 
 const isMac = result.os.name === 'Mac OS' || result.os.name === 'macOS';
 
+const isIosApp = (() => {
+  if (!isTauri()) return false;
+  try {
+    return osType() === 'ios';
+  } catch {
+    return false;
+  }
+})();
+
 export const isMacOS = () => isMac;
+export const iosApp = () => isIosApp;
 export const mobileOrTablet = () => isMobileOrTablet;
 
 export const deviceDisplayName = (): string => {


### PR DESCRIPTION
…

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
fix pasting on ios

Fixes #1364

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
