### PR TITLE
feat: add retry button for homeserver discovery during login

### DIFF
--- a/.changeset/add_retry_button_for_homeserver_discovery_during_login.md
+++ b/.changeset/add_retry_button_for_homeserver_discovery_during_login.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Add retry button for homeserver discovery during login

--- a/src/app/components/AuthFlowsLoader.tsx
+++ b/src/app/components/AuthFlowsLoader.tsx
@@ -16,7 +16,7 @@ import { fetch } from '$utils/fetch';
 
 type AuthFlowsLoaderProps = {
   fallback?: () => ReactNode;
-  error?: (err: unknown) => ReactNode;
+  error?: (err: unknown, retry: () => void) => ReactNode;
   children: (authFlows: AuthFlows) => ReactNode;
 };
 export function AuthFlowsLoader({ fallback, error, children }: AuthFlowsLoaderProps) {
@@ -72,7 +72,7 @@ export function AuthFlowsLoader({ fallback, error, children }: AuthFlowsLoaderPr
   }
 
   if (state.status === AsyncStatus.Error) {
-    return error?.(state.error);
+    return error?.(state.error, load);
   }
 
   return children(state.data);

--- a/src/app/pages/auth/AuthLayout.tsx
+++ b/src/app/pages/auth/AuthLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useCallback, useEffect } from 'react';
-import { Box, Chip, Header, Scroll, Spinner, Text, color } from 'folds';
+import { Box, Chip, Header, IconButton, Scroll, Spinner, Text, color } from 'folds';
+import { ArrowClockwiseIcon } from '@phosphor-icons/react';
 import {
   Outlet,
   generatePath,
@@ -26,6 +27,7 @@ import { AuthServerProvider } from '$hooks/useAuthServer';
 import { LOGIN_PATH, REGISTER_PATH, RESET_PASSWORD_PATH } from '$pages/paths';
 import { getHomePath } from '$pages/pathUtils';
 import { fetch } from '$utils/fetch';
+import { sizedIcon } from '$components/icons/phosphor';
 import { AutoDiscoveryAction, autoDiscovery } from '../../cs-api';
 import type { SpecVersions } from '../../cs-api';
 import { ServerPicker } from './ServerPicker';
@@ -57,12 +59,23 @@ function AuthLayoutLoading({ message }: { message: string }) {
   );
 }
 
-function AuthLayoutError({ message }: { message: string }) {
+function AuthLayoutError({ message, retry }: { message: string; retry: () => void }) {
   return (
     <Box justifyContent="Center" alignItems="Center" gap="200">
       <Text align="Center" style={{ color: color.Critical.Main }} size="T300">
         {message}
       </Text>
+      <IconButton
+        type="button"
+        size="300"
+        variant="Critical"
+        fill="None"
+        onClick={retry}
+        aria-label="Retry"
+        radii="300"
+      >
+        {sizedIcon(ArrowClockwiseIcon, '100')}
+      </IconButton>
     </Box>
   );
 }
@@ -71,9 +84,12 @@ function AuthHomeserverConnectFallback({ baseUrl }: { baseUrl: string }) {
   return <AuthLayoutLoading message={`Connecting to ${baseUrl}`} />;
 }
 
-function authHomeserverConnectError() {
+function authHomeserverConnectError(_error: unknown, retry: () => void) {
   return (
-    <AuthLayoutError message="Failed to connect. Either homeserver is unavailable at this moment or does not exist." />
+    <AuthLayoutError
+      message="Failed to connect. Either homeserver is unavailable at this moment or does not exist."
+      retry={retry}
+    />
   );
 }
 
@@ -81,8 +97,8 @@ function authFlowsLoadingFallback() {
   return <AuthLayoutLoading message="Loading authentication flow..." />;
 }
 
-function authFlowsError() {
-  return <AuthLayoutError message="Failed to get authentication flow information." />;
+function authFlowsError(_error: unknown, retry: () => void) {
+  return <AuthLayoutError message="Failed to get authentication flow information." retry={retry} />;
 }
 
 function AuthFlowsOutlet({ authFlows }: { authFlows: AuthFlows }) {
@@ -138,6 +154,7 @@ export function AuthLayout() {
       };
     }, [])
   );
+  const retryHomeserverDiscovery = () => discoverServer(server);
 
   useEffect(() => {
     if (server) discoverServer(server);
@@ -234,15 +251,22 @@ export function AuthLayout() {
               <AuthLayoutLoading message="Looking for homeserver..." />
             )}
             {discoveryState.status === AsyncStatus.Error && (
-              <AuthLayoutError message="Failed to find homeserver." />
+              <AuthLayoutError
+                message="Failed to find homeserver."
+                retry={retryHomeserverDiscovery}
+              />
             )}
             {autoDiscoveryError?.action === AutoDiscoveryAction.FAIL_PROMPT && (
               <AuthLayoutError
                 message={`Failed to connect. Homeserver configuration found with ${autoDiscoveryError.host} appears unusable.`}
+                retry={retryHomeserverDiscovery}
               />
             )}
             {autoDiscoveryError?.action === AutoDiscoveryAction.FAIL_ERROR && (
-              <AuthLayoutError message="Failed to connect. Homeserver configuration base_url appears invalid." />
+              <AuthLayoutError
+                message="Failed to connect. Homeserver configuration base_url appears invalid."
+                retry={retryHomeserverDiscovery}
+              />
             )}
             {discoveryState.status === AsyncStatus.Success && autoDiscoveryInfo && (
               <AuthServerProvider value={discoveryState.data.serverName}>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1287 

Add retry button next to error after failed homeserver discovery
<img width="501" height="309" alt="image" src="https://github.com/user-attachments/assets/98a7de5c-c648-474e-8ee8-3148a823ee0a" />


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
