### PR TITLE
fix: show setting selects as dialogs on mobile and keep long-pressed sheets open

### DIFF
--- a/.changeset/fix-mobile-selects-and-long-press-sheet.md
+++ b/.changeset/fix-mobile-selects-and-long-press-sheet.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Show setting selects as a dialog on mobile instead of a bottom sheet, keep a long-pressed room's menu open, and stop wide setting tiles squeezing their title.

--- a/src/app/components/MobileSwipeDownModal.tsx
+++ b/src/app/components/MobileSwipeDownModal.tsx
@@ -27,6 +27,7 @@ export function useMobileSheetClose() {
 export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDownModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const touchStartY = useRef<number | null>(null);
+  const backdropTouchRef = useRef(false);
   const touchYDiff = useRef(0);
   const startTime = useRef(0);
   const [mounted, setMounted] = useState(false);
@@ -116,6 +117,16 @@ export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDown
     touchStartY.current = null;
   };
 
+  // A sheet opened by a long press mounts under the finger, and releasing it
+  // synthesises a click on the backdrop. Only a touch that started on the
+  // backdrop is a dismiss.
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    const fromTouch =
+      e.nativeEvent instanceof PointerEvent && e.nativeEvent.pointerType === 'touch';
+    if (fromTouch && !backdropTouchRef.current) return;
+    closeWithAnimation();
+  };
+
   const dragHandlers = {
     onTouchStart: handleTouchStart,
     onTouchMove: handleTouchMove,
@@ -135,8 +146,11 @@ export function MobileSwipeDownModal({ children, requestClose }: MobileSwipeDown
       className={css.MessageMobileOptionsWrapped}
       data-gestures="ignore"
       style={closing ? { opacity: 0, transition: 'opacity 100ms ease-out' } : undefined}
-      onClick={closeWithAnimation}
-      onTouchStart={(e: React.TouchEvent) => e.stopPropagation()}
+      onClick={handleBackdropClick}
+      onTouchStart={(e: React.TouchEvent) => {
+        backdropTouchRef.current = e.target === e.currentTarget;
+        e.stopPropagation();
+      }}
       onTouchMove={(e: React.TouchEvent) => e.stopPropagation()}
       onTouchEnd={(e: React.TouchEvent) => e.stopPropagation()}
     >

--- a/src/app/components/ResponsiveMenu.css.ts
+++ b/src/app/components/ResponsiveMenu.css.ts
@@ -1,6 +1,23 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 import { config, toRem } from 'folds';
 
+export const DialogContent = style({
+  width: `min(90vw, ${toRem(400)})`,
+  maxHeight: '85vh',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+// Same reach-by-selector trick as the sheet: neutralise the inline sizing the
+// callers set for their desktop popout so the menu fills the dialog.
+globalStyle(`${DialogContent} > *:last-child`, {
+  width: '100% !important',
+  maxWidth: 'none !important',
+  maxHeight: '100% !important',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
 export const SheetContent = style({
   width: '100%',
   maxHeight: '100%',

--- a/src/app/components/ResponsiveMenu.test.tsx
+++ b/src/app/components/ResponsiveMenu.test.tsx
@@ -19,6 +19,13 @@ vi.mock('folds', () => ({
       <div data-testid="popout-trigger">{children}</div>
     </div>
   ),
+  Overlay: ({ children, open }: any) => (open ? <div data-testid="overlay">{children}</div> : null),
+  OverlayBackdrop: () => <div data-testid="overlay-backdrop" />,
+  OverlayCenter: ({ children }: any) => <div data-testid="overlay-center">{children}</div>,
+}));
+
+vi.mock('$utils/androidBack', () => ({
+  useDismissOnBack: vi.fn<() => void>(),
 }));
 
 vi.mock('focus-trap-react', () => ({
@@ -78,6 +85,7 @@ function renderMenuMobile(props: {
   anchor: RectCords;
   menu: React.ReactNode;
   children?: React.ReactNode;
+  mobile?: 'sheet' | 'dialog';
 }) {
   return render(
     <ScreenSizeProvider value={ScreenSize.Mobile}>
@@ -197,6 +205,39 @@ describe('ResponsiveMenu', () => {
       expect(screen.getByTestId('mobile-swipe-down')).toBeInTheDocument();
       expect(screen.getByTestId('drag-handle')).toBeInTheDocument();
       expect(screen.getByTestId('focus-trap')).toBeInTheDocument();
+    });
+  });
+
+  describe('mobile branch (dialog)', () => {
+    it('renders a centred dialog instead of a sheet', () => {
+      renderMenuMobile({ anchor: anchorRect, menu: <SampleMenu />, mobile: 'dialog' });
+
+      expect(screen.getByTestId('overlay-center')).toBeTruthy();
+      expect(screen.getByTestId('sample-menu')).toBeTruthy();
+      expect(screen.queryByTestId('mobile-swipe-down')).toBeNull();
+      expect(screen.queryByTestId('drag-handle')).toBeNull();
+    });
+
+    it('does not render the dialog when anchor is undefined', () => {
+      render(
+        <ScreenSizeProvider value={ScreenSize.Mobile}>
+          <ResponsiveMenu
+            requestClose={vi.fn<() => void>()}
+            anchor={undefined}
+            mobile="dialog"
+            menu={<SampleMenu />}
+          />
+        </ScreenSizeProvider>
+      );
+
+      expect(screen.queryByTestId('overlay')).toBeNull();
+      expect(screen.queryByTestId('sample-menu')).toBeNull();
+    });
+
+    it('wraps the dialog in a FocusTrap', () => {
+      renderMenuMobile({ anchor: anchorRect, menu: <SampleMenu />, mobile: 'dialog' });
+
+      expect(screen.getByTestId('focus-trap')).toBeTruthy();
     });
   });
 

--- a/src/app/components/ResponsiveMenu.tsx
+++ b/src/app/components/ResponsiveMenu.tsx
@@ -1,14 +1,16 @@
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import type { RectCords } from 'folds';
-import { Box, PopOut } from 'folds';
+import { Box, Overlay, OverlayBackdrop, OverlayCenter, PopOut } from 'folds';
 import FocusTrap from 'focus-trap-react';
 import { ScreenSize, useScreenSizeOptionally } from '$hooks/useScreenSize';
 import { stopPropagation } from '$utils/keyboard';
+import { useDismissOnBack } from '$utils/androidBack';
 import { MobileSwipeDownModal } from './MobileSwipeDownModal';
 import * as css from './ResponsiveMenu.css';
 
 type ComponentPosition = 'Top' | 'Right' | 'Bottom' | 'Left';
 type ComponentAlign = 'Start' | 'Center' | 'End';
+type FocusTrapOptions = ComponentProps<typeof FocusTrap>['focusTrapOptions'];
 
 type ResponsiveMenuProps = {
   anchor: RectCords | undefined;
@@ -23,7 +25,35 @@ type ResponsiveMenuProps = {
   returnFocusOnDeactivate?: boolean;
   /** `both` also maps Left/Right, for menus laid out horizontally. */
   arrowNavigation?: 'vertical' | 'both';
+  /** How the menu shows on mobile: a bottom sheet, or a centred dialog for
+   *  option pickers, which a sheet makes look like an action menu. */
+  mobile?: 'sheet' | 'dialog';
 };
+
+function MenuDialog({
+  requestClose,
+  focusTrapOptions,
+  children,
+}: {
+  requestClose: () => void;
+  focusTrapOptions: FocusTrapOptions;
+  children: ReactNode;
+}) {
+  // Android back closes the dialog instead of navigating away.
+  useDismissOnBack(requestClose);
+
+  return (
+    <Overlay open backdrop={<OverlayBackdrop />}>
+      <OverlayCenter>
+        <FocusTrap focusTrapOptions={focusTrapOptions}>
+          <Box direction="Column" role="dialog" aria-modal="true" className={css.DialogContent}>
+            {children}
+          </Box>
+        </FocusTrap>
+      </OverlayCenter>
+    </Overlay>
+  );
+}
 
 /**
  * A menu that hangs off its trigger on desktop and rises as a bottom sheet on
@@ -40,6 +70,7 @@ export function ResponsiveMenu({
   offset,
   returnFocusOnDeactivate = false,
   arrowNavigation = 'vertical',
+  mobile = 'sheet',
 }: ResponsiveMenuProps) {
   // Null outside a provider, where desktop is the safe assumption.
   const isMobile = useScreenSizeOptionally() === ScreenSize.Mobile;
@@ -65,10 +96,24 @@ export function ResponsiveMenu({
     return (
       <>
         {children}
-        {anchor && (
+        {anchor && mobile === 'dialog' && (
+          <MenuDialog requestClose={requestClose} focusTrapOptions={focusTrapOptions}>
+            {menu}
+          </MenuDialog>
+        )}
+        {anchor && mobile === 'sheet' && (
           <MobileSwipeDownModal requestClose={requestClose}>
             {(dragHandle) => (
-              <FocusTrap focusTrapOptions={focusTrapOptions}>
+              <FocusTrap
+                focusTrapOptions={{
+                  ...focusTrapOptions,
+                  // The backdrop owns tap-to-dismiss. Left to focus-trap, the
+                  // mousedown synthesised when a long press is released lands on
+                  // the backdrop and reads as a click outside.
+                  clickOutsideDeactivates: false,
+                  allowOutsideClick: true,
+                }}
+              >
                 <Box
                   direction="Column"
                   role="dialog"

--- a/src/app/components/create-room/RoomVersionSelector.tsx
+++ b/src/app/components/create-room/RoomVersionSelector.tsx
@@ -44,6 +44,7 @@ export function RoomVersionSelector({
             offset={5}
             position="Bottom"
             align="End"
+            mobile="dialog"
             menu={
               <Menu>
                 <Box

--- a/src/app/components/setting-menu-selector/SettingMenuSelector.tsx
+++ b/src/app/components/setting-menu-selector/SettingMenuSelector.tsx
@@ -180,6 +180,7 @@ export function SettingMenuSelector<T extends string | number>({
         align={align}
         returnFocusOnDeactivate
         arrowNavigation="both"
+        mobile="dialog"
         menu={
           <Menu
             style={

--- a/src/app/components/setting-tile/SettingTile.css.ts
+++ b/src/app/components/setting-tile/SettingTile.css.ts
@@ -1,7 +1,22 @@
 import { style } from '@vanilla-extract/css';
+import { toRem } from 'folds';
 
 export const settingTileRoot = style({
   minWidth: 0,
+  flexWrap: 'wrap',
+});
+
+// Basis rather than a bare `minWidth: 0`, so a wide control drops to its own
+// row instead of squeezing the title down to one word per line.
+export const settingTileMain = style({
+  minWidth: 0,
+  flexBasis: toRem(200),
+});
+
+export const settingTileTrailing = style({
+  marginInlineStart: 'auto',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
 });
 
 export const settingTileTitleRow = style({

--- a/src/app/components/setting-tile/SettingTile.tsx
+++ b/src/app/components/setting-tile/SettingTile.tsx
@@ -14,6 +14,8 @@ import {
   settingTileSettingLinkActionMobileVisible,
   settingTileSettingLinkActionTransparentBackground,
   settingTileRoot,
+  settingTileMain,
+  settingTileTrailing,
   settingTileTitleRow,
 } from './SettingTile.css';
 
@@ -88,7 +90,7 @@ export function SettingTile({
 
   const trailing =
     after || trailingCopyAction ? (
-      <Box shrink="No" alignItems="Center" gap="200">
+      <Box className={settingTileTrailing} shrink="No" alignItems="Center" gap="200">
         {after}
         {trailingCopyAction}
       </Box>
@@ -103,7 +105,7 @@ export function SettingTile({
       gap="300"
     >
       {before && <Box shrink="No">{before}</Box>}
-      <Box grow="Yes" direction="Column" gap="100">
+      <Box className={settingTileMain} grow="Yes" direction="Column" gap="100">
         {title && (
           <Box
             data-setting-tile-title-row="true"

--- a/tests/e2e/touch.spec.ts
+++ b/tests/e2e/touch.spec.ts
@@ -1,4 +1,13 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures/test';
+
+async function longPress(page: Page, x: number, y: number): Promise<void> {
+  const cdp = await page.context().newCDPSession(page);
+  const touchPoints = [{ x: Math.round(x), y: Math.round(y) }];
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints });
+  await page.waitForTimeout(600);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+}
 
 test.describe('touch interactions', () => {
   test('long-press opens a bottom-sheet context menu', async ({ app, page }) => {
@@ -59,6 +68,29 @@ test.describe('touch interactions', () => {
     // rendered inside the MessageMobileOptionsContainer (z-index 1005, fixed at bottom)
     const sheet = page.locator('[data-gestures="ignore"]').first();
     await expect(sheet).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('long-press on a room opens its menu instead of navigating', async ({ app, page }) => {
+    const roomItem = app.room('General');
+    const box = await roomItem.boundingBox();
+    if (!box) throw new Error('Room item not visible');
+
+    await longPress(page, box.x + box.width / 2, box.y + box.height / 2);
+
+    await expect(page.getByText('Leave Room')).toBeVisible({ timeout: 5_000 });
+
+    // Tapping the backdrop still dismisses it.
+    await page.touchscreen.tap(box.x + box.width / 2, 8);
+    await expect(page.getByText('Leave Room')).toBeHidden({ timeout: 5_000 });
+  });
+
+  test('a single tap opens a room', async ({ app, page }) => {
+    const box = await app.room('General').boundingBox();
+    if (!box) throw new Error('Room item not visible');
+
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2);
+
+    await expect(page.getByText('Welcome to the test room.')).toBeVisible({ timeout: 10_000 });
   });
 
   // Never passed. The sheet does not dismiss from a downward swipe under real


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
