### PR TITLE
fix(mobile): stop swipe handlers swallowing taps in bottom sheets

### DIFF
--- a/src/app/components/ResponsiveMenu.tsx
+++ b/src/app/components/ResponsiveMenu.tsx
@@ -66,15 +66,13 @@ export function ResponsiveMenu({
         {children}
         {anchor && (
           <MobileSwipeDownModal requestClose={requestClose}>
-            {(dragHandle, dragHandlers) => (
+            {(dragHandle) => (
               <FocusTrap focusTrapOptions={focusTrapOptions}>
                 <Box
                   direction="Column"
                   role="dialog"
                   aria-modal="true"
                   className={css.SheetContent}
-                  // Swiping anywhere on the sheet dismisses it, not just the handle.
-                  {...dragHandlers}
                 >
                   {dragHandle}
                   {menu}

--- a/tests/e2e/touch.spec.ts
+++ b/tests/e2e/touch.spec.ts
@@ -134,8 +134,10 @@ test.describe('touch interactions', () => {
     await expect(sheetContainer).toBeHidden({ timeout: 3_000 });
   });
 
-  // Never passed: the Save click times out on a touch viewport, so the long
-  // status is never persisted and the overflow assertion never runs.
+  // Never passed: the Save click times out on a touch viewport (Save button is
+  // disabled/not-clickable on touch), so the long status is never persisted.
+  // Separate from the ResponsiveMenu tap-swallowing bug — StatusEditor Save is
+  // a regular button on a route, not inside a sheet. Investigate before enabling.
   test.fixme('settings page has no horizontal overflow', async ({ app, page }) => {
     // Confirm the client is loaded (app.open() has already waited for room list)
     await expect(app.room('General')).toBeVisible();


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fix issue with settings

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
