### PR TITLE
fix(e2e): give sliding-sync recovery-key reveal its full 180s budget

### DIFF
--- a/tests/e2e/device-verification-reset.spec.ts
+++ b/tests/e2e/device-verification-reset.spec.ts
@@ -152,7 +152,9 @@ test.describe('device verification reset', () => {
   test('sets up verification when the session syncs over sliding sync', async ({
     page,
   }, testInfo) => {
-    test.setTimeout(180_000);
+    // Sliding sync serialises the crypto bootstrap across long-poll round-trips,
+    // so this test needs more headroom than the 180s its siblings use.
+    test.setTimeout(240_000);
     const storageStatePath = testInfo.project.use.storageState as string;
     const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
     await loginAsFreshUser(
@@ -168,6 +170,6 @@ test.describe('device verification reset', () => {
     await expect(page.getByText('Setup Device Verification')).toBeVisible();
     await page.locator('form').getByRole('button', { name: 'Continue' }).click();
 
-    await expect(recoveryKeyShown(page)).toBeVisible({ timeout: 120_000 });
+    await expect(recoveryKeyShown(page)).toBeVisible({ timeout: 180_000 });
   });
 });


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

fix flaky e2e

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code in this PR does in moderate detail).

