### PR TITLE
fix: stop click handlers firing after long-press and drag-select

### DIFF
--- a/src/app/components/message/RenderBody.tsx
+++ b/src/app/components/message/RenderBody.tsx
@@ -10,6 +10,7 @@ import { PopOut, Text, Tooltip, TooltipProvider, toRem } from 'folds';
 import { sanitizeCustomHtml } from '$utils/sanitize';
 import { highlightText, scaleSystemEmoji } from '$plugins/react-custom-html-parser';
 import { useRoomAbbreviationsContext } from '$hooks/useRoomAbbreviations';
+import { isMobileOrTablet } from '$utils/platform';
 import type { TextSegment } from '$utils/abbreviations';
 import { splitByAbbreviations } from '$utils/abbreviations';
 import { MessageEmptyContent } from './content';
@@ -91,6 +92,7 @@ function AbbreviationTerm({ text, definition }: AbbreviationTermProps) {
   };
 
   const handleClick: MouseEventHandler<HTMLElement> = (e) => {
+    if (!window.getSelection()?.isCollapsed) return;
     e.stopPropagation();
     toggleAnchor(e.currentTarget);
   };
@@ -140,6 +142,7 @@ function AbbreviationTerm({ text, definition }: AbbreviationTermProps) {
               padding: 0,
               font: 'inherit',
               color: 'inherit',
+              userSelect: isMobileOrTablet() ? 'none' : 'text',
             }}
           >
             {text}

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -379,6 +379,7 @@ export function RoomNavItem({
   };
 
   const handleNavItemClick: MouseEventHandler<HTMLElement> = (evt) => {
+    if (menu.consumeLongPressFired() || menu.anchor) return;
     if (room.isCallRoom()) {
       if (!livekitSupport(autoDiscoveryInfo) && callMembers.length === 0) return;
       if (callEmbed && !isActiveCall) return;

--- a/src/app/hooks/useMentionClickHandler.ts
+++ b/src/app/hooks/useMentionClickHandler.ts
@@ -21,6 +21,7 @@ export const useMentionClickHandler = (roomId: string): ReactEventHandler<HTMLEl
 
   const handleClick: ReactEventHandler<HTMLElement> = useCallback(
     (evt) => {
+      if (!window.getSelection()?.isCollapsed) return;
       evt.stopPropagation();
       evt.preventDefault();
       const target = evt.currentTarget;

--- a/src/app/pages/client/sidebar/SpaceTabs.tsx
+++ b/src/app/pages/client/sidebar/SpaceTabs.tsx
@@ -540,10 +540,14 @@ function SpaceTab({
 }: Readonly<SpaceTabProps>) {
   const isMobile = useScreenSizeContext() === ScreenSize.Mobile;
   const targetRef = useRef<HTMLDivElement>(null);
+  const menu = useMenuAnchor<HTMLButtonElement>();
   const mobileTapActivation = useMobileTapActivation(
     isMobile,
     () => onSelect(space.roomId),
-    () => onSelect(space.roomId)
+    () => {
+      if (menu.consumeLongPressFired() || menu.anchor) return;
+      onSelect(space.roomId);
+    }
   );
 
   const spaceDraggable: SidebarDraggable = useMemo(
@@ -560,8 +564,6 @@ function SpaceTab({
   useDraggableItem(spaceDraggable, targetRef, onDragging, undefined, !isMobile);
   const dropState = useDropTarget(spaceDraggable, targetRef, !isMobile);
   const dropType = dropState?.type;
-
-  const menu = useMenuAnchor<HTMLButtonElement>();
 
   return (
     <RoomUnreadProvider roomId={space.roomId}>


### PR DESCRIPTION


<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Long-press on a room/space nav item opened the context menu, but the synthetic click that followed navigated and immediately dismissed it. Guard the click path with menu.consumeLongPressFired() (RoomNavItem, SpaceTabs).

Drag-selecting across an abbreviation or mention link fired click on mouseup, toggling the tooltip or navigating away and killing the selection. Guard those handlers with a collapsed-selection check (AbbreviationTerm, useMentionClickHandler) and make abbreviation text selectable on desktop only (mobile keeps userSelect:none so the long-press context menu isn't hijacked by the native callout).

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
