### PR TITLE
fix(ios): make AltStore/SideStore register nightly updates

### DIFF
--- a/.github/scripts/release-meta.mjs
+++ b/.github/scripts/release-meta.mjs
@@ -17,9 +17,11 @@ export function computeNightlyVersion(baseVersion, timestamp = new Date()) {
   const d = String(timestamp.getUTCDate()).padStart(2, '0');
   const h = String(timestamp.getUTCHours()).padStart(2, '0');
   const min = String(timestamp.getUTCMinutes()).padStart(2, '0');
+  const sec = String(timestamp.getUTCSeconds()).padStart(2, '0');
 
   const [, major, minor, patch] = match;
-  return `${major}.${minor}.${Number(patch) + 1}-nightly.${y}${m}${d}${h}${min}`;
+  // Second resolution so same-minute commits get distinct build versions.
+  return `${major}.${minor}.${Number(patch) + 1}-nightly.${y}${m}${d}${h}${min}${sec}`;
 }
 
 export function nightlyVersion() {

--- a/altstore-source.json
+++ b/altstore-source.json
@@ -1,5 +1,6 @@
 {
   "name": "Sable",
+  "identifier": "moe.sable.client.source",
   "subtitle": "Sable for iOS",
   "description": "Sable iOS nightly builds for AltStore and SideStore.",
   "iconURL": "https://raw.githubusercontent.com/SableClient/Sable/dev/src-tauri/icons/icon.png",


### PR DESCRIPTION
Nightly build version was minute-resolution, so same-minute commits or identical rebuilds produced the same CFBundleVersion. AltStore and SideStore detect updates by exact string-equality on CFBundleVersion, so a collision meant no update was shown. Bump to second resolution.

Add the top-level identifier SideStore requires to link the source to installed apps; AltStore ignores it.

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
