### PR TITLE
fix: retry media after token refresh

### DIFF
--- a/src/sw-media-auth-recovery.test.ts
+++ b/src/sw-media-auth-recovery.test.ts
@@ -49,8 +49,9 @@ describe('service worker media auth recovery', () => {
     vi.mocked(fetch).mockImplementation(async (_input, init) => {
       const headers = new Headers(init?.headers);
       ranges.push({ authorization: headers.get('authorization'), range: headers.get('range') });
-      return new Response('', {
-        status: headers.get('authorization') === 'Bearer old-token' ? 401 : 206,
+      const isOldToken = headers.get('authorization') === 'Bearer old-token';
+      return new Response(isOldToken ? JSON.stringify({ errcode: 'M_UNKNOWN_TOKEN' }) : '', {
+        status: isOldToken ? 401 : 206,
       });
     });
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -775,16 +775,6 @@ function respondWithInflightMedia(
   );
 }
 
-async function isUnknownTokenError(response: Response): Promise<boolean> {
-  if (response.status !== 401) return false;
-  try {
-    const data = await response.clone().json();
-    return data?.errcode === 'M_UNKNOWN_TOKEN';
-  } catch {
-    return false;
-  }
-}
-
 async function respondWithMediaAuthRecovery(
   request: Request,
   session: SessionInfo,
@@ -793,7 +783,6 @@ async function respondWithMediaAuthRecovery(
 ): Promise<Response> {
   const response = await respondWithInflightMedia(request, session.accessToken, redirect);
   if ((response.status !== 401 && response.status !== 403) || !clientId) return response;
-  if (await isUnknownTokenError(response)) return response;
 
   // One exact-client retry; concurrent recoveries share this request.
   const refreshed = await requestSessionWithTimeout(clientId);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix issue when we load a fresh page and sometime there is no media or anything with oidc 


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
