### PR TITLE
fix: handle gallery messages without items

### DIFF
--- a/src/app/components/message/MGallery.test.tsx
+++ b/src/app/components/message/MGallery.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { IContent } from 'matrix-js-sdk';
+import type { IGalleryContent } from '$types/matrix/common';
+import { MGallery } from './MGallery';
+
+describe('MGallery', () => {
+  it('does not crash when a received gallery omits itemtypes', () => {
+    const renderItem = vi.fn<(content: IContent, index: number) => ReactNode>(() => null);
+
+    expect(() =>
+      render(
+        <MGallery
+          content={{ msgtype: 'dm.filament.gallery', body: 'Missing items' } as IGalleryContent}
+          renderItem={renderItem}
+        />
+      )
+    ).not.toThrow();
+
+    expect(renderItem).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/message/MGallery.tsx
+++ b/src/app/components/message/MGallery.tsx
@@ -25,7 +25,7 @@ type PartitionedMediaItem = {
 };
 
 export function MGallery({ content, renderItem }: MGalleryProps) {
-  const items = content.itemtypes;
+  const items = Array.isArray(content.itemtypes) ? content.itemtypes : [];
 
   let mediaItems = items.filter(
     (item) => item.itemtype == MsgType.Video || item.itemtype == MsgType.Image


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
