### PR TITLE
fix(media): stream ranged media through the service worker instead of buffering it

### DIFF
--- a/src/sw-media-auth-recovery.test.ts
+++ b/src/sw-media-auth-recovery.test.ts
@@ -86,6 +86,33 @@ describe('service worker media auth recovery', () => {
     ]);
   });
 
+  it('streams a ranged response without waiting for the whole body', async () => {
+    const session = { accessToken: 'token', baseUrl: 'https://matrix.example.org' };
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(body, { status: 206, headers: { 'Content-Range': 'bytes 0-1/2' } })
+    );
+
+    const request = new Request(
+      'https://matrix.example.org/_matrix/client/v1/media/download/example.org/media-id',
+      { headers: { Range: 'bytes=0-' } }
+    );
+
+    // Buffering the body would hang here: the stream is still open.
+    const response = await swTestHooks.respondWithMediaAuthRecovery(request, session, 'follow');
+    expect(response.status).toBe(206);
+    expect(response.headers.get('Content-Range')).toBe('bytes 0-1/2');
+
+    bodyController?.enqueue(new Uint8Array([1, 2]));
+    bodyController?.close();
+    await expect(response.arrayBuffer()).resolves.toHaveProperty('byteLength', 2);
+  });
+
   it('posts a new session request after a previous request times out', async () => {
     const client = {
       id: 'client-timeout',

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -731,12 +731,32 @@ type BufferedMediaResponse = {
 
 const inflightMediaFetches = new Map<string, Promise<BufferedMediaResponse>>();
 
+// Ranged media is streamed straight through: buffering it would hold playback until the whole
+// file had arrived, and sharing an in-flight fetch buys nothing when each request is its own
+// byte range.
+function respondWithStreamedMedia(
+  request: Request,
+  token: string,
+  redirect: RequestRedirect
+): Promise<Response> {
+  return fetch(request.url, { ...fetchConfig(token, request), redirect }).then(
+    (res) =>
+      new Response(res.body, {
+        status: res.status,
+        statusText: res.statusText,
+        headers: new Headers(res.headers),
+      })
+  );
+}
+
 function respondWithInflightMedia(
   request: Request,
   token: string,
   redirect: RequestRedirect
 ): Promise<Response> {
   const range = request.headers.get('Range') ?? '';
+  if (range) return respondWithStreamedMedia(request, token, redirect);
+
   const key = `${token}\x00${request.url}\x00${redirect}\x00${range}`;
   const existing = inflightMediaFetches.get(key);
   if (existing) {
@@ -794,6 +814,8 @@ async function respondWithMediaAuthRecovery(
     return response;
   }
 
+  // The retry replaces this response, so release its body rather than leaving the stream open.
+  await response.body?.cancel().catch(() => undefined);
   return respondWithInflightMedia(request, refreshed.accessToken, redirect);
 }
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
