### PR TITLE
Add persona latching when using shorthands

### DIFF
--- a/.changeset/add_persona_latching_when_using_shorthands.md
+++ b/.changeset/add_persona_latching_when_using_shorthands.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add persona latching when using shorthands

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -151,6 +151,8 @@ import {
   convertPerMessageProfileToBeeperFormat,
   getCurrentlyUsedPerMessageProfileForAccount,
   getCurrentlyUsedPerMessageProfileForRoom,
+  type PerMessageProfile,
+  setCurrentlyUsedPerMessageProfileIdForRoom,
 } from '$hooks/usePerMessageProfile';
 import {
   Bell,
@@ -336,7 +338,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     const [pkCompatEnable] = useSetting(settingsAtom, 'pkCompat');
     const [pmpProxyingEnable] = useSetting(settingsAtom, 'pmpProxying');
+    const [pmpLatchingEnable] = useSetting(settingsAtom, 'pmpLatching');
     const [pmpPickerEnable] = useSetting(settingsAtom, 'pmpPicker');
+
+    const [latchedPersona, setLatchedPersona] = useState<PerMessageProfile>();
 
     const emojiBtnRef = useRef<HTMLButtonElement>(null);
     const gifBtnRef = useRef<HTMLButtonElement>(null);
@@ -1284,6 +1289,15 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                 room,
               })
             );
+
+            if (pmpLatchingEnable) {
+              await setCurrentlyUsedPerMessageProfileIdForRoom(
+                mx,
+                roomId,
+                proxiedPerMessageProfile.id
+              );
+              setLatchedPersona(proxiedPerMessageProfile);
+            }
           }
         }
       }
@@ -1325,7 +1339,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
        */
       const globalPerMessageProfile = await getCurrentlyUsedPerMessageProfileForAccount(mx);
       const roomPerMessageProfile = await getCurrentlyUsedPerMessageProfileForRoom(mx, roomId);
-      let perMessageProfile = roomPerMessageProfile ?? globalPerMessageProfile;
+      let perMessageProfile = latchedPersona ?? roomPerMessageProfile ?? globalPerMessageProfile;
 
       if (pmpProxyingEnable) {
         if (proxiedPerMessageProfile) perMessageProfile = proxiedPerMessageProfile;
@@ -1485,6 +1499,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       replyDraft,
       silentReply,
       pmpProxyingEnable,
+      pmpLatchingEnable,
       pluralkitProxyMessageHandler,
       scheduledTime,
       editingScheduledDelayId,
@@ -1509,6 +1524,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       editingEvent,
       getEditingContent,
       onCancelEdit,
+      latchedPersona,
     ]);
 
     const handleKeyDown: KeyboardEventHandler = useCallback(
@@ -2162,6 +2178,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                   roomId={roomId}
                   suppressEditorRefocus={suppressEditorRefocus}
                   onTabChange={setPersonaPickerTab}
+                  latchedPersona={latchedPersona}
                 />
               )}
             </>

--- a/src/app/features/room/persona-picker/PersonaPicker.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.tsx
@@ -53,6 +53,7 @@ type PersonaPickerProps = {
   roomId: string;
   suppressEditorRefocus: () => void;
   onTabChange: (tab: PersonaPickerTab) => void;
+  latchedPersona: PerMessageProfile | undefined;
 };
 
 export function PersonaPicker({
@@ -61,6 +62,7 @@ export function PersonaPicker({
   roomId,
   suppressEditorRefocus,
   onTabChange,
+  latchedPersona,
 }: PersonaPickerProps) {
   const useAuthentication = useMediaAuthentication();
   const [AddPersonaMenuAnchor, setAddPersonaMenuAnchor] = useState<RectCords>();
@@ -68,7 +70,9 @@ export function PersonaPicker({
   const [selectedGlobalPersona, setSelectedGlobalPersona] = useState<PerMessageProfile | null>(
     null
   );
-  const [selectedRoomPersona, setSelectedRoomPersona] = useState<PerMessageProfile | null>(null);
+  const [selectedRoomPersona, setSelectedRoomPersona] = useState<PerMessageProfile | null>(
+    latchedPersona ?? null
+  );
   const isPickerMenuItemSelected = (persona: PerMessageProfile) => {
     const selectedPersona =
       tab === PersonaPickerTab.Global ? selectedGlobalPersona : selectedRoomPersona;
@@ -94,13 +98,13 @@ export function PersonaPicker({
   useEffect(() => {
     const syncProfile = async () => {
       const syncedRoomProfile = await getCurrentlyUsedPerMessageProfileForRoom(mx, roomId);
-      setSelectedRoomPersona(syncedRoomProfile ?? null);
+      if (!selectedRoomPersona) setSelectedRoomPersona(syncedRoomProfile ?? null);
 
       const syncedGlobalProfile = await getCurrentlyUsedPerMessageProfileForAccount(mx);
       setSelectedGlobalPersona(syncedGlobalProfile ?? null);
     };
     syncProfile();
-  }, [mx, roomId, profiles]);
+  }, [mx, roomId, profiles, latchedPersona, selectedRoomPersona]);
 
   const fetchProfiles = async (mx_: MatrixClient) => {
     const fetchedProfiles = await getAllPerMessageProfiles(mx_);

--- a/src/app/features/settings/Persona/PKCompat.tsx
+++ b/src/app/features/settings/Persona/PKCompat.tsx
@@ -7,6 +7,7 @@ import { Box, Switch, Text } from 'folds';
 export function PKCompatSettings() {
   const [usePKCompat, setUsePKCompat] = useSetting(settingsAtom, 'pkCompat');
   const [usePmpProxying, setUsePmpProxying] = useSetting(settingsAtom, 'pmpProxying');
+  const [usePmpLatching, setUsePmpLatching] = useSetting(settingsAtom, 'pmpLatching');
 
   return (
     <Box direction="Column" gap="100">
@@ -50,6 +51,30 @@ export function PKCompatSettings() {
                 usePmpProxying
                   ? 'disable checking typed messages for shorthands'
                   : 'enable checking typed messages for shorthands'
+              }
+            />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="100"
+      >
+        <SettingTile
+          focusId="enable-pk-latching"
+          title="Enable Shorthand Latching"
+          description="If enabled, you change a room's persona when you use a shorthand."
+          after={
+            <Switch
+              variant="Primary"
+              value={usePmpLatching}
+              onChange={setUsePmpLatching}
+              title={
+                usePmpLatching
+                  ? 'disable latching when using a shorthand'
+                  : 'enable latching when using a shorthand'
               }
             />
           }

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -240,6 +240,7 @@ export interface Settings {
   highlightMentions: boolean;
   pkCompat: boolean;
   pmpProxying: boolean;
+  pmpLatching: boolean;
   pmpPicker: boolean;
   mentionInReplies: boolean;
   profileChangePropagation: ProfileChangePropagation;
@@ -419,6 +420,7 @@ export const defaultSettings: Settings = {
   highlightMentions: true,
   pkCompat: false,
   pmpProxying: false,
+  pmpLatching: false,
   pmpPicker: false,
   mentionInReplies: true,
   profileChangePropagation: 'unchanged',


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds 'latching', a PluralKit feature where if a shorthand is used it will set the proxy to be used for subsequent messages. This is a setting that is off by default.

Part of #1279

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
