### PR TITLE
2 line fix for de-linkifying broken elements

### DIFF
--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -50,6 +50,7 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'right-aligned-bubbles',
     'right-swipe-action',
     'session-replay',
+    'export-diagnostics',
     'show-hidden-events',
     'hidden-event-edits',
     'show-redacted-message-tombstones',

--- a/src/app/plugins/react-custom-html-parser.tsx
+++ b/src/app/plugins/react-custom-html-parser.tsx
@@ -644,7 +644,7 @@ export const getReactCustomHtmlParser = (
     replace: (domNode) => {
       if (replaceTextNode && domNode instanceof DOMText) {
         const replacement = replaceTextNode(domNode.data, (text, key) =>
-          renderReplacementText(text, shouldLinkifyDomText(domNode), key)
+          renderReplacementText(text, !!params.linkifyOpts && shouldLinkifyDomText(domNode), key)
         );
 
         if (replacement !== undefined) {
@@ -1019,7 +1019,7 @@ export const getReactCustomHtmlParser = (
       }
 
       if (domNode instanceof DOMText) {
-        const linkify = shouldLinkifyDomText(domNode);
+        const linkify = !!params.linkifyOpts && shouldLinkifyDomText(domNode);
         const decoratedText = decorateText(domNode.data);
 
         if (linkify) {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This is a 2 line fix for the previous thing for this message specifically that i saw and then reproduced and checked for everything i can think of

<img width="1355" height="23" alt="image" src="https://github.com/user-attachments/assets/6f97c3d7-c00d-499e-885c-32e1ba1f7549" />

and apparently export-diagnostics missing a settingslink(??)

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Written w the assistance of the confusion of why i removed these lines from the previous pr forgetting why i added them :>