### PR TITLE
fix: device display name and update display name on mount

### DIFF
--- a/.changeset/device-display-name.md
+++ b/.changeset/device-display-name.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Update device display name post-login to reflect the current platform and flavor (e.g. "Sable Desktop (Nightly) on Windows").

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -32,10 +32,10 @@ fn main() {
     ) {
         format!("{} Nightly", base)
     } else {
-        base
+        base.clone()
     };
 
-    println!("cargo:rustc-env=SABLE_PRODUCT_NAME={}", full_name);
+    println!("cargo:rustc-env=SABLE_PRODUCT_NAME={}", base);
     println!(
         "cargo:rustc-env=TAURI_CONFIG={{\"productName\":\"{}\"}}",
         full_name

--- a/src/app/hooks/useDeviceDisplayName.ts
+++ b/src/app/hooks/useDeviceDisplayName.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+import { ClientEvent, SyncState } from '$types/matrix-sdk';
+import type { MatrixClient } from '$types/matrix-sdk';
+import { deviceDisplayName } from '$utils/platform';
+import { createLogger } from '$utils/debug';
+
+const SYNC_READY = new Set([SyncState.Prepared, SyncState.Syncing, SyncState.Catchup]);
+const log = createLogger('useDeviceDisplayName');
+
+async function updateDeviceName(mx: MatrixClient) {
+  const desired = deviceDisplayName();
+  const device = await mx.getDevice(mx.getDeviceId()!);
+  if (device?.display_name === desired) {
+    log.log('already set:', desired);
+    return;
+  }
+  await mx.setDeviceDetails(mx.getDeviceId()!, { display_name: desired });
+  log.log(desired);
+}
+
+export function useDeviceDisplayName(mx: MatrixClient | undefined) {
+  const updatedRef = useRef(false);
+
+  useEffect(() => {
+    if (!mx || updatedRef.current) return;
+
+    const state = mx.getSyncState();
+    if (state && SYNC_READY.has(state)) {
+      updatedRef.current = true;
+      updateDeviceName(mx).catch(() => {});
+      return;
+    }
+
+    const onSync = (syncState: SyncState) => {
+      if (SYNC_READY.has(syncState)) {
+        mx.removeListener(ClientEvent.Sync, onSync);
+        updatedRef.current = true;
+        updateDeviceName(mx).catch(() => {});
+      }
+    };
+    mx.on(ClientEvent.Sync, onSync);
+
+    return () => {
+      mx.removeListener(ClientEvent.Sync, onSync);
+    };
+  }, [mx]);
+}

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -37,6 +37,7 @@ import { MatrixClientProvider } from '$hooks/useMatrixClient';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { useSyncState } from '$hooks/useSyncState';
 import { useCrossSigningResetDetect } from '$hooks/useCrossSigningResetDetect';
+import { useDeviceDisplayName } from '$hooks/useDeviceDisplayName';
 import { useMatrixEvent } from '$hooks/useMatrixEvent';
 import { stopPropagation } from '$utils/keyboard';
 import { AuthMetadataProvider, getSessionAuthMetadata } from '$hooks/useAuthMetadata';
@@ -351,6 +352,7 @@ export function ClientRoot({ children }: ClientRootProps) {
   useAppVisibility(mx);
   useNetworkRecovery(mx);
   useCrossSigningResetDetect(mx);
+  useDeviceDisplayName(mx);
 
   useEffect(
     () => () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,7 +138,6 @@ function serverMatrixSdkCryptoWasm() {
 
 export default defineConfig(({ command }) => {
   const buildFlavor = process.env.SABLE_BUILD_FLAVOR || (command === 'serve' ? 'dev' : 'stable');
-  const productName = buildFlavor !== 'stable' ? `${baseProductName} Nightly` : baseProductName;
 
   return {
     clearScreen: false,
@@ -150,7 +149,7 @@ export default defineConfig(({ command }) => {
       APP_VERSION: JSON.stringify(appVersion),
       BUILD_HASH: JSON.stringify(buildHash ?? ''),
       IS_RELEASE_TAG: JSON.stringify(isReleaseTag),
-      SABLE_PRODUCT_NAME: JSON.stringify(productName),
+      SABLE_PRODUCT_NAME: JSON.stringify(baseProductName),
       SABLE_BUILD_FLAVOR: JSON.stringify(buildFlavor),
     },
     resolve: {


### PR DESCRIPTION
### Description

Adds `useDeviceDisplayName` hook which updates the device display name on mount. Previously we only set the display name at login. This should update the older sessions to the new naming scheme and makes it easier to change it, if we end up changing it again.

Fixes the updated display name to avoid showing up the build flavor twice:
 previously: `Sable Nightly Desktop (Nightly) on Windows`
 now: `Sable Desktop (Nightly) on Windows`

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
