### PR TITLE
fix: recover recent room history

### DIFF
--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -35,7 +35,6 @@ import type { SlidingSyncDiagnostics } from './slidingSync';
 import { scopeEphemeralExtensions, SlidingSyncManager } from './slidingSync';
 import { PresenceSyncManager } from './presenceSync';
 import { SlidingSyncSidebarCache } from './slidingSyncSidebarCache';
-import { hydrateRoomMember } from './roomMemberHydration';
 import { clearCachedUserProfiles } from './userProfileCache';
 import {
   primeVersionsFromCache,
@@ -124,13 +123,6 @@ const measureStartupPhase = async <T>(
   }
 };
 
-type FetchRoomEventResult = Awaited<ReturnType<MatrixClient['fetchRoomEvent']>>;
-type MatrixClientWithWritableFetchRoomEvent = MatrixClient & {
-  fetchRoomEvent: (roomId: string, eventId: string) => Promise<FetchRoomEventResult>;
-};
-
-const fetchRoomEventStartupCleanupByClient = new WeakMap<MatrixClient, () => void>();
-
 const slidingSyncRequestCleanupByClient = new WeakMap<MatrixClient, () => void>();
 
 type SlidingSyncMethod = (
@@ -170,49 +162,6 @@ function installSlidingSyncRequestPatch(mx: MatrixClient, manager: SlidingSyncMa
     slidingSyncRequestCleanupByClient.delete(mx);
     mxWritable.slidingSync = original;
   });
-}
-
-function installStartupFetchRoomEventPatch(
-  mx: MatrixClient,
-  slidingSyncManager: SlidingSyncManager
-): void {
-  fetchRoomEventStartupCleanupByClient.get(mx)?.();
-
-  const mxWritable = mx as MatrixClientWithWritableFetchRoomEvent;
-  const origFetchRoomEvent = mx.fetchRoomEvent.bind(mx);
-
-  let restored = false;
-  const restore = () => {
-    if (restored) return;
-    restored = true;
-    fetchRoomEventStartupCleanupByClient.delete(mx);
-    mx.removeListener(ClientEvent.Sync, onSync);
-    mxWritable.fetchRoomEvent = origFetchRoomEvent;
-  };
-
-  const onSync = (state: SyncState) => {
-    if (isInitialSyncReady(state)) restore();
-  };
-
-  mxWritable.fetchRoomEvent = (roomId: string, eventId: string) => {
-    if (slidingSyncManager.isRoomActive(roomId)) {
-      return origFetchRoomEvent(roomId, eventId).then((event) => {
-        if (typeof event.sender === 'string') {
-          void hydrateRoomMember(mx, roomId, event.sender);
-        }
-        return event;
-      });
-    }
-    const cachedEvent = mx.getRoom(roomId)?.findEventById(eventId);
-    const payload: FetchRoomEventResult = cachedEvent?.event ?? {
-      event_id: eventId,
-      room_id: roomId,
-    };
-    return Promise.resolve(payload);
-  };
-
-  fetchRoomEventStartupCleanupByClient.set(mx, restore);
-  mx.on(ClientEvent.Sync, onSync);
 }
 
 const deleteDatabase = (name: string): Promise<void> =>
@@ -493,7 +442,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig):
       initialRoomIds: config?.initialRoomIds,
     });
 
-    installStartupFetchRoomEventPatch(mx, manager);
     installSlidingSyncRequestPatch(mx, manager);
 
     manager.attach();
@@ -523,7 +471,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig):
       baseUrl: useSliding ? baseUrl : undefined,
       stack: err instanceof Error ? err.stack : undefined,
     });
-    fetchRoomEventStartupCleanupByClient.get(mx)?.();
     slidingSyncRequestCleanupByClient.get(mx)?.();
     membershipActionCleanupByClient.get(mx)?.();
     disposeSlidingSync(mx);
@@ -535,7 +482,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig):
 export const stopClient = (mx: MatrixClient): void => {
   log.log('stopClient', mx.getUserId());
   debugLog.info('sync', 'Stopping client', { userId: mx.getUserId() });
-  fetchRoomEventStartupCleanupByClient.get(mx)?.();
   slidingSyncRequestCleanupByClient.get(mx)?.();
   disposeSlidingSync(mx);
   disposePresenceSync(mx);

--- a/src/client/slidingSync.test.ts
+++ b/src/client/slidingSync.test.ts
@@ -129,7 +129,7 @@ describe('SlidingSyncManager initial request', () => {
       required_state: [[EventType.RoomMember, '$ME']],
       filters: { is_invite: false },
     });
-    expect(defaultSubscription.timeline_limit).toBe(30);
+    expect(defaultSubscription.timeline_limit).toBe(50);
     expect(defaultSubscription.required_state).toContainEqual([EventType.RoomMember, '$LAZY']);
     expect(defaultSubscription.required_state).not.toContainEqual([EventType.RoomMember, '*']);
     expect(mocks.slidingSyncConstructorArgs?.[4]).toBe(45000);
@@ -588,6 +588,24 @@ describe('SlidingSyncManager room subscription coordination', () => {
     expect(mocks.slidingSyncInstance.modifyRoomSubscriptions).toHaveBeenLastCalledWith(
       new Set([roomId])
     );
+  });
+
+  it('registers a 50-event active room subscription and a single-event sidebar subscription', () => {
+    makeManager(makeMockMx());
+
+    const calls = mocks.slidingSyncInstance.addCustomSubscription.mock.calls as unknown as [
+      string,
+      { timeline_limit: number; required_state: [string, string][] },
+    ][];
+    const activeRoom = calls.find(([name]) => name === 'active_room');
+    const sidebarRoom = calls.find(([name]) => name === 'sidebar_room');
+
+    expect(activeRoom).toBeDefined();
+    expect(activeRoom![1].timeline_limit).toBe(50);
+    expect(activeRoom![1].required_state).toContainEqual([EventType.RoomMember, '$LAZY']);
+
+    expect(sidebarRoom).toBeDefined();
+    expect(sidebarRoom![1].timeline_limit).toBe(1);
   });
 
   it('registers the composite space+image-pack subscription', () => {

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -43,7 +43,7 @@ const SIDEBAR_ROOM_SUBSCRIPTION_KEY = 'sidebar_room';
 const SPACE_SUBSCRIPTION_KEY = 'space';
 const IMAGE_PACK_SUBSCRIPTION_KEY = 'image_packs';
 const SPACE_IMAGE_PACK_SUBSCRIPTION_KEY = 'space_image_packs';
-const ACTIVE_ROOM_TIMELINE_LIMIT = 30;
+const ACTIVE_ROOM_TIMELINE_LIMIT = 50;
 
 export type PartialSlidingSyncRequest = {
   filters?: MSC3575List['filters'];


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Fix missing recent messages after reopening a room.
Inactive room previews keep one event, while opened rooms now request 50. Also removes the startup fake event response that caused replies and reactions to be dropped when their parent was not loaded.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
