### PR TITLE
fix: revoke upload metadata object URLs

### DIFF
--- a/src/app/components/image-pack-view/ImagePackContent.tsx
+++ b/src/app/components/image-pack-view/ImagePackContent.tsx
@@ -110,7 +110,13 @@ export const ImagePackContent = as<'div', ImagePackContentProps>(
 
     const handleUploadComplete = useCallback(
       async (data: UploadSuccess) => {
-        const imgEl = await loadImageElement(getImageFileUrl(data.file));
+        const imgUrl = getImageFileUrl(data.file);
+        let imgEl: HTMLImageElement;
+        try {
+          imgEl = await loadImageElement(imgUrl);
+        } finally {
+          URL.revokeObjectURL(imgUrl);
+        }
         const packImage: PackImage = {
           url: data.mxc,
           info: getImageInfo(imgEl, data.file),

--- a/src/app/features/room/msgContent.test.ts
+++ b/src/app/features/room/msgContent.test.ts
@@ -21,6 +21,15 @@ const createTgsItem = (): TUploadItem => {
   };
 };
 
+describe('object URL cleanup', () => {
+  it('revokes the object URL after loading the image fails', async () => {
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL');
+    await getImageMsgContent({} as MatrixClient, createTgsItem(), 'mxc://revoke');
+    expect(revokeSpy).toHaveBeenCalledWith('blob:test');
+    revokeSpy.mockRestore();
+  });
+});
+
 describe('TGS message content', () => {
   it('sends TGS uploads as images with their MIME metadata', async () => {
     const content = await getImageMsgContent({} as MatrixClient, createTgsItem(), 'mxc://sticker');

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -64,31 +64,36 @@ export const getImageMsgContent = async (
   mxc: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
-  const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
-  if (imgError) log.warn('Failed to load image element:', imgError);
-
+  const imgUrl = getImageFileUrl(originalFile);
   const content: IContent = {
     msgtype: MsgType.Image,
     filename: file.name,
     body: file.name,
     [MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
-  if (imgEl) {
-    const blurHash = await encodeBlurHashAsync(
-      imgEl,
-      512,
-      scaleYDimension(imgEl.width, 512, imgEl.height)
-    );
+  try {
+    const [imgError, imgEl] = await to(loadImageElement(imgUrl));
+    if (imgError) log.warn('Failed to load image element:', imgError);
 
-    content.info = {
-      ...getImageInfo(imgEl, file),
-      [MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME]: blurHash,
-    };
-  } else {
-    content.info = {
-      mimetype: originalFile.type,
-      size: originalFile.size,
-    };
+    if (imgEl) {
+      const blurHash = await encodeBlurHashAsync(
+        imgEl,
+        512,
+        scaleYDimension(imgEl.width, 512, imgEl.height)
+      );
+
+      content.info = {
+        ...getImageInfo(imgEl, file),
+        [MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME]: blurHash,
+      };
+    } else {
+      content.info = {
+        mimetype: originalFile.type,
+        size: originalFile.size,
+      };
+    }
+  } finally {
+    URL.revokeObjectURL(imgUrl);
   }
   if (encInfo) {
     content.file = {
@@ -113,8 +118,7 @@ export const getVideoMsgContent = async (
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
 
-  const [videoError, videoEl] = await to(loadVideoElement(getVideoFileUrl(originalFile)));
-  if (videoError) log.warn('Failed to load video element:', videoError);
+  const videoUrl = getVideoFileUrl(originalFile);
 
   const content: IContent = {
     msgtype: MsgType.Video,
@@ -122,28 +126,35 @@ export const getVideoMsgContent = async (
     body: file.name,
     [MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
-  if (videoEl) {
-    const [thumbError, thumbContent] = await to(
-      generateThumbnailContent(
-        mx,
-        videoEl,
-        getThumbnailDimensions(videoEl.videoWidth, videoEl.videoHeight),
-        !!encInfo
-      )
-    );
-    if (thumbContent && thumbContent.thumbnail_info) {
-      thumbContent.thumbnail_info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] =
-        await encodeBlurHashAsync(
+  try {
+    const [videoError, videoEl] = await to(loadVideoElement(videoUrl));
+    if (videoError) log.warn('Failed to load video element:', videoError);
+
+    if (videoEl) {
+      const [thumbError, thumbContent] = await to(
+        generateThumbnailContent(
+          mx,
           videoEl,
-          512,
-          scaleYDimension(videoEl.videoWidth, 512, videoEl.videoHeight)
-        );
+          getThumbnailDimensions(videoEl.videoWidth, videoEl.videoHeight),
+          !!encInfo
+        )
+      );
+      if (thumbContent && thumbContent.thumbnail_info) {
+        thumbContent.thumbnail_info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] =
+          await encodeBlurHashAsync(
+            videoEl,
+            512,
+            scaleYDimension(videoEl.videoWidth, 512, videoEl.videoHeight)
+          );
+      }
+      if (thumbError) log.warn('Failed to generate video thumbnail:', thumbError);
+      content.info = {
+        ...getVideoInfo(videoEl, file),
+        ...thumbContent,
+      };
     }
-    if (thumbError) log.warn('Failed to generate video thumbnail:', thumbError);
-    content.info = {
-      ...getVideoInfo(videoEl, file),
-      ...thumbContent,
-    };
+  } finally {
+    URL.revokeObjectURL(videoUrl);
   }
   if (encInfo) {
     content.file = {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Release temporary Blob URLs after extracting upload metadata and thumbnails.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
