### PR TITLE
fix: bound background notification decrypt listeners

### DIFF
--- a/src/app/pages/client/BackgroundNotifications.test.tsx
+++ b/src/app/pages/client/BackgroundNotifications.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MatrixEventEvent } from '$types/matrix-sdk';
+import type { MatrixEvent } from '$types/matrix-sdk';
+import { onceDecryptedWithTimeout } from './BackgroundNotifications';
+
+const makeEvent = () => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const event = {
+    once: vi.fn<(name: string, fn: (...args: unknown[]) => void) => void>((name, fn) => {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name)?.add(fn);
+    }),
+    removeListener: vi.fn<(name: string, fn: (...args: unknown[]) => void) => void>((name, fn) => {
+      listeners.get(name)?.delete(fn);
+    }),
+    emitDecrypted: () => {
+      const fns = [...(listeners.get(MatrixEventEvent.Decrypted) ?? [])];
+      listeners.get(MatrixEventEvent.Decrypted)?.clear(); // once semantics
+      fns.forEach((fn) => fn());
+    },
+    listenerCount: (name: string) => listeners.get(name)?.size ?? 0,
+  };
+  return event as unknown as MatrixEvent & {
+    emitDecrypted: () => void;
+    listenerCount: (name: string) => number;
+  };
+};
+
+describe('onceDecryptedWithTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls onDecrypted and does not run onTimeout when the event decrypts', () => {
+    const event = makeEvent();
+    const onDecrypted = vi.fn<() => void>();
+    const onTimeout = vi.fn<() => void>();
+
+    onceDecryptedWithTimeout(event, onDecrypted, onTimeout);
+    event.emitDecrypted();
+    vi.advanceTimersByTime(120_000);
+
+    expect(onDecrypted).toHaveBeenCalledTimes(1);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener and runs onTimeout when the event never decrypts', () => {
+    const event = makeEvent();
+    const onDecrypted = vi.fn<() => void>();
+    const onTimeout = vi.fn<() => void>();
+
+    onceDecryptedWithTimeout(event, onDecrypted, onTimeout, 60_000);
+    expect(event.listenerCount(MatrixEventEvent.Decrypted)).toBe(1);
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onDecrypted).not.toHaveBeenCalled();
+    expect(event.listenerCount(MatrixEventEvent.Decrypted)).toBe(0);
+  });
+
+  it('cancel removes the listener and prevents both callbacks', () => {
+    const event = makeEvent();
+    const onDecrypted = vi.fn<() => void>();
+    const onTimeout = vi.fn<() => void>();
+
+    const cancel = onceDecryptedWithTimeout(event, onDecrypted, onTimeout, 60_000);
+    cancel();
+
+    expect(event.listenerCount(MatrixEventEvent.Decrypted)).toBe(0);
+    vi.advanceTimersByTime(120_000);
+    expect(onDecrypted).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/client/BackgroundNotifications.tsx
+++ b/src/app/pages/client/BackgroundNotifications.tsx
@@ -51,6 +51,30 @@ const debugLog = createDebugLogger('BackgroundNotifications');
 
 const BACKGROUND_SYNC_POLL_TIMEOUT_MS = 60_000;
 const BACKGROUND_STAGGER_DELAY_MS = 5_000;
+// Background clients don't initialize crypto, so an encrypted event may never
+// fire MatrixEventEvent.Decrypted; bound the listener's lifetime.
+const DECRYPTED_LISTENER_TIMEOUT_MS = 60_000;
+
+export const onceDecryptedWithTimeout = (
+  mEvent: MatrixEvent,
+  onDecrypted: () => void,
+  onTimeout: () => void,
+  timeoutMs = DECRYPTED_LISTENER_TIMEOUT_MS
+): (() => void) => {
+  const handleDecrypted = () => {
+    clearTimeout(timer);
+    onDecrypted();
+  };
+  const timer = setTimeout(() => {
+    mEvent.removeListener(MatrixEventEvent.Decrypted, handleDecrypted);
+    onTimeout();
+  }, timeoutMs);
+  mEvent.once(MatrixEventEvent.Decrypted, handleDecrypted);
+  return () => {
+    clearTimeout(timer);
+    mEvent.removeListener(MatrixEventEvent.Decrypted, handleDecrypted);
+  };
+};
 
 let desktopNotificationSeq = 1;
 const nextDesktopNotificationId = (): number => {
@@ -329,6 +353,8 @@ export function BackgroundNotifications() {
           // Track encrypted events that are being decrypted to avoid re-checking the
           // encryption guard when the Decrypted callback fires.
           const decryptingEvents = new Set<string>();
+          // Cancel callbacks so teardown can drop listeners/timers outliving the client.
+          const decryptTimeouts = new Set<() => void>();
 
           const handleTimeline = (
             mEvent: MatrixEvent,
@@ -359,16 +385,24 @@ export function BackgroundNotifications() {
               isEncryptedType
             ) {
               decryptingEvents.add(eventId);
-              const handleDecrypted = () => {
-                // After decryption, run the notification logic with the decrypted event.
-                // Force liveEvent=true since the SDK's re-emission sets it to false.
-                handleTimeline(mEvent, room, true, false, {
-                  liveEvent: true,
-                });
-                // Clean up the tracking flag
-                decryptingEvents.delete(eventId);
-              };
-              mEvent.once(MatrixEventEvent.Decrypted, handleDecrypted);
+              const cancel = onceDecryptedWithTimeout(
+                mEvent,
+                () => {
+                  decryptTimeouts.delete(cancel);
+                  // After decryption, run the notification logic with the decrypted event.
+                  // Force liveEvent=true since the SDK's re-emission sets it to false.
+                  handleTimeline(mEvent, room, true, false, {
+                    liveEvent: true,
+                  });
+                  // Clean up the tracking flag
+                  decryptingEvents.delete(eventId);
+                },
+                () => {
+                  decryptTimeouts.delete(cancel);
+                  decryptingEvents.delete(eventId);
+                }
+              );
+              decryptTimeouts.add(cancel);
               return;
             }
 
@@ -559,6 +593,9 @@ export function BackgroundNotifications() {
 
           // Register teardown so these listeners are removed when this client is stopped.
           clientCleanupRef.current.set(session.userId, () => {
+            decryptTimeouts.forEach((cancel) => cancel());
+            decryptTimeouts.clear();
+            decryptingEvents.clear();
             mx.off(ClientEvent.AccountData, handleAccountData);
             mx.off(RoomEvent.Timeline, handleTimeline as unknown as (...args: unknown[]) => void);
           });


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Prevent encrypted background notification listeners from accumulating indefinitely

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
