### PR TITLE
chore: Wrap membership event reasons in parentheses

### DIFF
--- a/.changeset/wrap_membership_event_reasons_in_parentheses.md
+++ b/.changeset/wrap_membership_event_reasons_in_parentheses.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Wrap membership event reasons in parentheses

--- a/src/app/hooks/useMemberEventParser.tsx
+++ b/src/app/hooks/useMemberEventParser.tsx
@@ -198,6 +198,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
               <Text>{' left the room '}</Text>
+              <Text>{reason ? `(${reason})` : null}</Text>
             </>
           ) : (
             <>

--- a/src/app/hooks/useMemberEventParser.tsx
+++ b/src/app/hooks/useMemberEventParser.tsx
@@ -86,10 +86,8 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
               <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
               <Text>{' accepted '}</Text>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              <Text>
-                {`'s join request `}
-                {reason}
-              </Text>
+              <Text>{`'s join request`}</Text>
+              <Text>{reason ? `(${reason})` : null}</Text>
             </>
           ),
         };
@@ -102,7 +100,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
             <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
             <Text>{' invited '}</Text>
             <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-            <Text>{reason}</Text>
+            <Text>{reason ? `(${reason})` : null}</Text>
           </>
         ),
       };
@@ -114,10 +112,8 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
         body: (
           <>
             <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-            <Text>
-              {' requested to join room: '}
-              <i>{reason}</i>
-            </Text>
+            <Text>{' requested to join room'}</Text>
+            <Text>{reason ? `(${reason})` : null}</Text>
           </>
         ),
       };
@@ -130,6 +126,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
           <>
             <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
             <Text>{' joined the room'}</Text>
+            <Text>{reason ? `(${reason})` : null}</Text>
           </>
         ),
       };
@@ -143,20 +140,16 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
             senderId === userId ? (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                <Text>
-                  {' rejected the invitation '}
-                  {reason}
-                </Text>
+                <Text>{' rejected the invitation'}</Text>
+                <Text>{reason ? `(${reason})` : null}</Text>
               </>
             ) : (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
                 <Text>{' rejected '}</Text>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                <Text>
-                  {`'s join request `}
-                  {reason}
-                </Text>
+                <Text>{`'s join request`}</Text>
+                <Text>{reason ? `(${reason})` : null}</Text>
               </>
             ),
         };
@@ -169,20 +162,16 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
             senderId === userId ? (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                <Text>
-                  {' revoked joined request '}
-                  {reason}
-                </Text>
+                <Text>{' revoked joined request'}</Text>
+                <Text>{reason ? `(${reason})` : null}</Text>
               </>
             ) : (
               <>
                 <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
                 {' revoked '}
                 <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-                <Text>
-                  {`'s invite `}
-                  {reason}
-                </Text>
+                <Text>{`'s invite`}</Text>
+                <Text>{reason ? `(${reason})` : null}</Text>
               </>
             ),
         };
@@ -196,7 +185,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
               <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
               <Text>{' unbanned '}</Text>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              <Text>{reason}</Text>
+              <Text>{reason ? `(${reason})` : null}</Text>
             </>
           ),
         };
@@ -208,17 +197,14 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
           senderId === userId ? (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              <Text>
-                {' left the room '}
-                {reason}
-              </Text>
+              <Text>{' left the room '}</Text>
             </>
           ) : (
             <>
               <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
               <Text>{' kicked '}</Text>
               <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-              <Text>{reason}</Text>
+              <Text>{reason ? `(${reason})` : null}</Text>
             </>
           ),
       };
@@ -232,7 +218,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
             <DecoratedUser roomId={roomId ?? ''} userId={senderId} userName={senderName} />
             <Text>{' banned '}</Text>
             <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-            <Text>{reason}</Text>
+            <Text>{reason ? `(${reason})` : null}</Text>
           </>
         ),
       };
@@ -257,7 +243,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
         ) : (
           <>
             <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={prevUserName} />
-            <Text>{' removed their display name '}</Text>
+            <Text>{' removed their display name'}</Text>
           </>
         ),
     };
@@ -274,7 +260,7 @@ const parseMemberEvent: MemberEventParser = (mEvent) => {
         ) : (
           <>
             <DecoratedUser roomId={roomId ?? ''} userId={userId} userName={userName} />
-            <Text>{' removed their avatar '}</Text>
+            <Text>{' removed their avatar'}</Text>
           </>
         ),
     };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR attempts to slightly improve the visualization of membership join events.

#### Before

Without the PR, membership events' change reasons are either blended with the rest of the service message text, or not shown entirely in the case of join reasons.

<img width="573" height="464" alt="Screenshot before the change." src="https://github.com/user-attachments/assets/aff5bf5d-1a53-4133-80cf-b33f2e1e8e90" />

#### After

With the PR, all reasons are displayed, and they are wrapped in parentheses.

<img width="613" height="467" alt="Screenshot after the change." src="https://github.com/user-attachments/assets/0836dde7-f643-4a01-85fc-be27b6f144b4" />

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] ~~Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).~~
- [ ] ~~Fully AI generated (explain what all the generated code does in moderate detail).~~
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->