### PR TITLE
fix(macos): make native and custom titlebar consistent

### DIFF
--- a/.changeset/fix-macos-titlebar.md
+++ b/.changeset/fix-macos-titlebar.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Remove the duplicate title on macos title bar. Also fixes the duplicate title bar when the custom one is enabled on macos.

--- a/src-tauri/src/desktop/tray.rs
+++ b/src-tauri/src/desktop/tray.rs
@@ -196,18 +196,11 @@ fn apply_main_window_title_bar_settings(
     window.set_decorations(!settings.use_custom_title_bar)?;
 
     #[cfg(target_os = "macos")]
-    {
-        window.set_title_bar_style(if settings.use_custom_title_bar {
-            tauri::TitleBarStyle::Transparent
-        } else {
-            tauri::TitleBarStyle::Visible
-        })?;
-        window.set_title(if settings.use_custom_title_bar {
-            ""
-        } else {
-            crate::main_window_title(app)
-        })?;
-    }
+    window.set_title_bar_style(if settings.use_custom_title_bar {
+        tauri::TitleBarStyle::Overlay
+    } else {
+        tauri::TitleBarStyle::Visible
+    })?;
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,13 +192,14 @@ pub fn show_or_create_main_window(app: &AppHandle<crate::BrowserEngine>) -> taur
         .visible(false);
 
     #[cfg(target_os = "macos")]
-    let builder = if desktop_settings.use_custom_title_bar {
+    let builder =
         builder
-            .title("")
-            .title_bar_style(tauri::TitleBarStyle::Transparent)
-    } else {
-        builder.title_bar_style(tauri::TitleBarStyle::Visible)
-    };
+            .hidden_title(true)
+            .title_bar_style(if desktop_settings.use_custom_title_bar {
+                tauri::TitleBarStyle::Overlay
+            } else {
+                tauri::TitleBarStyle::Visible
+            });
 
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     let builder = builder.decorations(!desktop_settings.use_custom_title_bar);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Removes the duplicate title name on the macos title bar.
This also fixes the duplicate title bar appearing when using the custom title bar on macos.

I have never written the words "title bar" that much.........

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->