### PR TITLE
Properly format PMP replies

### DIFF
--- a/.changeset/properly_format_pmp_replies.md
+++ b/.changeset/properly_format_pmp_replies.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Properly format PMP replies

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -62,6 +62,8 @@ import * as css from './Reply.css';
 import { LinePlaceholder } from './placeholder';
 import { ReactionKeyInline } from './ReactionKeyInline';
 import { M_POLL_START, M_TEXT } from 'matrix-js-sdk';
+import type { PerMessageProfileBeeperFormat } from '$hooks/usePerMessageProfile';
+import { convertBeeperFormatToOurPerMessageProfile } from '$hooks/usePerMessageProfile';
 
 const ROOM_REPLY_TIMELINE_EVENT_TYPES = new Set<string>([
   EventType.RoomMessage as string,
@@ -259,6 +261,20 @@ export const Reply = as<'div', ReplyProps>(
         : rawContent;
 
     const { body, formatted_body: formattedBody, format } = contentForPreview;
+
+    // get pmp from message
+    const beeperProfile = rawContent['com.beeper.per_message_profile'] as
+      | PerMessageProfileBeeperFormat
+      | undefined;
+    const pmp = beeperProfile
+      ? convertBeeperFormatToOurPerMessageProfile(beeperProfile)
+      : undefined;
+
+    // strip the PMP fallback if it's there, to avoid displaying the PMP name twice
+    const formattedBodyStripped: string = pmp
+      ? formattedBody?.replace(/^<strong\s+data-mx-profile-fallback[^>]*>.*?<\/strong>/, '')
+      : formattedBody;
+
     const extensibleContent = contentForPreview[M_TEXT.name] as
       | string
       | { body: string }
@@ -307,7 +323,7 @@ export const Reply = as<'div', ReplyProps>(
     const badEncryption = replyEvent?.getContent().msgtype === 'm.bad.encrypted';
     const mentionClickHandler = useMentionClickHandler(room.roomId);
     const isFormattedReply =
-      format === 'org.matrix.custom.html' && typeof formattedBody === 'string';
+      format === 'org.matrix.custom.html' && typeof formattedBodyStripped === 'string';
     const hasPlainTextReply = typeof body === 'string' && body !== '';
     const hasExtensibleBody = typeof extensibleBody === 'string' && extensibleBody !== '';
     // An encrypted event that hasn't been decrypted yet (keys pending) has an
@@ -334,8 +350,8 @@ export const Reply = as<'div', ReplyProps>(
       image = timelineIcon(ListBullets);
       if (question)
         bodyJSX = `'s poll asking ${(question[M_TEXT.name] as string) ?? question?.body ?? ''}`;
-    } else if (isFormattedReply && formattedBody !== '') {
-      const sanitizedHtml = sanitizeReplyFormattedPreview(formattedBody);
+    } else if (isFormattedReply && formattedBodyStripped !== '') {
+      const sanitizedHtml = sanitizeReplyFormattedPreview(formattedBodyStripped);
       if (shouldParseReplyFormattedPreview(sanitizedHtml)) {
         const parserOpts = getReactCustomHtmlParser(mx, room.roomId, {
           settingsLinkBaseUrl,
@@ -496,7 +512,8 @@ export const Reply = as<'div', ReplyProps>(
             eventType !== EventType.RoomMember && (
               <Text size="T300" truncate style={{ fontFamily: usernameFont }}>
                 <b>
-                  {getMemberDisplayName(room, sender, nicknames) ??
+                  {pmp?.name ??
+                    getMemberDisplayName(room, sender, nicknames) ??
                     cachedProfiles[sender]?.displayName ??
                     getMxIdLocalPart(sender)}
                 </b>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Replying to a PMP now displays the PMP's name instead of the underlying displayname.
<img width="256" height="151" alt="image" src="https://github.com/user-attachments/assets/b82be835-bcfe-4797-9387-783af50dfef2" />



Part of #1279 

#### Considerations

- The reply does not indicate that the message author is a PMP. This could be used for impersonation. However, it's unlikely that someone would not notice that the message is not coming from a PMP, given that it is indicated on the actual message.
- Currently does not implement #1462, once one of these two PRs is merged the other will have to add a fix. (Stacked PRs pls :pleading_face:)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
