### PR TITLE
test: cover sliding sync timelines

### DIFF
--- a/tests/e2e/fixtures/continuwuity.ts
+++ b/tests/e2e/fixtures/continuwuity.ts
@@ -99,7 +99,7 @@ export async function sendText(
   roomId: string,
   text: string,
   txnId: number
-): Promise<void> {
+): Promise<string> {
   const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${txnId}`;
   const res = await fetch(url, {
     method: 'PUT',
@@ -109,4 +109,76 @@ export async function sendText(
   if (!res.ok) {
     throw new Error(`sendText failed: ${res.status} ${await res.text()}`);
   }
+  return ((await res.json()) as { event_id: string }).event_id;
+}
+
+export async function inviteUser(
+  baseUrl: string,
+  token: string,
+  roomId: string,
+  userId: string
+): Promise<void> {
+  const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/invite`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ user_id: userId }),
+  });
+  if (!res.ok) {
+    throw new Error(`inviteUser failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+export async function joinRoom(baseUrl: string, token: string, roomId: string): Promise<void> {
+  const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/join`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    body: '{}',
+  });
+  if (!res.ok) {
+    throw new Error(`joinRoom failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+export type RoomMessage = {
+  eventId: string;
+  body: string;
+};
+
+export async function getRoomMessages(
+  baseUrl: string,
+  token: string,
+  roomId: string
+): Promise<RoomMessage[]> {
+  const messages: RoomMessage[] = [];
+  let from: string | undefined;
+  do {
+    const params = new URLSearchParams({ dir: 'b', limit: '100' });
+    if (from) params.set('from', from);
+    const url = `${baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/messages?${params}`;
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      throw new Error(`getRoomMessages failed: ${res.status} ${await res.text()}`);
+    }
+    const data = (await res.json()) as {
+      chunk?: {
+        type?: string;
+        event_id?: string;
+        content?: { msgtype?: string; body?: string };
+      }[];
+      end?: string;
+    };
+    (data.chunk ?? []).forEach((event) => {
+      if (event.type === 'm.room.message' && typeof event.event_id === 'string') {
+        const body = event.content?.body;
+        if (typeof body === 'string') messages.push({ eventId: event.event_id, body });
+      }
+    });
+    from = data.end;
+  } while (from);
+  messages.reverse();
+  return messages;
 }

--- a/tests/e2e/live-timeline.spec.ts
+++ b/tests/e2e/live-timeline.spec.ts
@@ -1,0 +1,140 @@
+import { readFile } from 'node:fs/promises';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  createRoom,
+  getRoomMessages,
+  inviteUser,
+  joinRoom,
+  registerUser,
+  sendText,
+} from './fixtures/continuwuity';
+import { AppShell } from './pages/AppShell';
+
+const PASSWORD = 'test-passw0rd';
+const BURST_SIZE = 8;
+
+type InjectedSession = {
+  baseUrl: string;
+  userId: string;
+  deviceId: string;
+  accessToken: string;
+  slidingSyncOptIn?: boolean;
+};
+
+async function homeserverBaseUrl(storageStatePath: string): Promise<string> {
+  const state = JSON.parse(await readFile(storageStatePath, 'utf8')) as {
+    origins: { localStorage: { name: string; value: string }[] }[];
+  };
+  const entry = state.origins[0]!.localStorage.find((item) => item.name === 'matrixSessions')!;
+  return (JSON.parse(entry.value) as InjectedSession[])[0]!.baseUrl;
+}
+
+async function loginAsFreshUser(
+  page: Page,
+  baseUrl: string,
+  name: string
+): Promise<{ accessToken: string }> {
+  const user = await registerUser(baseUrl, name, PASSWORD);
+  const session: InjectedSession = {
+    baseUrl,
+    userId: user.userId,
+    deviceId: user.deviceId,
+    accessToken: user.accessToken,
+    slidingSyncOptIn: true,
+  };
+  await page.addInitScript((injected: InjectedSession) => {
+    localStorage.setItem('matrixSessions', JSON.stringify([injected]));
+    localStorage.setItem('matrixActiveSession', JSON.stringify(injected.userId));
+    localStorage.setItem('dismissNotice', 'true');
+  }, session);
+  return user;
+}
+
+test.describe('live timeline', () => {
+  test('renders an editor-sent message as a single server-confirmed row', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-focused');
+    test.setTimeout(300_000);
+    const storageStatePath = testInfo.project.use.storageState as string;
+    const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
+    const tag = `send-${process.pid}-${Date.now().toString(36)}`;
+    const app = new AppShell(page);
+    const user = await loginAsFreshUser(page, hsBaseUrl, `${tag}-u`);
+
+    const room = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} Room`,
+      preset: 'private_chat',
+    });
+
+    await page.goto('/');
+    await expect(page.getByText(`${tag} Room`).first()).toBeVisible({
+      timeout: 180_000,
+    });
+    await app.openRoom(`${tag} Room`);
+
+    const body = `${tag}-hello`;
+    const editor = page.locator('[data-editable-name="RoomInput"]');
+    await editor.click();
+    await editor.pressSequentially(body);
+    await editor.press('Enter');
+
+    await expect(page.getByText(body, { exact: true })).toBeVisible({
+      timeout: 120_000,
+    });
+
+    let serverId: string | undefined;
+    await expect(async () => {
+      const messages = await getRoomMessages(hsBaseUrl, user.accessToken, room);
+      serverId = messages.find((m) => m.body === body)?.eventId;
+      expect(serverId).toMatch(/^\$/);
+    }).toPass({ timeout: 120_000, intervals: [500] });
+
+    await expect(app.messageByEventId(serverId!).getByText(body, { exact: true })).toHaveCount(1);
+    expect(await page.getByText(body, { exact: true }).count()).toBe(1);
+  });
+
+  test('renders a remote burst in an open room exactly once and in canonical order', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-focused');
+    test.setTimeout(300_000);
+    const storageStatePath = testInfo.project.use.storageState as string;
+    const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
+    const tag = `burst-${process.pid}-${Date.now().toString(36)}`;
+    const app = new AppShell(page);
+    const user = await loginAsFreshUser(page, hsBaseUrl, `${tag}-u`);
+    const remote = await registerUser(hsBaseUrl, `${tag}-r`, PASSWORD);
+
+    const room = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} Room`,
+      preset: 'private_chat',
+    });
+    await inviteUser(hsBaseUrl, user.accessToken, room, remote.userId);
+    await joinRoom(hsBaseUrl, remote.accessToken, room);
+
+    await page.goto('/');
+    await expect(page.getByText(`${tag} Room`).first()).toBeVisible({
+      timeout: 180_000,
+    });
+    await app.openRoom(`${tag} Room`);
+
+    for (let i = 1; i <= BURST_SIZE; i += 1) {
+      await sendText(hsBaseUrl, remote.accessToken, room, `${tag}-b${i}`, i);
+    }
+
+    const expected = (await getRoomMessages(hsBaseUrl, user.accessToken, room))
+      .filter((m) => m.body.startsWith(`${tag}-b`))
+      .map((m) => m.body);
+    expect(expected).toEqual(Array.from({ length: BURST_SIZE }, (_, i) => `${tag}-b${i + 1}`));
+
+    for (const body of expected) {
+      await expect(page.getByText(body, { exact: true })).toHaveCount(1, {
+        timeout: 120_000,
+      });
+    }
+
+    const domOrder = await page.getByText(new RegExp(`^${tag}-b\\d+$`)).allTextContents();
+    expect(domOrder).toEqual(expected);
+  });
+});

--- a/tests/e2e/pages/AppShell.ts
+++ b/tests/e2e/pages/AppShell.ts
@@ -13,6 +13,17 @@ export class AppShell {
     this.createRoomButton = page.getByRole('button', { name: 'Create Room' }).first();
   }
 
+  messageByEventId(eventId: string): Locator {
+    const escaped = eventId.replace(/(["\\])/g, '\\$1');
+    return this.page.locator(`[data-message-id="${escaped}"]`);
+  }
+
+  async sendTextMessage(text: string): Promise<void> {
+    await this.page.locator('div[data-slate-editor="true"]').last().click();
+    await this.page.keyboard.type(text);
+    await this.page.keyboard.press('Enter');
+  }
+
   async open(): Promise<void> {
     await this.page.addInitScript(() => localStorage.setItem('dismissNotice', 'true'));
     await this.page.goto('/');
@@ -21,6 +32,11 @@ export class AppShell {
 
   room(name: string): Locator {
     return this.page.getByText(name).first();
+  }
+
+  async openRoom(name: string): Promise<void> {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    await this.page.getByRole('button', { name: new RegExp(`^${escaped}`) }).click();
   }
 
   async openRoomOptions(name: string): Promise<RoomOptionsMenu> {

--- a/tests/e2e/sliding-sync-timeline.spec.ts
+++ b/tests/e2e/sliding-sync-timeline.spec.ts
@@ -1,0 +1,193 @@
+import { readFile } from 'node:fs/promises';
+import { test, expect, type Page } from '@playwright/test';
+import { createRoom, registerUser, sendText } from './fixtures/continuwuity';
+import { AppShell } from './pages/AppShell';
+
+const PASSWORD = 'test-passw0rd';
+const HISTORY_SIZE = 100;
+const SEND_DELAYS_MS = [0, 150, 0, 400, 50];
+
+type InjectedSession = {
+  baseUrl: string;
+  userId: string;
+  deviceId: string;
+  accessToken: string;
+  slidingSyncOptIn?: boolean;
+};
+
+async function homeserverBaseUrl(storageStatePath: string): Promise<string> {
+  const state = JSON.parse(await readFile(storageStatePath, 'utf8')) as {
+    origins: { localStorage: { name: string; value: string }[] }[];
+  };
+  const entry = state.origins[0]!.localStorage.find((item) => item.name === 'matrixSessions')!;
+  return (JSON.parse(entry.value) as InjectedSession[])[0]!.baseUrl;
+}
+
+async function loginAsFreshUser(
+  page: Page,
+  baseUrl: string,
+  name: string
+): Promise<{ accessToken: string }> {
+  const user = await registerUser(baseUrl, name, PASSWORD);
+  const session: InjectedSession = {
+    baseUrl,
+    userId: user.userId,
+    deviceId: user.deviceId,
+    accessToken: user.accessToken,
+    slidingSyncOptIn: true,
+  };
+  await page.addInitScript((injected: InjectedSession) => {
+    localStorage.setItem('matrixSessions', JSON.stringify([injected]));
+    localStorage.setItem('matrixActiveSession', JSON.stringify(injected.userId));
+    localStorage.setItem('dismissNotice', 'true');
+  }, session);
+  return user;
+}
+
+let txnCounter = 1;
+
+const nextTxnId = () => {
+  txnCounter += 1;
+  return txnCounter;
+};
+
+async function sendMessage(
+  baseUrl: string,
+  token: string,
+  roomId: string,
+  body: string
+): Promise<void> {
+  await sendText(baseUrl, token, roomId, body, nextTxnId());
+}
+
+async function sendHistory(
+  baseUrl: string,
+  token: string,
+  roomId: string,
+  prefix: string,
+  bodies: string[]
+): Promise<void> {
+  for (let i = 0; i < bodies.length; i += 1) {
+    await sendMessage(baseUrl, token, roomId, `${prefix}-${bodies[i]}`);
+  }
+}
+
+async function wheelToTopUntilVisible(page: Page, text: string): Promise<void> {
+  await expect(async () => {
+    await page.mouse.move(640, 400);
+    await page.mouse.wheel(0, -2400);
+    expect(await page.getByText(text, { exact: true }).count()).toBeGreaterThan(0);
+  }).toPass({ timeout: 120_000, intervals: [500] });
+}
+
+test.describe('sliding sync timeline', () => {
+  test('paginates backwards through pre-subscription history after leaving and reopening a room', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-focused');
+    test.setTimeout(300_000);
+    const storageStatePath = testInfo.project.use.storageState as string;
+    const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
+    const tag = `hist-${process.pid}-${Date.now().toString(36)}`;
+    const app = new AppShell(page);
+    const user = await loginAsFreshUser(page, hsBaseUrl, `${tag}-u`);
+
+    const room = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} History`,
+      preset: 'private_chat',
+    });
+    const away = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} Away`,
+      preset: 'private_chat',
+    });
+
+    const bodies = ['sentinel', ...Array.from({ length: HISTORY_SIZE - 1 }, (_, i) => `m${i}`)];
+    const latest = `${tag}-m${HISTORY_SIZE - 2}`;
+    const sentinel = `${tag}-sentinel`;
+    await sendHistory(hsBaseUrl, user.accessToken, room, tag, bodies);
+    await sendMessage(hsBaseUrl, user.accessToken, away, `${tag}-away-msg`);
+
+    await page.goto('/');
+    await expect(page.getByText(`${tag} History`).first()).toBeVisible({
+      timeout: 180_000,
+    });
+
+    await app.openRoom(`${tag} History`);
+    await expect(page.getByText(latest, { exact: true }).first()).toBeVisible({
+      timeout: 180_000,
+    });
+    expect(await page.getByText(sentinel, { exact: true }).count()).toBe(0);
+
+    await app.openRoom(`${tag} Away`);
+    await expect(page.getByText(`${tag}-away-msg`, { exact: true })).toBeVisible({
+      timeout: 120_000,
+    });
+
+    await app.openRoom(`${tag} History`);
+    await expect(page.getByText(latest, { exact: true }).first()).toBeVisible({
+      timeout: 120_000,
+    });
+    expect(await page.getByText(sentinel, { exact: true }).count()).toBe(0);
+
+    await wheelToTopUntilVisible(page, sentinel);
+  });
+
+  test('renders messages received while the room was inactive exactly once, in order, after reopening', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-focused');
+    test.setTimeout(300_000);
+    const storageStatePath = testInfo.project.use.storageState as string;
+    const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
+    const tag = `live-${process.pid}-${Date.now().toString(36)}`;
+    const app = new AppShell(page);
+    const user = await loginAsFreshUser(page, hsBaseUrl, `${tag}-u`);
+
+    const room = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} Home`,
+      preset: 'private_chat',
+    });
+    const away = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} Away`,
+      preset: 'private_chat',
+    });
+
+    await sendMessage(hsBaseUrl, user.accessToken, room, `${tag}-seed`);
+    await sendMessage(hsBaseUrl, user.accessToken, away, `${tag}-away-msg`);
+
+    await page.goto('/');
+    await expect(page.getByText(`${tag} Home`).first()).toBeVisible({
+      timeout: 180_000,
+    });
+
+    await app.openRoom(`${tag} Home`);
+    await expect(page.getByText(`${tag}-seed`, { exact: true })).toBeVisible({
+      timeout: 180_000,
+    });
+
+    await app.openRoom(`${tag} Away`);
+    await expect(page.getByText(`${tag}-away-msg`, { exact: true })).toBeVisible({
+      timeout: 120_000,
+    });
+
+    for (let i = 0; i < SEND_DELAYS_MS.length; i += 1) {
+      if (SEND_DELAYS_MS[i]! > 0) await page.waitForTimeout(SEND_DELAYS_MS[i]!);
+      await sendMessage(hsBaseUrl, user.accessToken, room, `${tag}-live-${i + 1}`);
+    }
+
+    await app.openRoom(`${tag} Home`);
+    await expect(page.getByText(`${tag}-seed`, { exact: true })).toBeVisible({
+      timeout: 120_000,
+    });
+
+    for (let i = 0; i < SEND_DELAYS_MS.length; i += 1) {
+      await expect(page.getByText(`${tag}-live-${i + 1}`, { exact: true })).toHaveCount(1, {
+        timeout: 120_000,
+      });
+      await expect(page.getByText(`${tag}-live-${i + 1}`, { exact: true })).toBeVisible();
+    }
+
+    const domOrder = await page.getByText(new RegExp(`^${tag}-live-\\d+$`)).allTextContents();
+    expect(domOrder).toEqual(SEND_DELAYS_MS.map((_, i) => `${tag}-live-${i + 1}`));
+  });
+});

--- a/tests/e2e/timeline-recovery.spec.ts
+++ b/tests/e2e/timeline-recovery.spec.ts
@@ -1,0 +1,170 @@
+import { readFile } from 'node:fs/promises';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  createRoom,
+  getRoomMessages,
+  inviteUser,
+  joinRoom,
+  registerUser,
+  sendText,
+} from './fixtures/continuwuity';
+import { AppShell } from './pages/AppShell';
+
+const PASSWORD = 'test-passw0rd';
+
+type InjectedSession = {
+  baseUrl: string;
+  userId: string;
+  deviceId: string;
+  accessToken: string;
+  slidingSyncOptIn?: boolean;
+};
+
+async function homeserverBaseUrl(storageStatePath: string): Promise<string> {
+  const state = JSON.parse(await readFile(storageStatePath, 'utf8')) as {
+    origins: { localStorage: { name: string; value: string }[] }[];
+  };
+  const entry = state.origins[0]!.localStorage.find((item) => item.name === 'matrixSessions')!;
+  return (JSON.parse(entry.value) as InjectedSession[])[0]!.baseUrl;
+}
+
+async function loginAsFreshUser(
+  page: Page,
+  baseUrl: string,
+  name: string
+): Promise<{ accessToken: string; userId: string; deviceId: string }> {
+  const user = await registerUser(baseUrl, name, PASSWORD);
+  const session: InjectedSession = {
+    baseUrl,
+    userId: user.userId,
+    deviceId: user.deviceId,
+    accessToken: user.accessToken,
+    slidingSyncOptIn: true,
+  };
+  await page.addInitScript((injected: InjectedSession) => {
+    localStorage.setItem('matrixSessions', JSON.stringify([injected]));
+    localStorage.setItem('matrixActiveSession', JSON.stringify(injected.userId));
+    localStorage.setItem('dismissNotice', 'true');
+  }, session);
+  return user;
+}
+
+let txnCounter = 1;
+
+test.describe('timeline recovery', () => {
+  test('renders a remote burst received while offline exactly once, in canonical order', async ({
+    page,
+    context,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-focused');
+    test.setTimeout(300_000);
+    const storageStatePath = testInfo.project.use.storageState as string;
+    const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
+    const tag = `off-${process.pid}-${Date.now().toString(36)}`;
+    const app = new AppShell(page);
+    const alice = await loginAsFreshUser(page, hsBaseUrl, `${tag}-a`);
+    const bob = await registerUser(hsBaseUrl, `${tag}-b`, PASSWORD);
+
+    const room = await createRoom(hsBaseUrl, alice.accessToken, {
+      name: `${tag} Relay`,
+      preset: 'private_chat',
+    });
+    await inviteUser(hsBaseUrl, alice.accessToken, room, bob.userId);
+    await joinRoom(hsBaseUrl, bob.accessToken, room);
+    txnCounter += 1;
+    await sendText(hsBaseUrl, alice.accessToken, room, `${tag}-seed`, txnCounter);
+
+    await page.goto('/');
+    await expect(page.getByText(`${tag} Relay`).first()).toBeVisible({
+      timeout: 180_000,
+    });
+    await app.openRoom(`${tag} Relay`);
+    await expect(page.getByText(`${tag}-seed`, { exact: true })).toBeVisible({
+      timeout: 180_000,
+    });
+
+    await context.setOffline(true);
+
+    const burstCount = 6;
+    for (let i = 0; i < burstCount; i += 1) {
+      txnCounter += 1;
+      await sendText(hsBaseUrl, bob.accessToken, room, `${tag}-burst-${i + 1}`, txnCounter);
+    }
+
+    await context.setOffline(false);
+
+    for (let i = 0; i < burstCount; i += 1) {
+      await expect(page.getByText(`${tag}-burst-${i + 1}`, { exact: true })).toHaveCount(1, {
+        timeout: 180_000,
+      });
+      await expect(page.getByText(`${tag}-burst-${i + 1}`, { exact: true })).toBeVisible();
+    }
+
+    const canonical = (await getRoomMessages(hsBaseUrl, alice.accessToken, room))
+      .map((m) => m.body)
+      .filter((body) => body.startsWith(`${tag}-`));
+    const domOrder = (
+      await page.getByText(new RegExp(`^${tag}-(seed|burst-\\d+)$`)).allTextContents()
+    ).map((text) => text.trim());
+    expect(domOrder).toEqual(canonical);
+  });
+
+  test('retries a failed offline composer send to exactly one server-confirmed message', async ({
+    page,
+    context,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-focused');
+    test.fixme(true, 'failed-send Retry UI does not render for offline sends under sliding sync');
+    test.setTimeout(300_000);
+    const storageStatePath = testInfo.project.use.storageState as string;
+    const hsBaseUrl = await homeserverBaseUrl(storageStatePath);
+    const tag = `retry-${process.pid}-${Date.now().toString(36)}`;
+    const app = new AppShell(page);
+    const user = await loginAsFreshUser(page, hsBaseUrl, `${tag}-u`);
+
+    const room = await createRoom(hsBaseUrl, user.accessToken, {
+      name: `${tag} Outbox`,
+      preset: 'private_chat',
+    });
+    txnCounter += 1;
+    await sendText(hsBaseUrl, user.accessToken, room, `${tag}-seed`, txnCounter);
+
+    await page.goto('/');
+    await expect(page.getByText(`${tag} Outbox`).first()).toBeVisible({
+      timeout: 180_000,
+    });
+    await app.openRoom(`${tag} Outbox`);
+    await expect(page.getByText(`${tag}-seed`, { exact: true })).toBeVisible({
+      timeout: 180_000,
+    });
+
+    await context.setOffline(true);
+
+    const body = `${tag}-retry-body`;
+    await app.sendTextMessage(body);
+
+    const failedStatus = page.getByText('Failed to send.', { exact: true });
+    await expect(failedStatus).toHaveCount(1, { timeout: 180_000 });
+    const retryButton = page.getByRole('button', {
+      name: 'Retry',
+      exact: true,
+    });
+    await expect(retryButton).toHaveCount(1);
+    await expect(retryButton).toBeVisible();
+
+    await context.setOffline(false);
+
+    await retryButton.click();
+
+    await expect(page.getByText(body, { exact: true })).toHaveCount(1, {
+      timeout: 180_000,
+    });
+    await expect(page.getByText(body, { exact: true })).toBeVisible();
+    await expect(failedStatus).toHaveCount(0, { timeout: 180_000 });
+
+    const canonical = (await getRoomMessages(hsBaseUrl, user.accessToken, room))
+      .map((m) => m.body)
+      .filter((b) => b === body);
+    expect(canonical).toEqual([body]);
+  });
+});


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

1. Back-paginate history after leaving and reopening a Sliding Sync room.
2. Receive inactive-room messages once and in chronological order after reopening.
3. Send from composer; local echo resolves to exactly one server-confirmed event.
4. Receive an 8-message remote burst in an open room, once and canonical order.
5. Go offline, receive a remote burst, reconnect, and render it once in canonical order.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
