### PR TITLE
fix(crypto): preserve recovery key validation error

### DIFF
--- a/src/app/components/SecretStorage.test.tsx
+++ b/src/app/components/SecretStorage.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SecretStorageKeyContent } from '$types/matrix/accountData';
+import { SecretStorageRecoveryKey, SecretStorageRecoveryPassphrase } from './SecretStorage';
+
+const decodeRecoveryKey = vi.hoisted(() =>
+  vi.fn<(key: string) => Uint8Array>(() => new Uint8Array([1, 2, 3]))
+);
+const deriveRecoveryKeyFromPassphrase = vi.hoisted(() =>
+  vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([4, 5, 6]))
+);
+const checkKey = vi.hoisted(() => vi.fn<() => Promise<boolean>>());
+
+vi.mock('$types/matrix-sdk', () => ({ decodeRecoveryKey, deriveRecoveryKeyFromPassphrase }));
+vi.mock('$hooks/useMatrixClient', () => ({
+  useMatrixClient: () => ({ secretStorage: { checkKey } }),
+}));
+
+const KEY_CONTENT = { algorithm: 'm.secret_storage.v1.aes-hmac-sha2' } as SecretStorageKeyContent;
+const PASSPHRASE_CONTENT = {
+  algorithm: 'm.pbkdf2',
+  salt: 'salt',
+  iterations: 10000,
+  bits: 256,
+};
+
+const validKey = new Uint8Array([1, 2, 3]);
+
+const submitRecoveryKey = (value: string) => {
+  const input = document.querySelector('form input') as HTMLInputElement;
+  fireEvent.change(input, { target: { value } });
+  const form = input.closest('form') as HTMLFormElement;
+  // jsdom lacks named form-element properties (form.recoveryKeyInput), which
+  // the component relies on in real browsers.
+  Object.defineProperty(form, input.name, { value: input, configurable: true });
+  fireEvent.submit(form);
+};
+
+describe('SecretStorageRecoveryKey', () => {
+  beforeEach(() => {
+    decodeRecoveryKey.mockReset();
+    decodeRecoveryKey.mockReturnValue(validKey);
+    checkKey.mockReset();
+  });
+
+  it('does not forward a key when decoding fails and shows the original error', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    decodeRecoveryKey.mockImplementation(() => {
+      throw new Error('Malformed recovery key');
+    });
+    render(
+      <SecretStorageRecoveryKey
+        keyContent={KEY_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('not-a-key');
+
+    expect(await screen.findByText('Malformed recovery key')).toBeInTheDocument();
+    expect(onDecodedRecoveryKey).not.toHaveBeenCalled();
+  });
+
+  it('does not forward a key rejected by checkKey', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    checkKey.mockResolvedValue(false);
+    render(
+      <SecretStorageRecoveryKey
+        keyContent={KEY_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('stale-key');
+
+    expect(await screen.findByText('Invalid recovery key.')).toBeInTheDocument();
+    expect(onDecodedRecoveryKey).not.toHaveBeenCalled();
+  });
+
+  it('does not forward a key when checkKey rejects', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    checkKey.mockRejectedValue(new Error('network gone'));
+    render(
+      <SecretStorageRecoveryKey
+        keyContent={KEY_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('some-key');
+
+    expect(await screen.findByText('network gone')).toBeInTheDocument();
+    expect(onDecodedRecoveryKey).not.toHaveBeenCalled();
+  });
+
+  it('does not forward a non-Uint8Array result even when checkKey passes', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    decodeRecoveryKey.mockReturnValue('not-bytes' as unknown as Uint8Array);
+    checkKey.mockResolvedValue(true);
+    render(
+      <SecretStorageRecoveryKey
+        keyContent={KEY_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('some-key');
+
+    await waitFor(() => expect(checkKey).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByText('Verify')).toBeInTheDocument());
+    expect(onDecodedRecoveryKey).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid decoded key exactly once', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    checkKey.mockResolvedValue(true);
+    render(
+      <SecretStorageRecoveryKey
+        keyContent={KEY_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('valid-key');
+
+    await waitFor(() => expect(onDecodedRecoveryKey).toHaveBeenCalledTimes(1));
+    expect(onDecodedRecoveryKey).toHaveBeenCalledWith(validKey);
+    expect(screen.queryByText('Invalid recovery key.')).not.toBeInTheDocument();
+  });
+});
+
+describe('SecretStorageRecoveryPassphrase', () => {
+  beforeEach(() => {
+    deriveRecoveryKeyFromPassphrase.mockReset();
+    deriveRecoveryKeyFromPassphrase.mockResolvedValue(validKey);
+    checkKey.mockReset();
+  });
+
+  it('does not forward a key for an invalid passphrase', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    checkKey.mockResolvedValue(false);
+    render(
+      <SecretStorageRecoveryPassphrase
+        keyContent={KEY_CONTENT}
+        passphraseContent={PASSPHRASE_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('wrong passphrase');
+    expect(await screen.findByText('Invalid recovery passphrase.')).toBeInTheDocument();
+    expect(onDecodedRecoveryKey).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid passphrase-derived key exactly once', async () => {
+    const onDecodedRecoveryKey = vi.fn<(key: Uint8Array) => void>();
+    checkKey.mockResolvedValue(true);
+    render(
+      <SecretStorageRecoveryPassphrase
+        keyContent={KEY_CONTENT}
+        passphraseContent={PASSPHRASE_CONTENT}
+        onDecodedRecoveryKey={onDecodedRecoveryKey}
+      />
+    );
+
+    submitRecoveryKey('correct passphrase');
+
+    await waitFor(() => expect(onDecodedRecoveryKey).toHaveBeenCalledTimes(1));
+    expect(onDecodedRecoveryKey).toHaveBeenCalledWith(validKey);
+  });
+});

--- a/src/app/components/SecretStorage.tsx
+++ b/src/app/components/SecretStorage.tsx
@@ -74,7 +74,7 @@ export function SecretStorageRecoveryPassphrase({
 
     const { salt, iterations, bits } = passphraseContent;
     submitPassphrase(recoveryPassphrase, salt, iterations, bits).then((decodedRecoveryKey) => {
-      if (alive()) {
+      if (alive() && decodedRecoveryKey instanceof Uint8Array) {
         recoveryPassphraseInput.value = '';
         onDecodedRecoveryKey(decodedRecoveryKey);
       }
@@ -193,7 +193,7 @@ export function SecretStorageRecoveryKey({
     if (!recoveryKey) return;
 
     submitRecoveryKey(recoveryKey).then((decodedRecoveryKey) => {
-      if (alive()) {
+      if (alive() && decodedRecoveryKey instanceof Uint8Array) {
         recoveryKeyInput.value = '';
         onDecodedRecoveryKey(decodedRecoveryKey);
       }


### PR DESCRIPTION


<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
- preserve recovery-key and passphrase validation failures in the form
- prevent failed decoding from forwarding an undefined key into verification/storage

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
