### PR TITLE
fix(mobile): recover sync after resume

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -494,18 +494,6 @@ pub fn run() {
         #[cfg(desktop)]
         desktop::tray::handle_run_event(app, event);
 
-        #[cfg(mobile)]
-        {
-            use tauri::Emitter;
-            if let tauri::RunEvent::WindowEvent {
-                event: tauri::WindowEvent::Resumed,
-                ..
-            } = event
-            {
-                let _ = app.emit("app-resumed", ());
-            }
-        }
-
         #[cfg(not(any(desktop, mobile)))]
         let _ = (app, event);
     });

--- a/src/app/hooks/useNetworkRecovery.test.tsx
+++ b/src/app/hooks/useNetworkRecovery.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen,
+  TauriEvent: { WINDOW_RESUMED: 'tauri://resumed' },
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -171,16 +172,53 @@ describe('useNetworkRecovery', () => {
     expect(nudgeReconnect).toHaveBeenCalledTimes(2);
   });
 
+  describe('foreground nudge verification', () => {
+    it('retries once past the throttle when no Sync follows the nudge', () => {
+      renderHook(() => useNetworkRecovery({ clientRunning: true } as never));
+
+      dispatchEvent(new Event('online'));
+      expect(nudgeReconnect).toHaveBeenCalledTimes(1);
+      expect(nudgeReconnect).toHaveBeenLastCalledWith(expect.anything(), 'online');
+
+      vi.advanceTimersByTime(3_000);
+
+      expect(nudgeReconnect).toHaveBeenCalledTimes(2);
+      expect(nudgeReconnect).toHaveBeenLastCalledWith(expect.anything(), 'retry', { force: true });
+    });
+
+    it('cancels the retry when a Sync arrives after the nudge', () => {
+      renderHook(() => useNetworkRecovery({ clientRunning: true } as never));
+
+      dispatchEvent(new Event('online'));
+      vi.advanceTimersByTime(1_000);
+      syncCallback?.();
+      vi.advanceTimersByTime(3_000);
+
+      expect(nudgeReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('issues only one follow-up nudge', () => {
+      renderHook(() => useNetworkRecovery({ clientRunning: true } as never));
+
+      dispatchEvent(new Event('online'));
+      vi.advanceTimersByTime(3_000);
+      vi.advanceTimersByTime(30_000);
+
+      expect(nudgeReconnect).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('tauri mobile resume', () => {
     beforeEach(() => {
       mockIsTauri.value = true;
     });
 
-    it('nudges on app-resumed event', () => {
+    it('nudges on tauri://resumed event', () => {
       listen.mockResolvedValue(listenOff);
 
       renderHook(() => useNetworkRecovery({ clientRunning: true } as never));
 
+      expect(listen).toHaveBeenCalledWith('tauri://resumed', expect.any(Function));
       const [, cb] = listen.mock.calls[0] as [string, () => void];
       cb();
 

--- a/src/app/hooks/useNetworkRecovery.ts
+++ b/src/app/hooks/useNetworkRecovery.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { onlineManager } from '@tanstack/react-query';
-import { listen } from '@tauri-apps/api/event';
+import { TauriEvent, listen } from '@tauri-apps/api/event';
 import { isTauri } from '@tauri-apps/api/core';
 import type { MatrixClient } from '$types/matrix-sdk';
 import type { NudgeReason } from '$client/reconnect';
@@ -12,9 +12,18 @@ const SYNC_STALL_MS = 75_000;
 const STALL_CHECK_INTERVAL_MS = 10_000;
 // Visibility alone is not evidence the network changed.
 const VISIBLE_STALE_MS = 30_000;
+// After a foreground nudge, verify a Sync arrived within this window; retry once otherwise.
+const VERIFY_AFTER_NUDGE_MS = 3_000;
 
 export const useNetworkRecovery = (mx: MatrixClient | undefined): void => {
   const lastSyncAtRef = useRef(Date.now());
+  const verifyTimerRef = useRef<number | undefined>(undefined);
+
+  const cancelVerify = useCallback(() => {
+    if (verifyTimerRef.current === undefined) return;
+    window.clearTimeout(verifyTimerRef.current);
+    verifyTimerRef.current = undefined;
+  }, []);
 
   const nudge = useCallback(
     (reason: NudgeReason): boolean => {
@@ -29,19 +38,39 @@ export const useNetworkRecovery = (mx: MatrixClient | undefined): void => {
     mx,
     useCallback(() => {
       lastSyncAtRef.current = Date.now();
-    }, [])
+      cancelVerify();
+    }, [cancelVerify])
+  );
+
+  // Foreground nudges (resume / visible-stale / online) get one sync verification:
+  // if no Sync arrives within VERIFY_AFTER_NUDGE_MS, retry once past the throttle.
+  const nudgeForeground = useCallback(
+    (reason: NudgeReason): void => {
+      cancelVerify();
+      if (!mx) return;
+      const syncAtNudge = lastSyncAtRef.current;
+      if (!nudge(reason)) return;
+      verifyTimerRef.current = window.setTimeout(() => {
+        verifyTimerRef.current = undefined;
+        if (lastSyncAtRef.current === syncAtNudge) {
+          onlineManager.setOnline(true);
+          nudgeReconnect(mx, 'retry', { force: true });
+        }
+      }, VERIFY_AFTER_NUDGE_MS);
+    },
+    [mx, nudge, cancelVerify]
   );
 
   useEffect(() => {
     if (!mx) return undefined;
 
-    const onOnline = () => nudge('online');
+    const onOnline = () => nudgeForeground('online');
     const onVisible = () => {
       if (
         document.visibilityState === 'visible' &&
         Date.now() - lastSyncAtRef.current >= VISIBLE_STALE_MS
       ) {
-        nudge('visible');
+        nudgeForeground('visible');
       }
     };
 
@@ -53,13 +82,16 @@ export const useNetworkRecovery = (mx: MatrixClient | undefined): void => {
       if (nudge('stalled')) lastSyncAtRef.current = Date.now();
     }, STALL_CHECK_INTERVAL_MS);
 
-    const unlisten = isTauri() ? listen('app-resumed', () => nudge('resumed')) : undefined;
+    const unlisten = isTauri()
+      ? listen(TauriEvent.WINDOW_RESUMED, () => nudgeForeground('resumed'))
+      : undefined;
 
     return () => {
       window.removeEventListener('online', onOnline);
       document.removeEventListener('visibilitychange', onVisible);
       window.clearInterval(stallCheck);
+      cancelVerify();
       unlisten?.then((off) => off());
     };
-  }, [mx, nudge]);
+  }, [mx, nudge, nudgeForeground, cancelVerify]);
 };

--- a/src/client/reconnect.ts
+++ b/src/client/reconnect.ts
@@ -8,19 +8,23 @@ const NUDGE_THROTTLE_MS = 3000;
 
 const lastNudgeAt = new WeakMap<MatrixClient, number>();
 
-export type NudgeReason = 'online' | 'visible' | 'resumed' | 'stalled';
+export type NudgeReason = 'online' | 'visible' | 'resumed' | 'stalled' | 'retry';
 
 /**
  * Sliding sync aborts the long-poll and re-requests with no backoff sleep.
  * Classic has no public abort, so this only collapses an existing keepalive
  * backoff — a hung classic poll still waits out its 110s localTimeout.
  */
-export const nudgeReconnect = (mx: MatrixClient, reason: NudgeReason): boolean => {
+export const nudgeReconnect = (
+  mx: MatrixClient,
+  reason: NudgeReason,
+  opts?: { force?: boolean }
+): boolean => {
   if (!mx.clientRunning) return false;
 
   const now = Date.now();
   const last = lastNudgeAt.get(mx);
-  if (last !== undefined && now - last < NUDGE_THROTTLE_MS) return false;
+  if (!opts?.force && last !== undefined && now - last < NUDGE_THROTTLE_MS) return false;
   lastNudgeAt.set(mx, now);
 
   const slidingSync = getSlidingSyncManager(mx)?.slidingSync;


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Recover Matrix sync promptly after app resume with a verified retry nudge, and use Tauri’s built-in resume event.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
