### PR TITLE
fix(mobile): stop pinned list sheet from jittering in height

### DIFF
--- a/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
+++ b/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
@@ -212,13 +212,21 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
 
     // Rows re-measure as dynamic content lands (decrypts, lazy media, replies),
     // nudging the total size back and forth across the sheet's max height. The
-    // sheet sizes itself off this list, so latch the largest size seen: it may
-    // grow as content arrives, but never shrink and jitter while open.
+    // sheet sizes itself off this list, so latch the largest size seen for the
+    // current set of pins. Structural changes rebase the latch so removals do
+    // not leave stale empty space.
     const totalSize = virtualizer.getTotalSize();
-    const [latchedSize, setLatchedSize] = useState(0);
+    const pinListKey = JSON.stringify(sortedPinnedEvent);
+    const [latchedSize, setLatchedSize] = useState({ pinListKey, size: 0 });
     useLayoutEffect(() => {
-      setLatchedSize((prev) => (totalSize > prev ? totalSize : prev));
-    }, [totalSize]);
+      setLatchedSize((prev) => {
+        if (prev.pinListKey !== pinListKey) return { pinListKey, size: totalSize };
+        if (totalSize <= prev.size) return prev;
+        return { pinListKey, size: totalSize };
+      });
+    }, [pinListKey, totalSize]);
+    const currentLatchedSize = latchedSize.pinListKey === pinListKey ? latchedSize.size : totalSize;
+    const mobileMaxHeight = 'calc(85vh - 4rem)';
 
     const renderMatrixEvent = useRoomMessagePreviewRenderer(room);
 
@@ -247,9 +255,9 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
               hideTrack
               visibility="Hover"
               style={{
-                minHeight: isMobile ? latchedSize : 0,
+                minHeight: isMobile ? `min(${currentLatchedSize}px, ${mobileMaxHeight})` : 0,
                 flex: isMobile ? '0 1 auto' : 1,
-                maxHeight: isMobile ? 'calc(85vh - 4rem)' : undefined,
+                maxHeight: isMobile ? mobileMaxHeight : undefined,
                 overflowY: 'auto',
                 touchAction: 'pan-y',
               }}

--- a/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
+++ b/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
@@ -1,5 +1,5 @@
 import type { MouseEventHandler, ReactNode } from 'react';
-import { forwardRef, useCallback, useMemo, useRef } from 'react';
+import { forwardRef, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { MatrixEvent, Room, RoomPinnedEventsEventContent } from '$types/matrix-sdk';
 import {
   Box,
@@ -210,6 +210,16 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
       overscan: 4,
     });
 
+    // Rows re-measure as dynamic content lands (decrypts, lazy media, replies),
+    // nudging the total size back and forth across the sheet's max height. The
+    // sheet sizes itself off this list, so latch the largest size seen: it may
+    // grow as content arrives, but never shrink and jitter while open.
+    const totalSize = virtualizer.getTotalSize();
+    const [latchedSize, setLatchedSize] = useState(0);
+    useLayoutEffect(() => {
+      setLatchedSize((prev) => (totalSize > prev ? totalSize : prev));
+    }, [totalSize]);
+
     const renderMatrixEvent = useRoomMessagePreviewRenderer(room);
 
     const handleOpen = (roomId: string, eventId: string) => {
@@ -237,7 +247,7 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
               hideTrack
               visibility="Hover"
               style={{
-                minHeight: 0,
+                minHeight: isMobile ? latchedSize : 0,
                 flex: isMobile ? '0 1 auto' : 1,
                 maxHeight: isMobile ? 'calc(85vh - 4rem)' : undefined,
                 overflowY: 'auto',


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fix jitter from mobile sheet

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
