### PR TITLE
fix: Missing scheduled message chip

### DIFF
--- a/.changeset/fix-missing-scheduled-message-chip.md
+++ b/.changeset/fix-missing-scheduled-message-chip.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix the scheduled-messages chip not appearing in a room despite having pending scheduled messages.

--- a/src/app/features/room/schedule-send/ScheduledMessagesList.tsx
+++ b/src/app/features/room/schedule-send/ScheduledMessagesList.tsx
@@ -10,11 +10,15 @@ import {
   PencilSimple,
   X,
 } from '$components/icons/phosphor';
-import type { DelayedEventInfo, Room } from '$types/matrix-sdk';
+import type { Room } from '$types/matrix-sdk';
 import { MatrixEvent } from '$types/matrix-sdk';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import { getDelayedEvents, cancelDelayedEvent } from '$utils/delayedEvents';
+import {
+  getDelayedEvents,
+  cancelDelayedEvent,
+  type DelayedEventsResponse,
+} from '$utils/delayedEvents';
 import {
   delayedEventsSupportedAtom,
   roomIdToScheduledTimeAtomFamily,
@@ -32,7 +36,7 @@ type ScheduledMessagesListProps = {
   onEditMessage?: (body: string, formattedBody?: string) => void;
 };
 
-type ScheduledEvent = NonNullable<DelayedEventInfo['scheduled']>[number];
+type ScheduledEvent = DelayedEventsResponse['delayed_events'][number];
 
 type ScheduledMessageRowProps = {
   room: Room;
@@ -150,7 +154,7 @@ export function ScheduledMessagesList({ room, onEditMessage }: ScheduledMessages
     enabled: supported,
   });
 
-  const roomEvents = data?.scheduled?.filter(
+  const roomEvents = data?.delayed_events.filter(
     (event) =>
       event.room_id === room.roomId &&
       (event.type === 'm.room.message' || event.type === 'm.room.encrypted')

--- a/src/app/utils/delayedEvents.ts
+++ b/src/app/utils/delayedEvents.ts
@@ -1,6 +1,6 @@
 import { EventType, MatrixEvent, UpdateDelayedEventAction } from '$types/matrix-sdk';
 import type {
-  DelayedEventInfo,
+  DelayedEventInfoItem,
   SendDelayedEventResponse,
   IContent,
   MatrixClient,
@@ -13,6 +13,15 @@ import type {
 interface EncryptableBackend {
   encryptEvent(event: MatrixEvent, room: Room): Promise<void>;
 }
+
+// matrix-js-sdk's own `DelayedEventInfo` type declares this array under `scheduled`, but its
+// `_unstable_getDelayedEvents` call is a raw passthrough of the server's response, and MSC4140
+// (and every homeserver implementing it) puts the array under `delayed_events`:
+// https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4140-delayed-events-futures.md
+export type DelayedEventsResponse = {
+  delayed_events: DelayedEventInfoItem[];
+  next_batch?: string;
+};
 
 export async function supportsDelayedEvents(mx: MatrixClient): Promise<boolean> {
   try {
@@ -87,8 +96,8 @@ export async function sendDelayedMessageE2EE(
   );
 }
 
-export async function getDelayedEvents(mx: MatrixClient): Promise<DelayedEventInfo> {
-  return mx._unstable_getDelayedEvents();
+export async function getDelayedEvents(mx: MatrixClient): Promise<DelayedEventsResponse> {
+  return mx._unstable_getDelayedEvents() as unknown as Promise<DelayedEventsResponse>;
 }
 
 export async function cancelDelayedEvent(mx: MatrixClient, delayId: string): Promise<void> {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes missing schedule message chip bug which showed up during the matrix SDK migration. My first pass at fixing this was a one-line change (which did work) but generated a type error during the requested post-deploy checks. I used Claude to investigate the errors and it added the remaining changes which fix all type errors.

Deployed in my test environment and the scheduled message feature is fully working as expected again.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
As above I used Claude to help me resolve the type error after deploying a one-line visibility fix