### PR TITLE
fix(call): re-evaluate injected CSS when remote theme styles load

### DIFF
--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -132,6 +132,7 @@ export class CallEmbed {
       perParticipantE2EE: room.hasEncryptionStateEvent().toString(),
       lang: 'en-EN',
       theme: themeKind,
+      background: 'solid',
       header: 'none',
     });
 
@@ -446,6 +447,7 @@ export class CallEmbed {
     const doc = this.document;
     if (!doc) return;
 
+    doc.documentElement.style.setProperty('background', 'none', 'important');
     doc.body.style.setProperty('background', 'none', 'important');
 
     // Copy stylesheets from parent just in case
@@ -757,6 +759,7 @@ export class CallEmbed {
           font-family: ${appFontFamily} !important;
         }
       `;
+      if (doc.head.lastChild !== styleEl) doc.head.appendChild(styleEl);
     };
 
     // Sync theme classes from parent html/body
@@ -783,7 +786,12 @@ export class CallEmbed {
       attributes: true,
       attributeFilter: ['class', 'data-theme', 'style'],
     });
+    observer.observe(document.head, { childList: true, subtree: true });
     this.disposables.push(() => observer.disconnect());
+
+    const iframeHeadObserver = new MutationObserver(syncThemeClasses);
+    iframeHeadObserver.observe(doc.head, { childList: true });
+    this.disposables.push(() => iframeHeadObserver.disconnect());
   }
 
   private onEvent(ev: MatrixEvent): void {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
