### PR TITLE
fix: register enable-pk-latching focusId in settings link map

### DIFF
--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -104,7 +104,13 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'has-cats',
     'profile-change-propagation',
   ],
-  persona: ['enable-pk-commands', 'enable-pk-shorthands', 'create-pmp', 'enable-pmp-picker'],
+  persona: [
+    'enable-pk-commands',
+    'enable-pk-shorthands',
+    'enable-pk-latching',
+    'create-pmp',
+    'enable-pmp-picker',
+  ],
   appearance: [
     'autoplay-emojis',
     'old-sidebar',


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
