### PR TITLE
fix(sliding-sync): keep an accepted invite joined when the server replays stale invite state

### DIFF
--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -146,7 +146,7 @@ function installSlidingSyncRequestPatch(mx: MatrixClient, manager: SlidingSyncMa
 
   const mxWritable = mx as MatrixClientWithWritableSlidingSync;
   const original = mx.slidingSync.bind(mx) as SlidingSyncMethod;
-  mxWritable.slidingSync = (reqBody, baseUrl, abortSignal) => {
+  mxWritable.slidingSync = async (reqBody, baseUrl, abortSignal) => {
     const req = reqBody as SlidingSyncRequestWithConnId;
     if (req.conn_id === undefined) {
       req.conn_id = SLIDING_SYNC_CONN_ID;
@@ -155,7 +155,10 @@ function installSlidingSyncRequestPatch(mx: MatrixClient, manager: SlidingSyncMa
     const roomIds = manager.getActiveRoomSubscriptionIds();
     scopeEphemeralExtensions(req.extensions, roomIds);
 
-    return original(reqBody, baseUrl, abortSignal);
+    // Must run before the SDK processes the response.
+    const response = await original(reqBody, baseUrl, abortSignal);
+    manager.sanitizeOptimisticJoinResponse(response);
+    return response;
   };
 
   slidingSyncRequestCleanupByClient.set(mx, () => {

--- a/src/client/slidingSync.test.ts
+++ b/src/client/slidingSync.test.ts
@@ -3,10 +3,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { MatrixClient, MSC3575List } from '$types/matrix-sdk';
+import type { MatrixClient, MatrixEvent, MSC3575List } from '$types/matrix-sdk';
 import { EventType, KnownMembership, SlidingSyncEvent, SlidingSyncState } from '$types/matrix-sdk';
 
 import { scopeEphemeralExtensions, SlidingSyncManager } from './slidingSync';
+import type { SlidingSyncSidebarCache } from './slidingSyncSidebarCache';
 
 // ── vi.hoisted mocks ─────────────────────────────────────────────────────────
 // Must be defined via vi.hoisted
@@ -77,6 +78,45 @@ function makeMockMx(overrides: Record<string, unknown> = {}) {
 function makeManager(mx: ReturnType<typeof makeMockMx>): SlidingSyncManager {
   return new SlidingSyncManager(mx, 'https://sliding.example.com');
 }
+
+function makeMemberRoom(roomId: string, initialMembership: string = KnownMembership.Invite) {
+  // Tracked separately, as in the SDK: updateMyMembership() touches only the former.
+  let selfMembership = initialMembership;
+  let memberEventMembership = initialMembership;
+  const setStateEvents = vi.fn<(events: MatrixEvent[]) => void>((events) => {
+    const membership = events[0]?.getContent().membership;
+    if (typeof membership === 'string') memberEventMembership = membership;
+  });
+  return {
+    roomId,
+    setStateEvents,
+    /** Simulate Room.recalculate() reading a stale invite back out. */
+    setMembership: (next: string) => {
+      selfMembership = next;
+      memberEventMembership = next;
+    },
+    getMyMembership: vi.fn<() => string>(() => selfMembership),
+    updateMyMembership: vi.fn<(next: string) => void>((next) => {
+      selfMembership = next;
+    }),
+    getLiveTimeline: vi.fn<() => unknown>(() => ({
+      getEvents: () => [],
+      getState: () => ({
+        getStateEvents: () => ({
+          getContent: () => ({
+            membership: memberEventMembership,
+            displayname: 'Alice',
+          }),
+        }),
+        setStateEvents,
+      }),
+    })),
+  };
+}
+
+const trackedJoins = (manager: SlidingSyncManager): Map<string, unknown> =>
+  (manager as unknown as { optimisticallyJoinedRoomIds: Map<string, unknown> })
+    .optimisticallyJoinedRoomIds;
 
 function makeRoomWithTimeline(eventCount: number) {
   const events = Array.from({ length: eventCount }, () => ({ status: null }));
@@ -753,39 +793,22 @@ describe('scopeEphemeralExtensions', () => {
 
 describe('SlidingSyncManager local membership reconciliation', () => {
   it('updates an existing invite immediately after a successful join', () => {
-    const updateMyMembership = vi.fn<() => void>();
-    const manager = makeManager(
-      makeMockMx({
-        getRoom: vi.fn<() => { updateMyMembership: typeof updateMyMembership }>().mockReturnValue({
-          updateMyMembership,
-        }),
-      })
-    );
+    const room = makeMemberRoom('!invite:example.com');
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
 
     manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
 
-    expect(updateMyMembership).toHaveBeenCalledWith(KnownMembership.Join);
+    expect(room.updateMyMembership).toHaveBeenCalledWith(KnownMembership.Join);
   });
 
   it('updates and unsubscribes a room immediately after a successful leave', () => {
-    const updateMyMembership = vi.fn<() => void>();
-    const manager = makeManager(
-      makeMockMx({
-        getRoom: vi
-          .fn<() => { updateMyMembership: typeof updateMyMembership; getLiveTimeline: unknown }>()
-          .mockReturnValue({
-            updateMyMembership,
-            getLiveTimeline: vi.fn<() => { getEvents: () => unknown[] }>(() => ({
-              getEvents: () => [],
-            })),
-          }),
-      })
-    );
+    const room = makeMemberRoom('!room:example.com', KnownMembership.Join);
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
     manager.subscribeToRoom('!room:example.com');
 
     manager.reconcileRoomMembership('!room:example.com', KnownMembership.Leave);
 
-    expect(updateMyMembership).toHaveBeenCalledWith(KnownMembership.Leave);
+    expect(room.updateMyMembership).toHaveBeenCalledWith(KnownMembership.Leave);
     expect(manager.isRoomActive('!room:example.com')).toBe(false);
     expect(mocks.slidingSyncInstance.modifyRoomSubscriptions).toHaveBeenLastCalledWith(new Set());
   });
@@ -839,11 +862,7 @@ describe('SlidingSyncManager local membership reconciliation', () => {
   });
 
   it('re-asserts join for a joined room hydrated from cache as invite', async () => {
-    const updateMyMembership = vi.fn<(m: string) => void>();
-    const room = {
-      getMyMembership: vi.fn<() => string>().mockReturnValue(KnownMembership.Invite),
-      updateMyMembership,
-    };
+    const room = makeMemberRoom('!joined:example.com');
     const getJoinedRooms = vi
       .fn<() => Promise<{ joined_rooms: string[] }>>()
       .mockResolvedValue({ joined_rooms: ['!joined:example.com'] });
@@ -862,22 +881,31 @@ describe('SlidingSyncManager local membership reconciliation', () => {
     internals.reconcileSidebarCacheMembership();
     await vi.waitFor(() => expect(getJoinedRooms).toHaveBeenCalledOnce());
 
-    expect(updateMyMembership).toHaveBeenCalledWith(KnownMembership.Join);
+    expect(room.updateMyMembership).toHaveBeenCalledWith(KnownMembership.Join);
+    // Repaired too, otherwise the next Room.recalculate() reverts it.
+    expect(room.setStateEvents).toHaveBeenCalledOnce();
   });
 
-  it('subscribes an optimistically joined room and tracks it for re-assertion', () => {
-    const updateMyMembership = vi.fn<() => void>();
-    const manager = makeManager(
-      makeMockMx({
-        getRoom: vi.fn<() => { updateMyMembership: typeof updateMyMembership }>().mockReturnValue({
-          updateMyMembership,
-        }),
-      })
+  it('clears the persisted invite when joining, so a reload cannot resurrect it', () => {
+    const room = makeMemberRoom('!invite:example.com');
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
+    const clearInviteStateForRooms = vi.spyOn(
+      (manager as unknown as { sidebarCache: SlidingSyncSidebarCache }).sidebarCache,
+      'clearInviteStateForRooms'
     );
 
     manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
 
-    expect(updateMyMembership).toHaveBeenCalledWith(KnownMembership.Join);
+    expect(clearInviteStateForRooms).toHaveBeenCalledWith(['!invite:example.com']);
+  });
+
+  it('subscribes an optimistically joined room and tracks it for re-assertion', () => {
+    const room = makeMemberRoom('!invite:example.com');
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
+
+    manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
+
+    expect(room.updateMyMembership).toHaveBeenCalledWith(KnownMembership.Join);
     // Room is now an active subscription so the next sync pulls real joined state
     expect(manager.isRoomActive('!invite:example.com')).toBe(true);
     expect(mocks.slidingSyncInstance.modifyRoomSubscriptions).toHaveBeenLastCalledWith(
@@ -886,110 +914,300 @@ describe('SlidingSyncManager local membership reconciliation', () => {
   });
 
   it('re-asserts join after a sync cycle when the SDK reverted to invite', () => {
-    let myMembership: string = KnownMembership.Invite;
-    const updateMyMembership = vi.fn<(m: string) => void>().mockImplementation((m) => {
-      myMembership = m;
-    });
-    const room = {
-      getMyMembership: vi.fn<() => string>().mockImplementation(() => myMembership),
-      updateMyMembership,
-    };
-    const manager = makeManager(
-      makeMockMx({
-        getRoom: vi.fn<() => typeof room>().mockReturnValue(room),
-      })
-    );
+    const room = makeMemberRoom('!invite:example.com');
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
     manager.attach();
 
     // Optimistic join
     manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
-    expect(myMembership).toBe(KnownMembership.Join);
+    expect(room.getMyMembership()).toBe(KnownMembership.Join);
 
     // Simulate the SDK reverting to invite during a sync cycle, then fire Complete.
     // (room.recalculate() in the SDK would set this back to invite via invite_state)
-    myMembership = KnownMembership.Invite;
+    room.setMembership(KnownMembership.Invite);
 
     fireLifecycle(SlidingSyncState.Complete, {
-      rooms: {
-        '!invite:example.com': {
-          required_state: [],
-          invite_state: [
-            {
-              type: EventType.RoomMember,
-              state_key: '@user:example.com',
-              sender: '@inviter:example.com',
-              content: { membership: KnownMembership.Invite },
-            },
-          ],
-        },
-      },
+      rooms: { '!invite:example.com': {} },
     });
 
     // The manager re-asserted join
-    expect(updateMyMembership).toHaveBeenLastCalledWith(KnownMembership.Join);
-    expect(myMembership).toBe(KnownMembership.Join);
+    expect(room.updateMyMembership).toHaveBeenLastCalledWith(KnownMembership.Join);
+    expect(room.getMyMembership()).toBe(KnownMembership.Join);
   });
 
-  it('stops tracking a room once the server confirms join (no invite_state)', () => {
-    let myMembership: string = KnownMembership.Join;
-    const updateMyMembership = vi.fn<(m: string) => void>().mockImplementation((m) => {
-      myMembership = m;
+  it('leaves tracking to the response sanitiser rather than the SDK membership', () => {
+    const room = makeMemberRoom('!invite:example.com', KnownMembership.Join);
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
+    manager.attach();
+
+    manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
+    fireLifecycle(SlidingSyncState.Complete, {
+      rooms: { '!invite:example.com': {} },
     });
-    const room = {
-      getMyMembership: vi.fn<() => string>().mockImplementation(() => myMembership),
-      updateMyMembership,
-    };
-    const manager = makeManager(
-      makeMockMx({
-        getRoom: vi.fn<() => typeof room>().mockReturnValue(room),
-      })
-    );
+
+    // Membership reading "join" is not proof the server caught up.
+    expect(trackedJoins(manager).has('!invite:example.com')).toBe(true);
+    // Only the optimistic write; nothing re-asserted.
+    expect(room.updateMyMembership).toHaveBeenCalledOnce();
+    expect(room.setStateEvents).not.toHaveBeenCalled();
+  });
+
+  it('stops re-asserting a join for a room the server stops reporting', () => {
+    const room = makeMemberRoom('!invite:example.com');
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
+    manager.attach();
+
+    manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
+    // Never appears in a response, so sanitisation cannot release it. The
+    // deadline counts cycles *after* the join.
+    for (let cycle = 0; cycle <= 10; cycle += 1) {
+      fireLifecycle(SlidingSyncState.Complete, { rooms: {} });
+    }
+
+    expect(trackedJoins(manager).has('!invite:example.com')).toBe(false);
+  });
+
+  const runStaleInviteCycles = (
+    manager: SlidingSyncManager,
+    room: ReturnType<typeof makeMemberRoom>,
+    cycles: number
+  ) => {
+    for (let cycle = 0; cycle < cycles; cycle += 1) {
+      const response = respond(room.roomId, {
+        invite_state: [selfMember(KnownMembership.Invite)],
+      });
+      manager.sanitizeOptimisticJoinResponse(response as never);
+      room.setMembership(KnownMembership.Invite);
+      fireLifecycle(SlidingSyncState.Complete, response);
+    }
+  };
+
+  it('keeps correcting a server that sends a stale invite past the deadline', async () => {
+    const room = makeMemberRoom('!invite:example.com');
+    const getJoinedRooms = vi
+      .fn<() => Promise<{ joined_rooms: string[] }>>()
+      .mockResolvedValue({ joined_rooms: ['!invite:example.com'] });
+    const manager = makeManager(makeMockMx({ getRoom: () => room, getJoinedRooms }));
     manager.attach();
 
     manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
 
-    // Server caught up: room is joined, no invite_state in the response.
-    fireLifecycle(SlidingSyncState.Complete, {
-      rooms: {
-        '!invite:example.com': {
-          required_state: [
-            {
-              type: EventType.RoomMember,
-              state_key: '@user:example.com',
-              sender: '@user:example.com',
-              content: { membership: KnownMembership.Join },
-            },
-          ],
-          timeline: [],
-        },
-      },
-    });
+    // The deadline must not expire while the server is still sending the room.
+    runStaleInviteCycles(manager, room, 21);
+    await vi.waitFor(() => expect(getJoinedRooms).toHaveBeenCalled());
 
-    // Room is no longer tracked; a subsequent revert would not be re-asserted.
-    expect(updateMyMembership).toHaveBeenCalledTimes(1); // only the initial optimistic join
+    expect(trackedJoins(manager).has('!invite:example.com')).toBe(true);
+    expect(room.getMyMembership()).toBe(KnownMembership.Join);
+  });
+
+  it('defers to the server once it confirms we are not actually joined', async () => {
+    const room = makeMemberRoom('!invite:example.com');
+    // Kicked and re-invited inside one sync gap: the new invite is real.
+    const getJoinedRooms = vi
+      .fn<() => Promise<{ joined_rooms: string[] }>>()
+      .mockResolvedValue({ joined_rooms: [] });
+    const manager = makeManager(makeMockMx({ getRoom: () => room, getJoinedRooms }));
+    manager.attach();
+
+    manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
+    runStaleInviteCycles(manager, room, 4);
+    await vi.waitFor(() => expect(getJoinedRooms).toHaveBeenCalledOnce());
+
+    expect(trackedJoins(manager).has('!invite:example.com')).toBe(false);
+  });
+
+  it('keeps assuming joined when the membership check cannot be made', async () => {
+    const room = makeMemberRoom('!invite:example.com');
+    const getJoinedRooms = vi
+      .fn<() => Promise<{ joined_rooms: string[] }>>()
+      .mockRejectedValue(new Error('offline'));
+    const manager = makeManager(makeMockMx({ getRoom: () => room, getJoinedRooms }));
+    manager.attach();
+
+    manager.reconcileRoomMembership('!invite:example.com', KnownMembership.Join);
+    runStaleInviteCycles(manager, room, 4);
+    await vi.waitFor(() => expect(getJoinedRooms).toHaveBeenCalledOnce());
+
+    // Must not strand the user back on the invite.
+    expect(trackedJoins(manager).has('!invite:example.com')).toBe(true);
+    expect(room.getMyMembership()).toBe(KnownMembership.Join);
   });
 
   it('clears optimistic join tracking on leave', () => {
-    const updateMyMembership = vi.fn<() => void>();
-    const manager = makeManager(
-      makeMockMx({
-        getRoom: vi
-          .fn<() => { updateMyMembership: typeof updateMyMembership; getLiveTimeline: unknown }>()
-          .mockReturnValue({
-            updateMyMembership,
-            getLiveTimeline: vi.fn<() => { getEvents: () => unknown[] }>(() => ({
-              getEvents: () => [],
-            })),
-          }),
-      })
-    );
+    const room = makeMemberRoom('!room:example.com');
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
     manager.subscribeToRoom('!room:example.com');
 
     manager.reconcileRoomMembership('!room:example.com', KnownMembership.Join);
     manager.reconcileRoomMembership('!room:example.com', KnownMembership.Leave);
 
-    expect(updateMyMembership).toHaveBeenCalledWith(KnownMembership.Leave);
+    expect(trackedJoins(manager).has('!room:example.com')).toBe(false);
+    expect(room.updateMyMembership).toHaveBeenCalledWith(KnownMembership.Leave);
     expect(manager.isRoomActive('!room:example.com')).toBe(false);
+  });
+});
+
+const selfMember = (membership: string) => ({
+  type: EventType.RoomMember,
+  state_key: '@user:example.com',
+  sender: '@inviter:example.com',
+  content: { membership },
+});
+
+const respond = (roomId: string, roomData: Record<string, unknown>) => ({
+  rooms: { [roomId]: roomData },
+});
+
+const sanitizedSelfMember = (roomData: Record<string, unknown> | undefined) =>
+  (roomData?.required_state as { state_key?: string; content?: unknown }[] | undefined)?.find(
+    (event) => event.state_key === '@user:example.com'
+  );
+
+describe('SlidingSyncManager optimistic join sanitisation', () => {
+  const ROOM_ID = '!invite:example.com';
+
+  it('replaces stale invite data with a join for an optimistically joined room', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+    const invite = selfMember(KnownMembership.Invite);
+
+    const response = respond(ROOM_ID, {
+      required_state: [invite],
+      invite_state: [invite],
+      timeline: [],
+    });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(response.rooms[ROOM_ID]?.invite_state).toBeUndefined();
+    // Replaced, not removed: the cache clears its invite only on a join here.
+    expect(sanitizedSelfMember(response.rooms[ROOM_ID])?.content).toMatchObject({
+      membership: KnownMembership.Join,
+    });
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(true);
+  });
+
+  it('replaces the invite when the server omits our member event entirely', () => {
+    // Continuwuity does not substitute "$ME", so our member event never appears.
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+
+    const response = respond(ROOM_ID, {
+      required_state: [{ type: EventType.RoomName, state_key: '', content: { name: 'Room' } }],
+      invite_state: [selfMember(KnownMembership.Invite)],
+    });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(response.rooms[ROOM_ID]?.invite_state).toBeUndefined();
+    expect(sanitizedSelfMember(response.rooms[ROOM_ID])?.content).toMatchObject({
+      membership: KnownMembership.Join,
+    });
+    expect(response.rooms[ROOM_ID]?.required_state).toHaveLength(2);
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(true);
+  });
+
+  it('drops a stale invite that accompanies a real join and stops tracking', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+    const join = selfMember(KnownMembership.Join);
+
+    // The SDK ignores required_state whenever invite_state is present.
+    const response = respond(ROOM_ID, {
+      required_state: [join],
+      invite_state: [selfMember(KnownMembership.Invite)],
+    });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(response.rooms[ROOM_ID]?.invite_state).toBeUndefined();
+    expect(response.rooms[ROOM_ID]?.required_state).toEqual([join]);
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(false);
+  });
+
+  it('stops tracking once the server stops sending any invite state', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+
+    // Server caught up without ever spelling the join out.
+    const response = respond(ROOM_ID, { required_state: [], timeline: [] });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(false);
+  });
+
+  it('keeps real join state and stops tracking once the server confirms', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+    const join = selfMember(KnownMembership.Join);
+
+    const response = respond(ROOM_ID, { required_state: [join], timeline: [] });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(response.rooms[ROOM_ID]?.required_state).toEqual([join]);
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(false);
+  });
+
+  it('stops tracking on a join confirmed only by the timeline', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+
+    // A limited timeline can still carry the prior invite, so the newest wins.
+    const response = respond(ROOM_ID, {
+      timeline: [selfMember(KnownMembership.Invite), selfMember(KnownMembership.Join)],
+    });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(false);
+  });
+
+  it('passes through a leave the server reports while the join is still tracked', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+    const leave = selfMember(KnownMembership.Leave);
+
+    // Kicked elsewhere: suppressing this strands us in a room we left.
+    const response = respond(ROOM_ID, {
+      required_state: [leave],
+      timeline: [],
+    });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(response.rooms[ROOM_ID]?.required_state).toEqual([leave]);
+    expect(trackedJoins(manager).has(ROOM_ID)).toBe(false);
+  });
+
+  it('leaves responses untouched for rooms that were not optimistically joined', () => {
+    const manager = makeManager(makeMockMx());
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+    const invite = selfMember(KnownMembership.Invite);
+
+    const response = respond('!other:example.com', {
+      required_state: [invite],
+      invite_state: [invite],
+      timeline: [],
+    });
+    manager.sanitizeOptimisticJoinResponse(response as never);
+
+    expect(response.rooms['!other:example.com']).toMatchObject({
+      required_state: [invite],
+      invite_state: [invite],
+    });
+  });
+
+  it('replaces the stale invite member event with a synthesized join one', () => {
+    const room = makeMemberRoom(ROOM_ID);
+    const manager = makeManager(makeMockMx({ getRoom: () => room }));
+
+    manager.reconcileRoomMembership(ROOM_ID, KnownMembership.Join);
+
+    expect(room.setStateEvents).toHaveBeenCalledOnce();
+    const [events] = room.setStateEvents.mock.calls[0] ?? [];
+    expect(events).toHaveLength(1);
+    expect(events?.[0]?.getContent()).toEqual({
+      membership: KnownMembership.Join,
+      displayname: 'Alice',
+    });
+    expect(events?.[0]?.getRoomId()).toBe(ROOM_ID);
+    // Sent by the user, not the inviter.
+    expect(events?.[0]?.getSender()).toBe('@user:example.com');
   });
 });
 

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -1,13 +1,16 @@
 import type {
+  IRoomEvent,
+  IStateEvent,
   MatrixClient,
-  MatrixEvent,
   MSC3575List,
   MSC3575RoomData,
   MSC3575RoomSubscription,
   MSC3575SlidingSyncResponse,
+  Room,
 } from '$types/matrix-sdk';
 import {
   KnownMembership,
+  MatrixEvent,
   MSC3575_WILDCARD,
   RoomMemberEvent,
   SlidingSync,
@@ -16,6 +19,7 @@ import {
   MSC3575_STATE_KEY_LAZY,
   MSC3575_STATE_KEY_ME,
   EventType,
+  EventTimeline,
   EventEmitterEvents,
   ClientEvent,
 } from '$types/matrix-sdk';
@@ -44,6 +48,14 @@ const SPACE_SUBSCRIPTION_KEY = 'space';
 const IMAGE_PACK_SUBSCRIPTION_KEY = 'image_packs';
 const SPACE_IMAGE_PACK_SUBSCRIPTION_KEY = 'space_image_packs';
 const ACTIVE_ROOM_TIMELINE_LIMIT = 50;
+const OPTIMISTIC_JOIN_MAX_SYNC_CYCLES = 10;
+const OPTIMISTIC_JOIN_VERIFY_AFTER_CYCLES = 3;
+
+type OptimisticJoin = {
+  joinedAtSyncCount: number;
+  lastSeenSyncCount: number;
+  verificationRequested: boolean;
+};
 
 export type PartialSlidingSyncRequest = {
   filters?: MSC3575List['filters'];
@@ -79,6 +91,60 @@ export type HydrationProgress = { loadedRooms: number; totalRooms: number };
 const clampPositive = (value: number | undefined, fallback: number): number => {
   if (typeof value !== 'number' || Number.isNaN(value) || value <= 0) return fallback;
   return Math.round(value);
+};
+
+type SlidingSyncEventLike = IStateEvent | IRoomEvent;
+
+const isSelfMemberEvent = (event: SlidingSyncEventLike, userId: string): boolean =>
+  event.type === (EventType.RoomMember as string) &&
+  'state_key' in event &&
+  event.state_key === userId;
+
+// Scans backwards so the newest wins in a timeline that still holds the
+// previous membership.
+const findSelfMemberEvent = <T extends SlidingSyncEventLike>(
+  events: readonly T[],
+  userId: string
+): T | undefined => {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (event && isSelfMemberEvent(event, userId)) return event;
+  }
+  return undefined;
+};
+
+const membershipOf = (event: SlidingSyncEventLike | undefined): string | undefined => {
+  const content = event?.content;
+  return content && typeof content === 'object'
+    ? ((content as { membership?: unknown }).membership as string | undefined)
+    : undefined;
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+// "~" is the SDK's local-echo event id prefix (see MatrixClient.sendEvent).
+const buildSelfJoinEvent = (
+  roomId: string,
+  userId: string,
+  previousContent: unknown
+): IStateEvent & { room_id: string } => {
+  // Only the profile carries over; is_direct and third_party_invite are invite-only.
+  const previous = (previousContent ?? {}) as { displayname?: unknown; avatar_url?: unknown };
+
+  return {
+    type: EventType.RoomMember,
+    state_key: userId,
+    room_id: roomId,
+    sender: userId,
+    event_id: `~sable-self-join:${roomId}`,
+    origin_server_ts: Date.now(),
+    content: {
+      membership: KnownMembership.Join,
+      displayname: asString(previous.displayname),
+      avatar_url: asString(previous.avatar_url),
+    },
+  };
 };
 
 const buildListRequiredState = (): MSC3575RoomSubscription['required_state'] => [
@@ -237,12 +303,11 @@ export class SlidingSyncManager {
   private readonly activeRoomSubscriptions = new Set<string>();
 
   /**
-   * Room IDs joined locally via reconcileRoomMembership(Join) but not yet
-   * confirmed as joined by the server's sliding-sync response. The SDK can
-   * revert these to "invite" when the server still sends invite_state after a
-   * join; we re-assert join after each sync until the server catches up.
+   * Rooms joined locally via reconcileRoomMembership(Join) but not yet confirmed
+   * joined by a sliding-sync response. The SDK reverts these to "invite" when the
+   * server still sends invite_state after a join, so we re-assert join each sync.
    */
-  private readonly optimisticallyJoinedRoomIds = new Set<string>();
+  private readonly optimisticallyJoinedRoomIds = new Map<string, OptimisticJoin>();
 
   private readonly sidebarRoomSubscriptions = new Set<string>();
 
@@ -643,17 +708,12 @@ export class SlidingSyncManager {
   private recordServerMembershipRooms(response: MSC3575SlidingSyncResponse): void {
     const userId = this.mx.getSafeUserId();
     Object.entries(response.rooms ?? {}).forEach(([roomId, roomData]) => {
-      const membershipEvent = [
-        ...(roomData.required_state ?? []),
-        ...(roomData.invite_state ?? []),
-      ].find(
-        (event) => event.type === (EventType.RoomMember as string) && event.state_key === userId
+      const membership = membershipOf(
+        findSelfMemberEvent(
+          [...(roomData.required_state ?? []), ...(roomData.invite_state ?? [])],
+          userId
+        )
       );
-      const content = membershipEvent?.content;
-      const membership =
-        content && typeof content === 'object'
-          ? (content as { membership?: unknown }).membership
-          : undefined;
 
       if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
         this.serverMembershipRoomIds.delete(roomId);
@@ -691,7 +751,7 @@ export class SlidingSyncManager {
       joinedRoomIds.forEach((roomId) => {
         const room = this.mx.getRoom(roomId);
         if (room?.getMyMembership() === (KnownMembership.Invite as string)) {
-          room.updateMyMembership(KnownMembership.Join);
+          this.assertLocalJoin(room);
         }
       });
 
@@ -1014,22 +1074,157 @@ export class SlidingSyncManager {
    * after the SDK has finished processing all room data for the cycle (Complete
    * fires post-processing) and before the responseSettled microtask that drives
    * unread computation, so the app sees the corrected membership.
+   *
+   * Release is driven by sanitizeOptimisticJoinResponse, not by the SDK
+   * membership read back here: that would release the room merely because
+   * nothing in the cycle touched it, letting a later stale invite win for good.
    */
   private reassertOptimisticJoins(): void {
     if (this.optimisticallyJoinedRoomIds.size === 0) return;
-    for (const roomId of this.optimisticallyJoinedRoomIds) {
+    for (const [roomId, tracked] of this.optimisticallyJoinedRoomIds) {
       const room = this.mx.getRoom(roomId);
       if (!room) {
         this.optimisticallyJoinedRoomIds.delete(roomId);
         continue;
       }
-      if (room.getMyMembership() === (KnownMembership.Join as string)) {
-        // Server has caught up: the room is genuinely joined now. Stop tracking.
-        this.optimisticallyJoinedRoomIds.delete(roomId);
-      } else {
-        // SDK reverted to invite (or another state). Re-assert join.
-        room.updateMyMembership(KnownMembership.Join);
+      this.assertLocalJoin(room);
+
+      if (
+        !tracked.verificationRequested &&
+        this.syncCount - tracked.joinedAtSyncCount >= OPTIMISTIC_JOIN_VERIFY_AFTER_CYCLES
+      ) {
+        tracked.verificationRequested = true;
+        this.verifyOptimisticJoin(roomId);
       }
+
+      if (this.syncCount - tracked.lastSeenSyncCount >= OPTIMISTIC_JOIN_MAX_SYNC_CYCLES) {
+        debugLog.warn('sync', 'Stopped re-asserting optimistic join: room no longer reported', {
+          roomId,
+          syncCycles: OPTIMISTIC_JOIN_MAX_SYNC_CYCLES,
+        });
+        this.optimisticallyJoinedRoomIds.delete(roomId);
+      }
+    }
+  }
+
+  /**
+   * Asks the authoritative /joined_rooms who is right when the disagreement
+   * lasts. A "no" means our /join is stale (a fresh invite after a kick, or a
+   * join that never committed), so stop overriding the server. Errors keep the
+   * optimistic join: an unreachable server must not strand the user on an invite.
+   */
+  private verifyOptimisticJoin(roomId: string): void {
+    void this.mx
+      .getJoinedRooms()
+      .then((response) => {
+        if (this.disposed || !this.optimisticallyJoinedRoomIds.has(roomId)) return;
+        if (response.joined_rooms.includes(roomId)) return;
+
+        this.optimisticallyJoinedRoomIds.delete(roomId);
+        debugLog.warn('sync', 'Stopped re-asserting optimistic join: server reports not joined', {
+          roomId,
+        });
+        Sentry.addBreadcrumb({
+          category: 'sync.sliding',
+          message: 'Stopped re-asserting optimistic join: server reports not joined',
+          level: 'warning',
+        });
+      })
+      .catch((error: unknown) => {
+        debugLog.warn('sync', 'Could not verify optimistic join; still assuming joined', {
+          roomId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+
+  /**
+   * Room.recalculate() derives selfMembership from the m.room.member event, so
+   * fixing only one of the two lets the next recalculate() undo it. The crypto
+   * layer reads membership from that event too.
+   */
+  private assertLocalJoin(room: Room): void {
+    if (room.getMyMembership() !== (KnownMembership.Join as string)) {
+      room.updateMyMembership(KnownMembership.Join);
+    }
+    this.repairSelfJoinMemberEvent(room);
+  }
+
+  private repairSelfJoinMemberEvent(room: Room): void {
+    const myUserId = this.mx.getUserId();
+    if (!myUserId) return;
+    const roomState = room.getLiveTimeline().getState(EventTimeline.FORWARDS);
+    if (!roomState) return;
+    const existing = roomState.getStateEvents(EventType.RoomMember, myUserId)?.getContent();
+    if (existing?.membership === KnownMembership.Join) return;
+
+    roomState.setStateEvents([
+      new MatrixEvent(buildSelfJoinEvent(room.roomId, myUserId, existing)),
+    ]);
+  }
+
+  /**
+   * Strips the stale stripped invite some servers keep sending for a room we
+   * already joined, before the SDK derives an invite from it.
+   *
+   * Which field reports the membership varies: Synapse omits required_state for
+   * invites, and Continuwuity does not substitute the "$ME" state key at all, so
+   * our own member event never appears in its required_state.
+   */
+  public sanitizeOptimisticJoinResponse(resp: MSC3575SlidingSyncResponse | null): void {
+    if (!resp?.rooms || this.optimisticallyJoinedRoomIds.size === 0) return;
+    const myUserId = this.mx.getUserId();
+    if (!myUserId) return;
+
+    for (const [roomId, tracked] of this.optimisticallyJoinedRoomIds) {
+      const roomData = resp.rooms[roomId];
+      if (!roomData) continue;
+
+      tracked.lastSeenSyncCount = this.syncCount;
+
+      const stateMember = findSelfMemberEvent(roomData.required_state ?? [], myUserId);
+      const reported =
+        membershipOf(stateMember) ??
+        membershipOf(findSelfMemberEvent(roomData.timeline ?? [], myUserId));
+      const staleInvite = findSelfMemberEvent(roomData.invite_state ?? [], myUserId);
+
+      if (
+        reported !== undefined &&
+        reported !== (KnownMembership.Invite as string) &&
+        reported !== (KnownMembership.Knock as string)
+      ) {
+        // Our join, or something newer we must not suppress.
+        this.optimisticallyJoinedRoomIds.delete(roomId);
+        // The SDK ignores required_state whenever invite_state is present.
+        if (reported === (KnownMembership.Join as string)) delete roomData.invite_state;
+        continue;
+      }
+
+      if (!roomData.invite_state) {
+        // The server stopped treating us as invited.
+        this.optimisticallyJoinedRoomIds.delete(roomId);
+        continue;
+      }
+
+      // Replaced, not removed: the sidebar cache only clears its persisted
+      // invite once required_state says join.
+      delete roomData.invite_state;
+      roomData.required_state = [
+        ...(roomData.required_state ?? []).filter((event) => !isSelfMemberEvent(event, myUserId)),
+        buildSelfJoinEvent(roomId, myUserId, staleInvite?.content ?? stateMember?.content),
+      ];
+
+      debugLog.info('sync', 'Replaced stale invite data for optimistically joined room', {
+        roomId,
+        reported,
+        syncCycle: this.syncCount,
+      });
+      Sentry.addBreadcrumb({
+        category: 'sync.sliding',
+        message: 'Replaced stale invite data for optimistically joined room',
+        level: 'info',
+        data: { reported, syncCycle: this.syncCount },
+      });
     }
   }
 
@@ -1037,12 +1232,21 @@ export class SlidingSyncManager {
     roomId: string,
     membership: KnownMembership.Join | KnownMembership.Leave
   ): void {
-    this.mx.getRoom(roomId)?.updateMyMembership(membership);
+    const room = this.mx.getRoom(roomId);
+    room?.updateMyMembership(membership);
 
     if (membership === KnownMembership.Join) {
+      if (room) this.repairSelfJoinMemberEvent(room);
+      // The cache clears its own invite only once required_state says join, which
+      // a server without "$ME" substitution never sends, so drop it here.
+      this.sidebarCache.clearInviteStateForRooms([roomId]);
       // Track the room so we can re-assert join if the SDK reverts it while the
       // server's sliding-sync proxy still reports the room in the invite list.
-      this.optimisticallyJoinedRoomIds.add(roomId);
+      this.optimisticallyJoinedRoomIds.set(roomId, {
+        joinedAtSyncCount: this.syncCount,
+        lastSeenSyncCount: this.syncCount,
+        verificationRequested: false,
+      });
       // Subscribe so the next sync pulls real joined member state into the
       // room's current state, letting recalculate() see "join" not "invite".
       this.subscribeToRoom(roomId);


### PR DESCRIPTION
### Description

repair the m.room.member event alongside selfMembership so a replayed invite cannot revert an accepted join, and clear the invite the sidebar cache persisted

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
