### PR TITLE
timeline bug fixes plus tests, and one sliding sync fix for #1324

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.4",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+    "@faker-js/faker": "^10.5.0",
     "@playwright/test": "^1.61.1",
     "@rollup/plugin-inject": "^5.0.5",
     "@rollup/plugin-wasm": "^6.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.2.3
         version: 0.2.3(esbuild@0.28.1)
+      '@faker-js/faker':
+        specifier: ^10.5.0
+        version: 10.5.0
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -1397,6 +1400,10 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@faker-js/faker@10.5.0':
+    resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@fontsource-variable/nunito@5.2.7':
     resolution: {integrity: sha512-2N8QhatkyKgSUbAGZO2FYLioxA32+RyI1EplVLawbpkGjUeui9Qg9VMrpkCaik1ydjFjfLV+kzQ0cGEsMrMenQ==}
@@ -6905,6 +6912,8 @@ snapshots:
   '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
     optionalDependencies:
       '@noble/hashes': 2.2.0
+
+  '@faker-js/faker@10.5.0': {}
 
   '@fontsource-variable/nunito@5.2.7': {}
 

--- a/src/app/features/room/RoomTimeline.test.tsx
+++ b/src/app/features/room/RoomTimeline.test.tsx
@@ -14,6 +14,7 @@ const {
   getRoomUnreadInfoMock,
   rendererCtxPermissions,
   rendererCtxSettings,
+  rowItemIndex,
   processedTimelineOptions,
   windowFocused,
   rowRenders,
@@ -50,6 +51,7 @@ const {
     current: undefined as Record<string, unknown> | undefined,
   },
   windowFocused: { current: false },
+  rowItemIndex: { current: 0 },
   rowRenders: { count: 0 },
 }));
 
@@ -160,6 +162,8 @@ vi.mock('$hooks/timeline/useProcessedTimeline', async (importOriginal) => {
     ...actual,
     useProcessedTimeline: (options: Record<string, unknown>) => {
       processedTimelineOptions.current = options;
+      // Same object every call so the row memo can compare eventData by identity.
+      fakeEvent.itemIndex = rowItemIndex.current;
       return [fakeEvent];
     },
   };
@@ -274,6 +278,7 @@ beforeEach(() => {
   rendererCtxSettings.hideReads = false;
   processedTimelineOptions.current = undefined;
   windowFocused.current = false;
+  rowItemIndex.current = 0;
   rowRenders.count = 0;
   timelineSync.eventsLength = 1;
   timelineSync.focusItem = undefined;
@@ -400,6 +405,16 @@ describe('MemoizedTimelineItem', () => {
     expect(rowRenders.count).toBe(before);
   });
 
+  it('does not re-render for a focusItem pointing at the -1 merged-row sentinel', () => {
+    rowItemIndex.current = -1;
+    const { rerender } = renderTimeline();
+    const before = rowRenders.count;
+
+    timelineSync.focusItem = { index: -1, highlight: true, scrollTo: false };
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(rowRenders.count).toBe(before);
+  });
 });
 
 describe('unread read marker (normal sync)', () => {

--- a/src/app/features/room/RoomTimeline.test.tsx
+++ b/src/app/features/room/RoomTimeline.test.tsx
@@ -16,9 +16,9 @@ const {
   getRoomUnreadInfoMock,
   rendererCtxPermissions,
   rendererCtxSettings,
-  rowItemIndex,
   processedTimelineOptions,
   windowFocused,
+  rowItemIndex,
   rowRenders,
 } = vi.hoisted(() => ({
   vListHandle: {
@@ -166,7 +166,7 @@ vi.mock('$hooks/timeline/useProcessedTimeline', async (importOriginal) => {
       processedTimelineOptions.current = options;
       // Same object every call so the row memo can compare eventData by identity.
       fakeEvent.itemIndex = rowItemIndex.current;
-      return [fakeEvent];
+      return (options.items as number[]).length === 0 ? [] : [fakeEvent];
     },
   };
 });
@@ -427,6 +427,39 @@ describe('remote read receipts', () => {
     });
 
     expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
+  });
+});
+
+describe('failed backfill on an empty timeline', () => {
+  it('surfaces the error with a working Retry instead of endless placeholders', () => {
+    timelineSync.eventsLength = 0;
+    timelineSync.canPaginateBack = true;
+    timelineSync.backwardStatus = 'error';
+
+    const { container, getByText } = renderTimeline();
+
+    expect(container.textContent).toContain('Failed to load history.');
+    expect(container.querySelector('[data-testid="vlist-content"]')?.textContent).not.toContain(
+      'placeholder'
+    );
+    const listWrapper = container.querySelector('[data-testid="vlist-scroll"]')
+      ?.parentElement as HTMLElement;
+    expect(listWrapper.style.opacity).toBe('1');
+
+    act(() => {
+      getByText('Retry').click();
+    });
+    expect(timelineSync.handleTimelinePagination).toHaveBeenCalledWith(true);
+  });
+
+  it('still shows placeholders while the first backfill is in flight', () => {
+    timelineSync.eventsLength = 0;
+    timelineSync.canPaginateBack = true;
+    timelineSync.backwardStatus = 'loading';
+
+    const { container } = renderTimeline();
+
+    expect(container.textContent).not.toContain('Failed to load history.');
   });
 });
 

--- a/src/app/features/room/RoomTimeline.test.tsx
+++ b/src/app/features/room/RoomTimeline.test.tsx
@@ -7,7 +7,17 @@ import type { ProcessedEvent } from '$hooks/timeline/useProcessedTimeline';
 import type * as DomUtils from '$utils/dom';
 import { RoomTimeline } from './RoomTimeline';
 
-const { vListHandle, timelineSync, setUnreadTimelineMock } = vi.hoisted(() => ({
+const {
+  vListHandle,
+  timelineSync,
+  setUnreadTimelineMock,
+  getRoomUnreadInfoMock,
+  rendererCtxPermissions,
+  rendererCtxSettings,
+  processedTimelineOptions,
+  windowFocused,
+  rowRenders,
+} = vi.hoisted(() => ({
   vListHandle: {
     scrollSize: 1000,
     scrollOffset: 0,
@@ -31,6 +41,16 @@ const { vListHandle, timelineSync, setUnreadTimelineMock } = vi.hoisted(() => ({
     handleTimelinePagination: vi.fn<() => void>(),
   },
   setUnreadTimelineMock: vi.fn<() => void>(),
+  getRoomUnreadInfoMock: vi
+    .fn<() => { readUptoEventId: string; inLiveTimeline: boolean; scrollTo: boolean } | undefined>()
+    .mockReturnValue(undefined),
+  rendererCtxPermissions: { canRedact: false },
+  rendererCtxSettings: { hideReads: false },
+  processedTimelineOptions: {
+    current: undefined as Record<string, unknown> | undefined,
+  },
+  windowFocused: { current: false },
+  rowRenders: { count: 0 },
 }));
 
 let lastOnScroll: ((offset: number) => void) | undefined;
@@ -138,43 +158,64 @@ vi.mock('$hooks/timeline/useProcessedTimeline', async (importOriginal) => {
   } as unknown as ProcessedEvent;
   return {
     ...actual,
-    useProcessedTimeline: () => [fakeEvent],
+    useProcessedTimeline: (options: Record<string, unknown>) => {
+      processedTimelineOptions.current = options;
+      return [fakeEvent];
+    },
   };
 });
 
-vi.mock('$hooks/timeline/useTimelineEventRenderer', () => ({
-  useTimelineEventRenderer: () => () => null,
-}));
+vi.mock('$hooks/timeline/useTimelineEventRenderer', () => {
+  // Stable identity like useMatrixEventRenderer's ref dispatch: the row memo,
+  // not this callback, is what has to notice a change.
+  const renderMatrixEvent = () => {
+    rowRenders.count += 1;
+    return `canRedact:${rendererCtxPermissions.canRedact} hideReads:${rendererCtxSettings.hideReads}`;
+  };
+  return {
+    useTimelineEventRenderer: () => renderMatrixEvent,
+  };
+});
 
-vi.mock('$hooks/timeline/useTimelineRendererContext', () => ({
-  useTimelineRendererContext: () => ({
-    settings: {
-      hiddenEvents: {},
-      messageLayout: 0,
-      messageSpacing: '300',
-      hideReads: false,
-      hideMembershipEvents: false,
-      hideNickAvatarEvents: false,
-      hideMemberInReadOnly: false,
-    },
-    linkifyOpts: {},
-    htmlReactParserOptions: {},
-    permissions: {
-      canRedact: false,
-      canDeleteOwn: false,
-      canSendReaction: false,
-      canPinEvent: false,
-      isReadOnly: false,
-      getMemberPowerTag: vi.fn<() => void>(),
-      parseMemberEvent: vi.fn<() => void>(),
-    },
-  }),
-}));
+vi.mock('$hooks/timeline/useTimelineRendererContext', () => {
+  let settings = {
+    hiddenEvents: {},
+    messageLayout: 0,
+    messageSpacing: '300',
+    hideReads: false,
+    hideMembershipEvents: false,
+    hideNickAvatarEvents: false,
+    hideMemberInReadOnly: false,
+  };
+  // New identity only when a value changes, like the real memoized context.
+  const currentSettings = () => {
+    if (settings.hideReads !== rendererCtxSettings.hideReads) {
+      settings = { ...settings, hideReads: rendererCtxSettings.hideReads };
+    }
+    return settings;
+  };
+  return {
+    useTimelineRendererContext: () => ({
+      settings: currentSettings(),
+      linkifyOpts: {},
+      htmlReactParserOptions: {},
+      permissions: {
+        canRedact: rendererCtxPermissions.canRedact,
+        canDeleteOwn: false,
+        canSendReaction: false,
+        canPinEvent: false,
+        isReadOnly: false,
+        getMemberPowerTag: vi.fn<() => void>(),
+        parseMemberEvent: vi.fn<() => void>(),
+      },
+    }),
+  };
+});
 
 vi.mock('$components/room-intro', () => ({ RoomIntro: () => null }));
 
 vi.mock('$utils/timeline', () => ({
-  getRoomUnreadInfo: () => undefined,
+  getRoomUnreadInfo: () => getRoomUnreadInfoMock(),
   getEventTimeline: () => undefined,
   getFirstLinkedTimeline: () => undefined,
   getInitialTimeline: () => undefined,
@@ -185,7 +226,7 @@ vi.mock('$utils/notifications', () => ({ markAsRead: vi.fn<() => void>() }));
 
 vi.mock('$utils/dom', async (importOriginal) => {
   const actual = await importOriginal<typeof DomUtils>();
-  return { ...actual, isWindowFocused: () => false };
+  return { ...actual, isWindowFocused: () => windowFocused.current };
 });
 
 type ObserverEntry = { callback: ResizeObserverCallback; elements: Set<Element> };
@@ -226,6 +267,22 @@ const getContentEl = (container: HTMLElement) => {
 };
 
 const renderTimeline = () => render(<RoomTimeline room={room} editor={{} as Editor} />);
+
+beforeEach(() => {
+  getRoomUnreadInfoMock.mockReset();
+  rendererCtxPermissions.canRedact = false;
+  rendererCtxSettings.hideReads = false;
+  processedTimelineOptions.current = undefined;
+  windowFocused.current = false;
+  rowRenders.count = 0;
+  timelineSync.eventsLength = 1;
+  timelineSync.focusItem = undefined;
+  timelineSync.canPaginateBack = false;
+  timelineSync.liveTimelineLinked = true;
+  timelineSync.backwardStatus = 'idle';
+  timelineSync.forwardStatus = 'idle';
+  (timelineSync.handleTimelinePagination as ReturnType<typeof vi.fn>).mockReset();
+});
 
 describe('RoomTimeline content ResizeObserver', () => {
   beforeEach(() => {
@@ -309,5 +366,151 @@ describe('RoomTimeline content ResizeObserver', () => {
       scrollTo: false,
       highlight: true,
     });
+  });
+});
+
+describe('MemoizedTimelineItem', () => {
+  it('re-renders message rows when canRedact flips (power-level update)', () => {
+    const { container, rerender } = renderTimeline();
+    expect(container.textContent).toContain('canRedact:false');
+
+    rendererCtxPermissions.canRedact = true;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(container.textContent).toContain('canRedact:true');
+  });
+
+  it('re-renders message rows when a display setting flips', () => {
+    const { container, rerender } = renderTimeline();
+    expect(container.textContent).toContain('hideReads:false');
+
+    rendererCtxSettings.hideReads = true;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(container.textContent).toContain('hideReads:true');
+  });
+
+  it('does not re-render rows when nothing a row depends on changed', () => {
+    const { rerender } = renderTimeline();
+    const before = rowRenders.count;
+
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(rowRenders.count).toBe(before);
+  });
+
+});
+
+describe('unread read marker (normal sync)', () => {
+  it('feeds the read marker to timeline processing and clears it on window blur', () => {
+    getRoomUnreadInfoMock.mockReturnValue({
+      readUptoEventId: '$read:example.org',
+      inLiveTimeline: true,
+      scrollTo: false,
+    });
+    windowFocused.current = true;
+    renderTimeline();
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
+
+    windowFocused.current = false;
+    act(() => {
+      document.dispatchEvent(new Event('focusout'));
+    });
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBeUndefined();
+  });
+});
+
+describe('unread read marker (sliding sync)', () => {
+  it('keeps the marker anchored across a limited-window timeline reset', () => {
+    getRoomUnreadInfoMock.mockReturnValue({
+      readUptoEventId: '$read:example.org',
+      inLiveTimeline: true,
+      scrollTo: false,
+    });
+    const { rerender } = renderTimeline();
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
+
+    timelineSync.eventsLength = 0;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    timelineSync.eventsLength = 1;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
+  });
+});
+
+describe('scroll-edge pagination', () => {
+  it('paginates backwards near the top only while a pagination token exists', () => {
+    const { rerender } = renderTimeline();
+
+    timelineSync.canPaginateBack = true;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    act(() => lastOnScroll?.(100));
+    expect(timelineSync.handleTimelinePagination).toHaveBeenCalledWith(true);
+
+    (timelineSync.handleTimelinePagination as ReturnType<typeof vi.fn>).mockClear();
+    timelineSync.canPaginateBack = false;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    act(() => lastOnScroll?.(100));
+    expect(timelineSync.handleTimelinePagination).not.toHaveBeenCalled();
+  });
+
+  it('paginates forwards near the bottom only while the live timeline is not linked', () => {
+    const { rerender } = renderTimeline();
+
+    timelineSync.liveTimelineLinked = false;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    act(() => lastOnScroll?.(0));
+    expect(timelineSync.handleTimelinePagination).toHaveBeenCalledWith(false);
+
+    (timelineSync.handleTimelinePagination as ReturnType<typeof vi.fn>).mockClear();
+    timelineSync.liveTimelineLinked = true;
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    act(() => lastOnScroll?.(0));
+    expect(timelineSync.handleTimelinePagination).not.toHaveBeenCalled();
+  });
+});
+
+describe('backfill scroll anchoring', () => {
+  it('re-pins to the bottom after a backfill completes if the user was at the bottom', async () => {
+    const { rerender } = renderTimeline();
+
+    // Let the mount-time initial scroll settle, then watch backfill only.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+    vListHandle.scrollToIndex.mockClear();
+
+    timelineSync.backwardStatus = 'loading';
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    timelineSync.backwardStatus = 'idle';
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(vListHandle.scrollToIndex).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({ align: 'end' })
+    );
+  });
+
+  it('does not scroll away after a backfill if the user had scrolled up', async () => {
+    const { rerender } = renderTimeline();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+
+    act(() => lastOnScroll?.(0));
+    vListHandle.scrollToIndex.mockClear();
+
+    timelineSync.backwardStatus = 'loading';
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+    timelineSync.backwardStatus = 'idle';
+    rerender(<RoomTimeline room={room} editor={{} as Editor} />);
+
+    expect(vListHandle.scrollToIndex).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/room/RoomTimeline.test.tsx
+++ b/src/app/features/room/RoomTimeline.test.tsx
@@ -1,8 +1,10 @@
+import { EventEmitter } from 'events';
 import { forwardRef, useImperativeHandle, type ReactNode } from 'react';
 import { act, render } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { Editor } from 'slate';
 import type { Room } from '$types/matrix-sdk';
+import { RoomEvent } from '$types/matrix-sdk';
 import type { ProcessedEvent } from '$hooks/timeline/useProcessedTimeline';
 import type * as DomUtils from '$utils/dom';
 import { RoomTimeline } from './RoomTimeline';
@@ -259,10 +261,20 @@ const fireResize = (element: Element) => {
   });
 };
 
+const roomEmitter = new EventEmitter();
 const room = {
   roomId: '!room:example.org',
   getLiveTimeline: () => undefined,
+  on: roomEmitter.on.bind(roomEmitter),
+  removeListener: roomEmitter.removeListener.bind(roomEmitter),
 } as unknown as Room;
+
+const emitReceiptFor = (userId: string) =>
+  roomEmitter.emit(
+    RoomEvent.Receipt,
+    { getContent: () => ({ '$evt:example.org': { 'm.read': { [userId]: { ts: 1 } } } }) },
+    room
+  );
 
 const getContentEl = (container: HTMLElement) => {
   const contentEl = container.querySelector('[data-testid="vlist-content"]');
@@ -371,6 +383,50 @@ describe('RoomTimeline content ResizeObserver', () => {
       scrollTo: false,
       highlight: true,
     });
+  });
+});
+
+describe('remote read receipts', () => {
+  const unread = {
+    readUptoEventId: '$read:example.org',
+    inLiveTimeline: true,
+    scrollTo: false,
+  };
+
+  it('clears the marker when the room is read on another device', () => {
+    getRoomUnreadInfoMock.mockReturnValue(unread);
+    renderTimeline();
+    expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
+
+    getRoomUnreadInfoMock.mockReturnValue(undefined);
+    act(() => {
+      emitReceiptFor('@me:example.org');
+    });
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBeUndefined();
+  });
+
+  it('ignores receipts belonging to other users', () => {
+    getRoomUnreadInfoMock.mockReturnValue(unread);
+    renderTimeline();
+
+    getRoomUnreadInfoMock.mockReturnValue(undefined);
+    act(() => {
+      emitReceiptFor('@bob:example.org');
+    });
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
+  });
+
+  it('keeps the marker when the room is still unread after the receipt', () => {
+    getRoomUnreadInfoMock.mockReturnValue(unread);
+    renderTimeline();
+
+    act(() => {
+      emitReceiptFor('@me:example.org');
+    });
+
+    expect(processedTimelineOptions.current?.readUptoEventId).toBe('$read:example.org');
   });
 });
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -113,6 +113,15 @@ const focusItemAffectsEvent = (focusItem: unknown, eventData: ProcessedEvent | u
 const eventIdAffectsEvent = (eventId: string | null | undefined, eventData?: ProcessedEvent) =>
   typeof eventId === 'string' && eventId === eventData?.id;
 
+const shallowEqual = (prev: Record<string, unknown>, next: Record<string, unknown>) => {
+  if (prev === next) return true;
+  if (Object.keys(prev).length !== Object.keys(next).length) return false;
+  for (const key in prev) {
+    if (prev[key] !== next[key]) return false;
+  }
+  return true;
+};
+
 const MemoizedTimelineItem = memo(
   function MemoizedTimelineItem({
     eventData,
@@ -134,6 +143,7 @@ const MemoizedTimelineItem = memo(
     messageLayout: MessageLayout;
     messageSpacing: MessageSpacing;
     settings: Record<string, unknown>;
+    permissions: Record<string, unknown>;
     renderMatrixEvent: ReturnType<typeof useTimelineEventRenderer>;
     focusItem: unknown;
     editId: string | undefined;
@@ -241,15 +251,9 @@ const MemoizedTimelineItem = memo(
     if (prev.messageSpacing !== next.messageSpacing) return false;
     if (prev.renderMatrixEvent !== next.renderMatrixEvent) return false;
 
-    // Shallow compare settings since it contains primitive toggles
-    const pSettings = prev.settings as Record<string, unknown>;
-    const nSettings = next.settings as Record<string, unknown>;
-    if (pSettings !== nSettings) {
-      if (Object.keys(pSettings).length !== Object.keys(nSettings).length) return false;
-      for (const key in pSettings) {
-        if (pSettings[key] !== nSettings[key]) return false;
-      }
-    }
+    // Shallow compare settings and permissions since both hold primitive toggles
+    if (!shallowEqual(prev.settings, next.settings)) return false;
+    if (!shallowEqual(prev.permissions, next.permissions)) return false;
 
     if (
       prev.focusItem !== next.focusItem &&
@@ -926,6 +930,10 @@ export function RoomTimeline({
     },
   });
 
+  // renderMatrixEvent keeps a stable identity and reads these through a ref, so
+  // the row memo has to compare them itself to notice a power-level change.
+  const rowPermissions = { canRedact, canDeleteOwn, canSendReaction, canPinEvent };
+
   const renderMatrixEvent = useTimelineEventRenderer({
     room,
     mx,
@@ -935,12 +943,7 @@ export function RoomTimeline({
     imagePackRooms,
     settings,
     state: { focusItem: timelineSync.focusItem, editId, activeReplyId, openThreadId },
-    permissions: {
-      canRedact,
-      canDeleteOwn,
-      canSendReaction,
-      canPinEvent,
-    },
+    permissions: rowPermissions,
     callbacks: {
       onUserClick: actions.handleUserClick,
       onUsernameClick: actions.handleUsernameClick,
@@ -1255,6 +1258,7 @@ export function RoomTimeline({
                 messageLayout={messageLayout}
                 messageSpacing={messageSpacing}
                 settings={settings as unknown as Record<string, unknown>}
+                permissions={rowPermissions}
                 renderMatrixEvent={renderMatrixEvent}
                 focusItem={timelineSync.focusItem}
                 editId={editId}

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1044,8 +1044,14 @@ export function RoomTimeline({
     [notifyScroll, syncAtBottom]
   );
 
+  // A failed backfill keeps its pagination token, so the placeholder condition
+  // would otherwise hold forever and never reach the error and its Retry.
+  const showEmptyPaginationError =
+    timelineSync.eventsLength === 0 && timelineSync.backwardStatus === 'error';
+
   const showLoadingPlaceholders =
     timelineSync.eventsLength === 0 &&
+    !showEmptyPaginationError &&
     (!isReady || timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading');
 
   let backPaginationJSX: ReactNode | undefined;
@@ -1116,11 +1122,10 @@ export function RoomTimeline({
       ? { top: `calc(${config.space.S400} + ${toRem(52)})` }
       : undefined;
 
-  const vListItemCount =
-    timelineSync.eventsLength === 0 &&
-    (!isReady || timelineSync.canPaginateBack || timelineSync.backwardStatus === 'loading')
-      ? 3
-      : timelineSync.eventsLength;
+  let vListItemCount = timelineSync.eventsLength;
+  if (showLoadingPlaceholders) vListItemCount = 3;
+  // One row so the error and its Retry have somewhere to render.
+  else if (showEmptyPaginationError) vListItemCount = 1;
   const vListIndices = useMemo(() => {
     // Keep the cache-busting timeline identity explicit for exhaustive-deps.
     void timelineSync.timeline;
@@ -1251,7 +1256,11 @@ export function RoomTimeline({
           minHeight: 0,
           overflow: 'hidden',
           position: 'relative',
-          opacity: !hideTimelineForRoomState && (isReady || showLoadingPlaceholders) ? 1 : 0,
+          opacity:
+            !hideTimelineForRoomState &&
+            (isReady || showLoadingPlaceholders || showEmptyPaginationError)
+              ? 1
+              : 0,
         }}
       >
         <TimelineScrollingProvider value={isTimelineScrolling}>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -107,7 +107,8 @@ const getDayDividerText = (ts: number) => {
 const focusItemAffectsEvent = (focusItem: unknown, eventData: ProcessedEvent | undefined) => {
   if (!focusItem || typeof focusItem !== 'object' || !eventData) return false;
   const index = 'index' in focusItem ? focusItem.index : undefined;
-  return typeof index === 'number' && index === eventData.itemIndex;
+  // itemIndex -1 marks a merged relation row, which is never a focus target.
+  return typeof index === 'number' && index >= 0 && index === eventData.itemIndex;
 };
 
 const eventIdAffectsEvent = (eventId: string | null | undefined, eventData?: ProcessedEvent) =>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -13,7 +13,7 @@ import {
 import type { Editor } from 'slate';
 import { useAtomValue, useSetAtom, useStore } from 'jotai';
 import type { Room, MatrixEvent, EventTimelineSet } from '$types/matrix-sdk';
-import { Direction, EventTimeline, EventType } from '$types/matrix-sdk';
+import { Direction, EventTimeline, EventType, RoomEvent } from '$types/matrix-sdk';
 import classNames from 'classnames';
 import type { VListHandle } from 'virtua';
 import { VList } from 'virtua';
@@ -23,6 +23,7 @@ import { ArrowDown, ChatTeardropDots, Checks, chipIcon } from '$components/icons
 import { MessageBase, CompactPlaceholder, DefaultPlaceholder } from '$components/message';
 import { RoomIntro } from '$components/room-intro';
 import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useMatrixEvent } from '$hooks/useMatrixEvent';
 import { useAlive } from '$hooks/useAlive';
 import { useMessageEdit } from '$hooks/useMessageEdit';
 import { useDocumentFocusChange } from '$hooks/useDocumentFocusChange';
@@ -986,6 +987,28 @@ export function RoomTimeline({
         }
       },
       [tryAutoMarkAsRead, atBottomState, timelineSync.liveTimelineLinked, setUnreadInfo]
+    )
+  );
+
+  // Reading elsewhere clears the room list badge, so clear the in-room marker too.
+  useMatrixEvent(
+    room,
+    RoomEvent.Receipt,
+    useCallback(
+      (mEvent: MatrixEvent) => {
+        const myUserId = mx.getUserId();
+        if (!myUserId) return;
+        const content =
+          mEvent.getContent<Record<string, Record<string, Record<string, unknown>>>>();
+        const isMyReceipt = Object.values(content).some((byType) =>
+          Object.values(byType ?? {}).some((byUser) => myUserId in (byUser ?? {}))
+        );
+        // Re-anchoring on a partial remote read would move the divider mid-read.
+        if (!isMyReceipt || getRoomUnreadInfo(room)) return;
+        readUptoEventIdRef.current = undefined;
+        setUnreadInfo(undefined);
+      },
+      [mx, room]
     )
   );
 

--- a/src/app/hooks/timeline/useProcessedTimeline.test.tsx
+++ b/src/app/hooks/timeline/useProcessedTimeline.test.tsx
@@ -386,6 +386,38 @@ describe('useProcessedTimeline new-messages divider', () => {
 
     expect(dividerIds(processed)).toEqual([]);
   });
+
+  it('renders the divider on a filtered anchor with show-hidden-events enabled', () => {
+    const events = [
+      createEvent({ id: '$a' }),
+      createMembership('$member'),
+      createEvent({ id: '$b' }),
+      createReaction('$reaction', '$a'),
+    ];
+    const { result } = renderHook(() =>
+      useProcessedTimeline({
+        items: events.map((_, index) => index),
+        linkedTimelines: [createTimeline(events)],
+        ignoredUsersSet: new Set(),
+        // Reaction/edit rows merge into their target, which reprocesses every
+        // row through a second divider pass.
+        hiddenEvents: {
+          ...hiddenEvents,
+          showHiddenEvents: true,
+          hiddenEventReactions: true,
+          hiddenEventEdits: true,
+        },
+        mxUserId: MY_USER,
+        readUptoEventId: '$member',
+        hideMembershipEvents: true,
+        hideNickAvatarEvents: true,
+        isReadOnly: false,
+        hideMemberInReadOnly: false,
+      })
+    );
+
+    expect(dividerIds(result.current)).toEqual(['$b']);
+  });
 });
 
 describe('useProcessedTimeline append-only fast path', () => {

--- a/src/app/hooks/timeline/useProcessedTimeline.test.tsx
+++ b/src/app/hooks/timeline/useProcessedTimeline.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { faker } from '@faker-js/faker';
 import { M_POLL_RESPONSE } from 'matrix-js-sdk';
 import type { EventTimeline, EventTimelineSet, MatrixEvent } from '$types/matrix-sdk';
 import { EventType, RelationType } from '$types/matrix-sdk';
@@ -467,5 +468,321 @@ describe('getProcessedRowIndexForRawTimelineIndex', () => {
       rowIndex: 1,
       focusRawIndex: 2,
     });
+  });
+});
+
+const rowSignature = (rows: ProcessedEvent[]) =>
+  rows.map((r) => ({
+    id: r.id,
+    itemIndex: r.itemIndex,
+    collapsed: r.collapsed,
+    willRenderNewDivider: r.willRenderNewDivider,
+    willRenderDayDivider: r.willRenderDayDivider,
+  }));
+
+describe('getProcessedRowIndexForRawTimelineIndex (fuzz)', () => {
+  it('matches a filter-based reference over random row maps', () => {
+    for (let seed = 1; seed <= 500; seed += 1) {
+      faker.seed(seed);
+      let nextIndex = 0;
+      const rows = Array.from(
+        { length: faker.number.int({ min: 0, max: 15 }) },
+        (): ProcessedEvent => {
+          if (faker.datatype.boolean({ probability: 0.25 }))
+            return { itemIndex: -1 } as unknown as ProcessedEvent;
+          // Real timelines assign each non-sentinel raw index exactly once.
+          nextIndex += faker.number.int({ min: 1, max: 3 });
+          return { itemIndex: nextIndex } as unknown as ProcessedEvent;
+        }
+      );
+      const start = faker.number.int({ min: -1, max: nextIndex + 2 });
+
+      // Reference: item indices are non-decreasing, so the addressable target
+      // is the last row with a non-sentinel index not beyond the raw index.
+      const candidates = rows
+        .map((row, rowIndex) => ({ rowIndex, itemIndex: row.itemIndex }))
+        .filter((c) => c.itemIndex >= 0 && c.itemIndex <= start);
+      const last = candidates.at(-1);
+      const expected = last
+        ? { rowIndex: last.rowIndex, focusRawIndex: last.itemIndex }
+        : undefined;
+
+      expect(getProcessedRowIndexForRawTimelineIndex(rows, start), `seed ${seed}`).toEqual(
+        expected
+      );
+    }
+  });
+});
+
+describe('append-only fast path vs full reprocess (fuzz)', () => {
+  it('incremental live appends produce the same rows as a full reprocess', () => {
+    for (let seed = 1; seed <= 50; seed += 1) {
+      faker.seed(seed * 7919);
+      const senders = [MY_USER, OTHER_USER, '@carol:test'];
+
+      // Occasional multi-day jumps so day-divider boundaries get crossed.
+      const total = faker.number.int({ min: 20, max: 49 });
+      let ts = 1_000_000_000_000;
+      const events: MatrixEvent[] = [];
+      for (let i = 0; i < total; i += 1) {
+        ts += faker.datatype.boolean({ probability: 0.08 })
+          ? faker.number.int({ min: 1, max: 2 }) * 86_400_000
+          : faker.number.int({ min: 0, max: 599_999 });
+        const id = `$seed${seed}-e${i}`;
+        if (faker.datatype.boolean({ probability: 0.1 })) {
+          events.push(
+            createEvent({
+              id,
+              type: EventType.RoomMember as string,
+              content: { membership: 'join' },
+              ts,
+            })
+          );
+        } else {
+          events.push(
+            createEvent({
+              id,
+              type: faker.datatype.boolean({ probability: 0.11 })
+                ? (EventType.Sticker as string)
+                : undefined,
+              sender: faker.helpers.arrayElement(senders),
+              ts,
+              content: { msgtype: 'm.text', body: `msg ${i}` },
+            })
+          );
+        }
+      }
+      // Anchor the read marker somewhere arbitrary — possibly on a filtered event.
+      const readUptoEventId = faker.datatype.boolean({ probability: 0.4 })
+        ? (faker.helpers.arrayElement(events).getId() ?? undefined)
+        : undefined;
+
+      const live: MatrixEvent[] = [];
+      const timeline = createTimeline(live);
+      const ignoredUsersSet = new Set<string>();
+      const { result, rerender } = renderHook(
+        ({ count }: { count: number }) =>
+          useProcessedTimeline({
+            items: Array.from({ length: count }, (_, index) => index),
+            linkedTimelines: [timeline],
+            ignoredUsersSet,
+            hiddenEvents,
+            mxUserId: MY_USER,
+            readUptoEventId,
+            hideMembershipEvents: true,
+            hideNickAvatarEvents: true,
+            isReadOnly: false,
+            hideMemberInReadOnly: false,
+          }),
+        { initialProps: { count: 0 } }
+      );
+
+      let cursor = 0;
+      while (cursor < events.length) {
+        const batch = faker.number.int({ min: 1, max: 5 });
+        cursor = Math.min(cursor + batch, events.length);
+        live.splice(live.length, 0, ...events.slice(live.length, cursor));
+        rerender({ count: cursor });
+      }
+
+      // Oracle: a fresh hook instance has no cache, so it always fully reprocesses.
+      const fresh = processTimeline(events, readUptoEventId);
+
+      expect(rowSignature(result.current), `seed ${seed}`).toEqual(rowSignature(fresh));
+    }
+  });
+
+  it('out-of-order (late-delivered) appends force a full reprocess with identical output', () => {
+    for (let seed = 1; seed <= 50; seed += 1) {
+      faker.seed(seed * 104_729);
+      const senders = [MY_USER, OTHER_USER, '@carol:test'];
+
+      const total = faker.number.int({ min: 10, max: 25 });
+      let ts = 1_000_000_000_000;
+      const events: MatrixEvent[] = [];
+      for (let i = 0; i < total; i += 1) {
+        ts += faker.number.int({ min: 0, max: 599_999 });
+        events.push(
+          createEvent({
+            id: `$late${seed}-e${i}`,
+            sender: faker.helpers.arrayElement(senders),
+            ts,
+            content: { msgtype: 'm.text', body: `msg ${i}` },
+          })
+        );
+      }
+
+      const live = [...events];
+      const timeline = createTimeline(live);
+      const ignoredUsersSet = new Set<string>();
+      const { result, rerender } = renderHook(
+        ({ count }: { count: number }) =>
+          useProcessedTimeline({
+            items: Array.from({ length: count }, (_, index) => index),
+            linkedTimelines: [timeline],
+            ignoredUsersSet,
+            hiddenEvents,
+            mxUserId: MY_USER,
+            readUptoEventId: undefined,
+            hideMembershipEvents: true,
+            hideNickAvatarEvents: true,
+            isReadOnly: false,
+            hideMemberInReadOnly: false,
+          }),
+        { initialProps: { count: live.length } }
+      );
+
+      // A late delivery: appended to the array, but timestamped mid-stream.
+      const insertionPoint = faker.number.int({ min: 0, max: events.length - 1 });
+      live.push(
+        createEvent({
+          id: `$late${seed}-straggler`,
+          sender: faker.helpers.arrayElement(senders),
+          ts: events[insertionPoint]?.getTs() ?? ts,
+          content: { msgtype: 'm.text', body: 'late' },
+        })
+      );
+      rerender({ count: live.length });
+
+      const fresh = processTimeline(live, undefined);
+      expect(rowSignature(result.current), `seed ${seed}`).toEqual(rowSignature(fresh));
+    }
+  });
+
+  it('spec-shaped relations and redactions in the stream force reprocessing, output still matches oracle', () => {
+    for (let seed = 1; seed <= 50; seed += 1) {
+      faker.seed(seed * 31_337);
+      const senders = [MY_USER, OTHER_USER, '@carol:test'];
+
+      const baseMsg = (id: string, ts: number): MatrixEvent =>
+        createEvent({
+          id,
+          sender: faker.helpers.arrayElement(senders),
+          ts,
+          content: { msgtype: 'm.text', body: `msg ${id}` },
+        });
+
+      const total = faker.number.int({ min: 15, max: 30 });
+      let ts = 1_000_000_000_000;
+      const all: MatrixEvent[] = [];
+      for (let i = 0; i < total; i += 1) {
+        ts += faker.number.int({ min: 0, max: 599_999 });
+        const id = `$spec${seed}-e${i}`;
+        all.push(baseMsg(id, ts));
+        if (faker.datatype.boolean({ probability: 0.3 }) && i > 1) {
+          const target = faker.helpers.arrayElement(all.slice(0, -1)).getId() ?? id;
+          const kind = faker.number.int({ min: 0, max: 3 });
+          if (kind === 0) all.push(createReaction(`$spec${seed}-r${i}`, target));
+          else if (kind === 1) all.push(createEdit(`$spec${seed}-r${i}`, target));
+          else if (kind === 2) all.push(createRedaction(`$spec${seed}-r${i}`, target));
+          else all.push(createThreadReply(`$spec${seed}-r${i}`, target));
+        }
+      }
+
+      const live: MatrixEvent[] = [];
+      const timeline = createTimeline(live);
+      const ignoredUsersSet = new Set<string>();
+      const { result, rerender } = renderHook(
+        ({ count }: { count: number }) =>
+          useProcessedTimeline({
+            items: Array.from({ length: count }, (_, index) => index),
+            linkedTimelines: [timeline],
+            ignoredUsersSet,
+            hiddenEvents,
+            mxUserId: MY_USER,
+            readUptoEventId: undefined,
+            hideMembershipEvents: true,
+            hideNickAvatarEvents: true,
+            isReadOnly: false,
+            hideMemberInReadOnly: false,
+          }),
+        { initialProps: { count: 0 } }
+      );
+
+      let cursor = 0;
+      while (cursor < all.length) {
+        const batch = faker.number.int({ min: 1, max: 5 });
+        cursor = Math.min(cursor + batch, all.length);
+        live.splice(live.length, 0, ...all.slice(live.length, cursor));
+        rerender({ count: cursor });
+      }
+
+      const fresh = processTimeline(all, undefined);
+      expect(rowSignature(result.current), `seed ${seed}`).toEqual(rowSignature(fresh));
+    }
+  });
+
+  it('sliding-sync limited windows replace the stream mid-run and stay consistent', () => {
+    for (let seed = 1; seed <= 50; seed += 1) {
+      faker.seed(seed * 97_403);
+      const senders = [MY_USER, OTHER_USER, '@carol:test'];
+
+      const total = faker.number.int({ min: 20, max: 40 });
+      let ts = 1_000_000_000_000;
+      const all: MatrixEvent[] = [];
+      for (let i = 0; i < total; i += 1) {
+        ts += faker.number.int({ min: 0, max: 599_999 });
+        all.push(
+          createEvent({
+            id: `$slide${seed}-e${i}`,
+            sender: faker.helpers.arrayElement(senders),
+            ts,
+            content: { msgtype: 'm.text', body: `msg ${i}` },
+          })
+        );
+      }
+
+      const live: MatrixEvent[] = [];
+      const timeline = createTimeline(live);
+      const ignoredUsersSet = new Set<string>();
+      const { result, rerender } = renderHook(
+        ({ count }: { count: number }) =>
+          useProcessedTimeline({
+            items: Array.from({ length: count }, (_, index) => index),
+            linkedTimelines: [timeline],
+            ignoredUsersSet,
+            hiddenEvents,
+            mxUserId: MY_USER,
+            readUptoEventId: undefined,
+            hideMembershipEvents: true,
+            hideNickAvatarEvents: true,
+            isReadOnly: false,
+            hideMemberInReadOnly: false,
+          }),
+        { initialProps: { count: 0 } }
+      );
+
+      let cursor = 0;
+      while (cursor < all.length) {
+        const batch = faker.number.int({ min: 1, max: 5 });
+        cursor = Math.min(cursor + batch, all.length);
+        live.splice(live.length, 0, ...all.slice(live.length, cursor));
+
+        // A limited window: the sdk dropped older rows from the live timeline.
+        if (cursor < all.length && faker.datatype.boolean({ probability: 0.25 })) {
+          const drop = faker.number.int({ min: 1, max: Math.max(1, live.length - 1) });
+          const kept = all.slice(drop, cursor);
+          // A reset re-instantiates MatrixEvent objects half of the time.
+          live.splice(
+            0,
+            live.length,
+            ...(faker.datatype.boolean()
+              ? kept.map((e) =>
+                  createEvent({
+                    id: e.getId() ?? '',
+                    sender: e.getSender() ?? '',
+                    ts: e.getTs(),
+                    content: e.getContent(),
+                  })
+                )
+              : kept)
+          );
+        }
+        rerender({ count: live.length });
+      }
+
+      const fresh = processTimeline(live, undefined);
+      expect(rowSignature(result.current), `seed ${seed}`).toEqual(rowSignature(fresh));
+    }
   });
 });

--- a/src/app/hooks/timeline/useProcessedTimeline.ts
+++ b/src/app/hooks/timeline/useProcessedTimeline.ts
@@ -124,7 +124,10 @@ const flattenTimelineEvents = (linkedTimelines: EventTimeline[]): TimelineEventE
 const computeCollapseAndDividers = (
   drafts: ProcessedEventDraft[],
   mxUserId: string | null,
-  readUptoEventId: string | undefined
+  readUptoEventId: string | undefined,
+  // Row that already carries the divider. Drafts hold only rendered rows, so a
+  // receipt anchored on a filtered event is unresolvable from `drafts` alone.
+  carriedDividerId: string | undefined
 ): ProcessedEvent[] => {
   let prevEvent: MatrixEvent | undefined;
   let isPrevRendered = false;
@@ -137,7 +140,7 @@ const computeCollapseAndDividers = (
 
     if (!newDivider && readUptoEventId) {
       const prevId = prevEvent ? prevEvent.getId() : undefined;
-      newDivider = prevId === readUptoEventId;
+      newDivider = prevId === readUptoEventId || draft.id === carriedDividerId;
     }
 
     if (!dayDivider) {
@@ -298,7 +301,12 @@ const mergeRelationReactions = (
 
   const mergedDrafts = mergeDraftsAndExtras(baseDrafts, allExtras);
 
-  return computeCollapseAndDividers(mergedDrafts, mxUserId, readUptoEventId);
+  return computeCollapseAndDividers(
+    mergedDrafts,
+    mxUserId,
+    readUptoEventId,
+    result.find((event) => event.willRenderNewDivider)?.id
+  );
 };
 
 const mergeRelationEdits = (
@@ -347,7 +355,12 @@ const mergeRelationEdits = (
 
   const mergedDrafts = mergeDraftsAndExtras(baseDrafts, allExtras);
 
-  return computeCollapseAndDividers(mergedDrafts, mxUserId, readUptoEventId);
+  return computeCollapseAndDividers(
+    mergedDrafts,
+    mxUserId,
+    readUptoEventId,
+    result.find((event) => event.willRenderNewDivider)?.id
+  );
 };
 
 type TimelineProcessingState = {

--- a/src/app/hooks/timeline/useTimelineEventRenderer.test.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.test.tsx
@@ -718,6 +718,9 @@ const branches: BranchEntry[] = [
   },
 ];
 
+const highlightOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="message"]')?.getAttribute('data-highlight');
+
 describe('useTimelineEventRenderer', () => {
   describe.each(branches)('$name', ({ isStateEvent, createEvent: makeEvent }) => {
     it('renders correctly', () => {
@@ -899,6 +902,71 @@ describe('useTimelineEventRenderer', () => {
       const { container } = renderEventWithOverrides(editEvent, false, {});
       expect(container).not.toBeNull();
       expect(container.innerHTML).toMatchSnapshot();
+    });
+  });
+
+  describe('focusItem highlight', () => {
+    function renderMessageAtItem(
+      mEvent: MatrixEvent,
+      item: number,
+      focusItem?: { index: number; highlight: boolean; scrollTo: boolean }
+    ) {
+      const opts = { ...rendererOpts, state: { ...rendererOpts.state, focusItem } };
+      const { result } = renderHook(() => useTimelineEventRenderer(opts));
+      const node = result.current(
+        mEvent.getType() ?? 'UNKNOWN',
+        false,
+        mEvent.getId() ?? 'null',
+        mEvent,
+        item,
+        timelineSet,
+        false
+      );
+      return render(node as any);
+    }
+
+    const msgEvent = (id: string) =>
+      createEvent({
+        id,
+        type: EventType.RoomMessage,
+        content: { msgtype: 'm.text', body: 'hello' },
+        replyEventId: undefined,
+      });
+
+    it('highlights the focused row for a regular raw timeline index', () => {
+      const { container } = renderMessageAtItem(msgEvent('$a:example.com'), 3, {
+        index: 3,
+        highlight: true,
+        scrollTo: false,
+      });
+      expect(highlightOf(container)).toBe('true');
+    });
+
+    it('does not highlight a different row', () => {
+      const { container } = renderMessageAtItem(msgEvent('$a:example.com'), 4, {
+        index: 3,
+        highlight: true,
+        scrollTo: false,
+      });
+      expect(highlightOf(container)).toBe('false');
+    });
+
+    it('never highlights merged relation rows, which all carry itemIndex -1', () => {
+      // ThreadDrawer derives focusItem.index from the row's itemIndex, and every
+      // merged extra shares the -1 sentinel, so -1 must highlight nothing.
+      const jumpTarget = renderMessageAtItem(msgEvent('$edit-1:example.com'), -1, {
+        index: -1,
+        highlight: true,
+        scrollTo: false,
+      });
+      expect(highlightOf(jumpTarget.container)).toBe('false');
+
+      const otherExtra = renderMessageAtItem(msgEvent('$reaction-2:example.com'), -1, {
+        index: -1,
+        highlight: true,
+        scrollTo: false,
+      });
+      expect(highlightOf(otherExtra.container)).toBe('false');
     });
   });
 });

--- a/src/app/hooks/timeline/useTimelineEventRenderer.tsx
+++ b/src/app/hooks/timeline/useTimelineEventRenderer.tsx
@@ -291,6 +291,12 @@ function ThreadReplyChip({
     </Chip>
   );
 }
+// Merged relation rows share the itemIndex -1 sentinel, so -1 targets nothing.
+const isFocusHighlighted = (
+  focusItem: { index: number; highlight: boolean } | undefined,
+  item: number
+) => item >= 0 && focusItem?.index === item && focusItem.highlight;
+
 export interface TimelineEventRendererOptions {
   room: Room;
   mx: MatrixClient;
@@ -413,7 +419,7 @@ export function useTimelineEventRenderer({
     timelineSet: EventTimelineSet,
     markedVariant: 'suppress' | 'plain' = 'suppress'
   ) {
-    const highlighted = focusItem?.index === item && focusItem.highlight;
+    const highlighted = isFocusHighlighted(focusItem, item);
     const marked =
       markedVariant === 'plain'
         ? activeReplyId === mEventId
@@ -442,7 +448,7 @@ export function useTimelineEventRenderer({
     item: number,
     timelineSet: EventTimelineSet
   ) {
-    const highlighted = focusItem?.index === item && focusItem.highlight;
+    const highlighted = isFocusHighlighted(focusItem, item);
     const marked = activeReplyId === mEventId && !suppressMark;
     const senderId = mEvent.getSender() ?? '';
     const senderName = getSenderDisplayName(senderId);
@@ -510,7 +516,7 @@ export function useTimelineEventRenderer({
   ) => {
     if (!hiddenEventEdits) return null;
 
-    const highlighted = focusItem?.index === item && focusItem.highlight;
+    const highlighted = isFocusHighlighted(focusItem, item);
     const marked = activeReplyId === mEventId && suppressMark !== true;
     const senderId = mEvent.getSender() ?? '';
     const senderName = getSenderDisplayName(senderId);

--- a/src/app/hooks/timeline/useTimelineSync.test.tsx
+++ b/src/app/hooks/timeline/useTimelineSync.test.tsx
@@ -1,15 +1,18 @@
 import { EventEmitter } from 'events';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { faker } from '@faker-js/faker';
 import type { Room } from '$types/matrix-sdk';
-import { RoomEvent } from '$types/matrix-sdk';
+import { Direction, RoomEvent } from '$types/matrix-sdk';
 import { countVisibleAmongNewest, useTimelineSync } from './useTimelineSync';
 import { getRoomUnreadInfo } from '$utils/timeline';
 import type * as TimelineUtils from '$utils/timeline';
 
 vi.mock('@sentry/react', () => ({
   default: {},
-  startSpan: vi.fn<(_options: unknown, fn: () => Promise<unknown>) => Promise<unknown>>(),
+  startSpan: vi.fn<(options: unknown, fn: () => Promise<unknown>) => Promise<unknown>>(
+    (_options, fn) => fn()
+  ),
   addBreadcrumb: vi.fn<() => void>(),
   captureMessage: vi.fn<(msg: string) => void>(),
   metrics: {
@@ -94,6 +97,41 @@ function createRoom(
   return { room, timelineSet, events, timeline };
 }
 
+function createPaginableRoom(roomId = '!room:test') {
+  const events: unknown[] = [{}];
+  const timeline = {
+    getEvents: () => events,
+    getNeighbouringTimeline: () => undefined,
+    getPaginationToken: () => 'tok' as string | undefined,
+    getTimelineSet: () => undefined,
+    getRoomId: () => roomId,
+  };
+  const timelineSet = new EventEmitter() as FakeTimelineSet;
+  timelineSet.getLiveTimeline = () => timeline as unknown as FakeTimeline;
+  timelineSet.getTimelineForEvent = () => undefined;
+
+  const roomEmitter = new EventEmitter();
+  const room = {
+    on: roomEmitter.on.bind(roomEmitter),
+    removeListener: roomEmitter.removeListener.bind(roomEmitter),
+    emit: roomEmitter.emit.bind(roomEmitter),
+    roomId,
+    getUnfilteredTimelineSet: () => timelineSet as never,
+    getEventReadUpTo: () => null,
+    getThread: () => null,
+    getLiveTimeline: () => timeline,
+    getUnreadNotificationCount: () => 0,
+    getMyMembership: () => 'join',
+    getMember: () => null,
+    hasEncryptionStateEvent: () => false,
+    client: {
+      getUserId: () => '@alice:test',
+    },
+  } as unknown as FakeRoom;
+
+  return { room, timelineSet, events };
+}
+
 function makeEvent(sender: string, roomId: string) {
   return {
     threadRootId: undefined,
@@ -160,6 +198,26 @@ describe('countVisibleAmongNewest', () => {
 
   it('handles empty timelines', () => {
     expect(count([], 5, true, ['a'])).toBe(0);
+  });
+
+  it('fuzz: matches a naive flatten-then-slice reference over random inputs', () => {
+    for (let seed = 1; seed <= 200; seed += 1) {
+      faker.seed(seed);
+      const timelines = Array.from({ length: faker.number.int({ min: 1, max: 4 }) }, (_t, t) =>
+        makeTimeline(
+          Array.from({ length: faker.number.int({ min: 0, max: 5 }) }, (_e, e) => `t${t}e${e}`)
+        )
+      );
+      const allIds = timelines.flatMap((t) => t.getEvents().map((ev: { id: string }) => ev.id));
+      const visible = allIds.filter(() => faker.datatype.boolean({ probability: 0.5 }));
+      const n = faker.number.int({ min: 0, max: allIds.length + 2 });
+      const backwards = faker.datatype.boolean();
+
+      const ordered = backwards ? allIds : allIds.toReversed();
+      const expected = ordered.slice(0, n).filter((id) => visible.includes(id)).length;
+
+      expect(count(timelines, n, backwards, visible), `seed ${seed}`).toBe(expected);
+    }
   });
 });
 
@@ -506,4 +564,650 @@ describe('useTimelineSync', () => {
       expect(scrollToBottom).not.toHaveBeenCalled();
     });
   });
+});
+
+const syncOpts = (
+  room: FakeRoom,
+  paginateEventTimeline: ReturnType<typeof vi.fn>,
+  isEventVisible?: () => boolean
+) => ({
+  room: room as Room,
+  mx: { getUserId: () => '@alice:test', paginateEventTimeline } as never,
+  isAtBottom: true,
+  isAtBottomRef: { current: true },
+  scrollToBottom: vi.fn<() => void>(),
+  unreadInfo: undefined,
+  setUnreadInfo: vi.fn<() => void>(),
+  hideReadsRef: { current: false },
+  readUptoEventIdRef: { current: undefined },
+  isEventVisible,
+});
+
+describe('back-pagination', () => {
+  describe('normal sync', () => {
+    it('auto-continues over hidden-only pages, then settles back to idle', async () => {
+      const { room, events } = createPaginableRoom();
+      const paginateEventTimeline = vi.fn<() => Promise<boolean>>(async () => {
+        events.push({});
+        return true;
+      });
+      const { result } = renderHook(() =>
+        useTimelineSync(syncOpts(room, paginateEventTimeline, () => false))
+      );
+
+      await act(async () => {
+        await result.current.handleTimelinePagination(true);
+      });
+
+      // Nothing rendered, so the loader keeps going up to MAX_AUTO_CONTINUATIONS.
+      expect(paginateEventTimeline).toHaveBeenCalledTimes(4);
+      expect(result.current.backwardStatus).toBe('idle');
+    });
+
+    it('keeps paginating while a page renders fewer than 5 events, and stops at 5', async () => {
+      const thinPage = createPaginableRoom();
+      const thinPaginate = vi.fn<() => Promise<boolean>>(async () => {
+        thinPage.events.push({}, {}, {}, {});
+        return true;
+      });
+      const thin = renderHook(() =>
+        useTimelineSync(syncOpts(thinPage.room, thinPaginate, () => true))
+      );
+      await act(async () => {
+        await thin.result.current.handleTimelinePagination(true);
+      });
+      expect(thinPaginate).toHaveBeenCalledTimes(4);
+
+      const fullPage = createPaginableRoom();
+      const fullPaginate = vi.fn<() => Promise<boolean>>(async () => {
+        fullPage.events.push({}, {}, {}, {}, {});
+        return true;
+      });
+      const full = renderHook(() =>
+        useTimelineSync(syncOpts(fullPage.room, fullPaginate, () => true))
+      );
+      await act(async () => {
+        await full.result.current.handleTimelinePagination(true);
+      });
+      expect(fullPaginate).toHaveBeenCalledTimes(1);
+    });
+
+    it('never reports idle before the fetched page is committed', async () => {
+      // The sdk puts a fetched page in a fresh EventTimeline linked behind the
+      // live one, so the new events only become visible once setTimeline commits.
+      const { room, timelineSet } = createRoom();
+      const live = timelineSet.getLiveTimeline() as unknown as {
+        getEvents: () => unknown[];
+        getPaginationToken: (d?: Direction) => string | undefined;
+        getNeighbouringTimeline: (d: Direction) => unknown;
+        getTimelineSet: () => unknown;
+      };
+      live.getPaginationToken = () => 'tok';
+      live.getTimelineSet = () => timelineSet;
+      let older: unknown;
+      live.getNeighbouringTimeline = (direction: Direction) =>
+        direction === Direction.Backward ? older : undefined;
+
+      const paginateEventTimeline = vi.fn<() => Promise<boolean>>(async () => {
+        live.getPaginationToken = () => undefined;
+        older = {
+          getEvents: () => [{}, {}, {}, {}, {}],
+          getPaginationToken: () => undefined,
+          getRoomId: () => room.roomId,
+          getTimelineSet: () => timelineSet,
+          getNeighbouringTimeline: (direction: Direction) =>
+            direction === Direction.Forward ? live : undefined,
+        };
+        return true;
+      });
+
+      const commits: { eventsLength: number; backwardStatus: string }[] = [];
+      const { result } = renderHook(() => {
+        const sync = useTimelineSync(syncOpts(room as FakeRoom, paginateEventTimeline, () => true));
+        commits.push({
+          eventsLength: sync.eventsLength,
+          backwardStatus: sync.backwardStatus,
+        });
+        return sync;
+      });
+
+      const lengthBefore = commits[0]!.eventsLength;
+      await act(async () => {
+        await result.current.handleTimelinePagination(true);
+      });
+
+      // RoomTimeline releases the virtua scroll shift on the loading -> idle edge,
+      // so idle without the rows would jump a scrolled-up user.
+      const afterLoading = commits.slice(
+        commits.findIndex((commit) => commit.backwardStatus === 'loading')
+      );
+      expect(afterLoading.length).toBeGreaterThan(0);
+      expect(
+        afterLoading.filter(
+          (commit) => commit.backwardStatus === 'idle' && commit.eventsLength === lengthBefore
+        )
+      ).toEqual([]);
+    });
+
+    it('ignores overlapping pagination requests while one is in flight', async () => {
+      const { room } = createPaginableRoom();
+      const paginateEventTimeline = vi.fn<() => Promise<boolean>>(async () => false);
+      const { result } = renderHook(() =>
+        useTimelineSync(syncOpts(room, paginateEventTimeline, () => false))
+      );
+
+      await act(async () => {
+        await Promise.all([
+          result.current.handleTimelinePagination(true),
+          result.current.handleTimelinePagination(true),
+        ]);
+      });
+
+      // The page fetched nothing new, so no continuation either.
+      expect(paginateEventTimeline).toHaveBeenCalledTimes(1);
+      expect(result.current.backwardStatus).toBe('idle');
+    });
+
+    it('marks a failed backfill as error and recovers on retry', async () => {
+      const { room, events } = createPaginableRoom();
+      const paginateEventTimeline = vi
+        .fn<() => Promise<boolean>>()
+        .mockRejectedValueOnce(new Error('homeserver unavailable'))
+        .mockImplementation(async () => {
+          // A fully visible page: 5 rendered events, no continuation needed.
+          events.push({}, {}, {}, {}, {});
+          return true;
+        });
+      const { result } = renderHook(() =>
+        useTimelineSync(syncOpts(room, paginateEventTimeline, () => true))
+      );
+
+      await act(async () => {
+        await result.current.handleTimelinePagination(true);
+      });
+      expect(result.current.backwardStatus).toBe('error');
+
+      await act(async () => {
+        await result.current.handleTimelinePagination(true);
+      });
+      expect(result.current.backwardStatus).toBe('idle');
+      expect(paginateEventTimeline).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('sliding sync', () => {
+    it('settles to idle when a TimelineReset lands mid-pagination', async () => {
+      const { room, timelineSet } = createPaginableRoom();
+      let resolvePaginate: ((value: boolean) => void) | undefined;
+      const paginateEventTimeline = vi.fn<() => Promise<boolean>>(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolvePaginate = resolve;
+          })
+      );
+      const { result } = renderHook(() =>
+        useTimelineSync(syncOpts(room, paginateEventTimeline, () => false))
+      );
+
+      let paginatePromise: Promise<void> | undefined;
+      await act(async () => {
+        paginatePromise = result.current.handleTimelinePagination(true);
+        await Promise.resolve();
+      });
+      expect(result.current.backwardStatus).toBe('loading');
+
+      // Sliding sync resets the live window while /messages is in flight.
+      await act(async () => {
+        timelineSet.emit(RoomEvent.TimelineReset);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        resolvePaginate?.(true);
+        await paginatePromise;
+      });
+
+      expect(result.current.backwardStatus).toBe('idle');
+      expect(paginateEventTimeline).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+const renderSyncHook = (
+  room: FakeRoom,
+  options: {
+    isAtBottom?: boolean;
+    mx?: Record<string, unknown>;
+    readUptoEventId?: string;
+  } = {}
+) => {
+  const scrollToBottom = vi.fn<() => void>();
+  const isAtBottom = options.isAtBottom ?? true;
+  const { result } = renderHook(() =>
+    useTimelineSync({
+      room: room as Room,
+      mx: (options.mx ?? { getUserId: () => '@alice:test' }) as never,
+      isAtBottom,
+      isAtBottomRef: { current: isAtBottom },
+      scrollToBottom,
+      unreadInfo: undefined,
+      setUnreadInfo: vi.fn<() => void>(),
+      hideReadsRef: { current: false },
+      readUptoEventIdRef: { current: options.readUptoEventId },
+    })
+  );
+  return { result, scrollToBottom };
+};
+
+const makeLiveEvent = (roomId: string, ts: number) => ({
+  threadRootId: undefined,
+  getSender: () => '@bob:test',
+  getRoomId: () => roomId,
+  getTs: () => ts,
+  getRelation: () => undefined,
+});
+
+describe('live-arrive edge cases', () => {
+  it('ignores timeline events emitted for a different room', async () => {
+    const { room, timeline, events } = createRoom();
+    const otherRoom = createRoom('!other:test');
+    const { scrollToBottom } = renderSyncHook(room);
+
+    await act(async () => {
+      events.push({});
+      room.emit(
+        RoomEvent.Timeline,
+        makeLiveEvent(otherRoom.room.roomId, Date.now()),
+        otherRoom.room,
+        false,
+        false,
+        {
+          liveEvent: true,
+          timeline,
+        }
+      );
+      await Promise.resolve();
+    });
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('ignores removed events arriving with non-live data', async () => {
+    const { room, timeline, events } = createRoom();
+    const { scrollToBottom } = renderSyncHook(room);
+
+    await act(async () => {
+      events.push({});
+      room.emit(RoomEvent.Timeline, makeLiveEvent(room.roomId, Date.now()), room, false, true, {
+        liveEvent: false,
+        timeline,
+      });
+      await Promise.resolve();
+    });
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('treats only recent non-live events as part of the reconnect backfill window', async () => {
+    const { room, timeline, events } = createRoom();
+    const { scrollToBottom } = renderSyncHook(room);
+
+    // A reconnect pages events onto the live timeline without liveEvent: true;
+    // anything older than the 60 s grace window is history, not an arrival.
+    await act(async () => {
+      events.push({});
+      room.emit(
+        RoomEvent.Timeline,
+        makeLiveEvent(room.roomId, Date.now() - 120_000),
+        room,
+        false,
+        false,
+        { liveEvent: false, timeline }
+      );
+      await Promise.resolve();
+    });
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    await act(async () => {
+      events.push({});
+      room.emit(RoomEvent.Timeline, makeLiveEvent(room.roomId, Date.now()), room, false, false, {
+        liveEvent: false,
+        timeline,
+      });
+      await Promise.resolve();
+    });
+    expect(scrollToBottom).toHaveBeenCalledWith('instant');
+  });
+
+  it('ignores events emitted on a non-live timeline of the same room', async () => {
+    const { room, events } = createRoom();
+    const { scrollToBottom } = renderSyncHook(room);
+    // A detached window (permalink jump / search result) backfilling in the
+    // background must not pull the view to the bottom of the live timeline.
+    const detached = createTimeline([{}]);
+
+    await act(async () => {
+      events.push({});
+      room.emit(RoomEvent.Timeline, makeLiveEvent(room.roomId, Date.now()), room, false, false, {
+        liveEvent: false,
+        timeline: detached,
+      });
+      await Promise.resolve();
+    });
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('re-anchors after a sliding sync reset and ignores events on the detached timeline', async () => {
+    const { room, timelineSet } = createRoom();
+    const { scrollToBottom } = renderSyncHook(room);
+    const oldTimeline = timelineSet.getLiveTimeline();
+    const freshEvents: unknown[] = [];
+    const freshTimeline = createTimeline(freshEvents);
+    timelineSet.getLiveTimeline = () => freshTimeline;
+
+    // An event arriving on the OLD timeline is dropped even though the live
+    // timeline did grow — pushing to `events` instead would pass either way.
+    await act(async () => {
+      freshEvents.push({});
+      room.emit(RoomEvent.Timeline, makeLiveEvent(room.roomId, Date.now()), room, false, false, {
+        liveEvent: false,
+        timeline: oldTimeline,
+      });
+      await Promise.resolve();
+    });
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    await act(async () => {
+      freshEvents.push({});
+      timelineSet.emit(RoomEvent.TimelineReset);
+      await Promise.resolve();
+    });
+    expect(scrollToBottom).toHaveBeenCalledWith('instant');
+
+    scrollToBottom.mockClear();
+    await act(async () => {
+      freshEvents.push({});
+      room.emit(RoomEvent.Timeline, makeLiveEvent(room.roomId, Date.now()), room, false, false, {
+        liveEvent: false,
+        timeline: freshTimeline,
+      });
+      await Promise.resolve();
+    });
+    expect(scrollToBottom).toHaveBeenCalledWith('instant');
+  });
+
+  it('updates the unread marker for a live event while scrolled up, without scrolling', async () => {
+    const { room, timeline, events } = createRoom();
+    const unread = { readUptoEventId: '$read:test', inLiveTimeline: true, scrollTo: false };
+    vi.mocked(getRoomUnreadInfo).mockReturnValue(unread);
+    const setUnreadInfo = vi.fn<() => void>();
+    const scrollToBottom = vi.fn<() => void>();
+
+    renderHook(() =>
+      useTimelineSync({
+        room: room as Room,
+        mx: { getUserId: () => '@alice:test' } as never,
+        isAtBottom: false,
+        isAtBottomRef: { current: false },
+        scrollToBottom,
+        unreadInfo: undefined,
+        setUnreadInfo,
+        hideReadsRef: { current: false },
+        readUptoEventIdRef: { current: undefined },
+      })
+    );
+
+    await act(async () => {
+      events.push({});
+      room.emit(RoomEvent.Timeline, makeLiveEvent(room.roomId, Date.now()), room, false, false, {
+        liveEvent: true,
+        timeline,
+      });
+      await Promise.resolve();
+    });
+
+    expect(setUnreadInfo).toHaveBeenCalledWith(unread);
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('re-renders when a late local echo updates (slow send acknowledgement)', async () => {
+    const { room } = createRoom();
+    const { result } = renderSyncHook(room);
+    const before = result.current.timeline;
+
+    await act(async () => {
+      room.emit(RoomEvent.LocalEchoUpdated, {}, room);
+      await Promise.resolve();
+    });
+
+    expect(result.current.timeline).not.toBe(before);
+  });
+});
+
+describe('event jump recovery', () => {
+  // A room where the target event is nowhere in the loaded window, so the loader
+  // has to pull a fresh window from the homeserver before it can jump.
+  const setupUnloadedTarget = (targetId: string) => {
+    const { room, timelineSet } = createRoom();
+    timelineSet.getTimelineForEvent = () => undefined;
+
+    const olderEvents = [{ getId: () => '$older:test' }, { getId: () => '$older2:test' }];
+    const olderTimeline = {
+      getEvents: () => olderEvents,
+      getPaginationToken: () => undefined,
+      getRoomId: () => room.roomId,
+      getNeighbouringTimeline: (direction: Direction) =>
+        direction === Direction.Forward ? targetTimeline : undefined,
+    };
+    const targetTimeline = {
+      getEvents: () => [{ getId: () => targetId }],
+      getPaginationToken: () => undefined,
+      getRoomId: () => room.roomId,
+      getNeighbouringTimeline: (direction: Direction) =>
+        direction === Direction.Backward ? olderTimeline : undefined,
+    };
+
+    const roomInitialSync = vi.fn<() => Promise<unknown>>(() => Promise.resolve(undefined));
+    const getLatestTimeline = vi.fn<() => Promise<unknown>>(() => Promise.resolve(undefined));
+    return {
+      room,
+      olderTimeline,
+      targetTimeline,
+      roomInitialSync,
+      getLatestTimeline,
+      mx: {
+        getUserId: () => '@alice:test',
+        roomInitialSync,
+        getLatestTimeline,
+        getEventTimeline: vi.fn<() => Promise<unknown>>(() => Promise.resolve(targetTimeline)),
+      },
+    };
+  };
+
+  it('backfills and jumps to a permalink target that is not in the loaded history', async () => {
+    const fixture = setupUnloadedTarget('$target:test');
+    const { result, scrollToBottom } = renderSyncHook(fixture.room, {
+      isAtBottom: false,
+      mx: fixture.mx,
+    });
+
+    await act(async () => {
+      await result.current.loadEventTimeline('$target:test');
+    });
+
+    expect(fixture.roomInitialSync).toHaveBeenCalled();
+    expect(fixture.getLatestTimeline).toHaveBeenCalled();
+    // The whole linked chain is adopted, not just the timeline holding the event.
+    expect(result.current.timeline.linkedTimelines).toEqual([
+      fixture.olderTimeline,
+      fixture.targetTimeline,
+    ]);
+    // Absolute index across the chain: 2 older events precede the target.
+    expect(result.current.focusItem).toEqual({ index: 2, scrollTo: true, highlight: true });
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('jumps without highlighting when the target is the read marker itself', async () => {
+    const fixture = setupUnloadedTarget('$read:test');
+    const { result } = renderSyncHook(fixture.room, {
+      isAtBottom: false,
+      mx: fixture.mx,
+      readUptoEventId: '$read:test',
+    });
+
+    await act(async () => {
+      await result.current.loadEventTimeline('$read:test');
+    });
+
+    expect(result.current.focusItem).toEqual({ index: 2, scrollTo: true, highlight: false });
+  });
+
+  it('falls back to the initial timeline when a jump load times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const { room } = createRoom();
+      const mx = {
+        getUserId: () => '@alice:test',
+        roomInitialSync: vi.fn<() => Promise<unknown>>(() => Promise.resolve(undefined)),
+        getLatestTimeline: vi.fn<() => Promise<unknown>>(() => Promise.resolve(undefined)),
+        // The homeserver never answers /context: hit the 12 s timeout.
+        getEventTimeline: () => new Promise(() => {}),
+      };
+      const { result, scrollToBottom } = renderSyncHook(room, { isAtBottom: false, mx });
+
+      await act(async () => {
+        const pending = result.current.loadEventTimeline('$missing:test');
+        await vi.advanceTimersByTimeAsync(13_000);
+        await pending;
+      });
+
+      expect(scrollToBottom).toHaveBeenCalledWith('instant');
+      expect(result.current.timeline.linkedTimelines).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('sliding sync chain relink', () => {
+  it('re-links a grown timeline chain without fetching when the token is gone', async () => {
+    const { room, timelineSet } = createRoom();
+    const first = timelineSet.getLiveTimeline();
+    (first as { getEvents: () => unknown[] }).getEvents = () => [{}];
+    (first as { getPaginationToken: () => string | undefined }).getPaginationToken = () =>
+      undefined;
+    const paginateEventTimeline = vi.fn<() => Promise<boolean>>(() => Promise.resolve(false));
+    const { result } = renderSyncHook(room, {
+      mx: { getUserId: () => '@alice:test', paginateEventTimeline },
+    });
+
+    expect(result.current.eventsLength).toBe(1);
+
+    // A sliding sync limited response re-linked the chain server-side: the
+    // live timeline now has a forward neighbour we never saw.
+    const second = {
+      getEvents: () => [{}],
+      getPaginationToken: () => undefined as string | undefined,
+      getRoomId: () => room.roomId,
+      getNeighbouringTimeline: (direction: Direction) =>
+        direction === Direction.Backward ? first : undefined,
+    };
+    (first as { getNeighbouringTimeline: (d: Direction) => unknown }).getNeighbouringTimeline = (
+      direction
+    ) => (direction === Direction.Forward ? second : undefined);
+
+    await act(async () => {
+      await result.current.handleTimelinePagination(true);
+    });
+
+    expect(paginateEventTimeline).not.toHaveBeenCalled();
+    expect(result.current.eventsLength).toBe(2);
+    expect(result.current.backwardStatus).toBe('idle');
+  });
+});
+
+describe('sync transport fuzz', () => {
+  it.each([
+    // sliding sync additionally injects TimelineReset (limited windows)
+    ['normal sync', false],
+    ['sliding sync', true],
+  ])(
+    '%s: random op sequences never scroll a scrolled-up user and settle statuses',
+    async (_label, withResets) => {
+      for (let seed = 1; seed <= 30; seed += 1) {
+        faker.seed(seed * 55_440_491);
+        const { room, timelineSet, events } = createPaginableRoom();
+        const paginateEventTimeline = vi.fn<() => Promise<boolean>>(() => {
+          // 15% transient homeserver failure; otherwise 1..3 events land.
+          if (faker.number.float() < 0.15) return Promise.reject(new Error('hs down'));
+          const n = faker.number.int({ min: 1, max: 3 });
+          for (let i = 0; i < n; i += 1)
+            events.push({ hidden: faker.datatype.boolean({ probability: 0.4 }) });
+          return Promise.resolve(true);
+        });
+        const scrollToBottom = vi.fn<() => void>();
+        const { result, unmount } = renderHook(() =>
+          useTimelineSync({
+            room: room as Room,
+            mx: { getUserId: () => '@alice:test', paginateEventTimeline } as never,
+            isAtBottom: false,
+            isAtBottomRef: { current: false },
+            scrollToBottom,
+            unreadInfo: undefined,
+            setUnreadInfo: vi.fn<() => void>(),
+            hideReadsRef: { current: false },
+            readUptoEventIdRef: { current: undefined },
+            isEventVisible: (ev) => !(ev as unknown as { hidden?: boolean }).hidden,
+          })
+        );
+
+        for (let i = 0; i < 30; i += 1) {
+          const op = faker.number.int({ min: 0, max: withResets ? 4 : 3 });
+          // eslint-disable-next-line no-await-in-loop -- ops must be sequential
+          await act(async () => {
+            if (op === 0) {
+              // live message
+              events.push({});
+              room.emit(
+                RoomEvent.Timeline,
+                makeLiveEvent(room.roomId, Date.now()),
+                room,
+                false,
+                false,
+                { liveEvent: true, timeline: timelineSet.getLiveTimeline() }
+              );
+            } else if (op === 1) {
+              // reconnect backfill (old timestamp, not flagged live)
+              events.push({});
+              room.emit(
+                RoomEvent.Timeline,
+                makeLiveEvent(room.roomId, Date.now() - 120_000),
+                room,
+                false,
+                false,
+                { liveEvent: false, timeline: timelineSet.getLiveTimeline() }
+              );
+            } else if (op === 2) {
+              void result.current.handleTimelinePagination(true);
+            } else if (op === 3) {
+              void result.current.handleTimelinePagination(false);
+            } else {
+              // sliding sync limited window wipes and re-links the chain
+              timelineSet.emit(RoomEvent.TimelineReset);
+            }
+            await Promise.resolve();
+          });
+
+          // A user reading old history is never scrolled, and neither
+          // pagination direction ever wedges outside a known status.
+          expect(scrollToBottom).not.toHaveBeenCalled();
+          expect(['idle', 'loading', 'error']).toContain(result.current.backwardStatus);
+          expect(['idle', 'loading', 'error']).toContain(result.current.forwardStatus);
+        }
+
+        unmount();
+      }
+    }
+  );
 });

--- a/src/client/slidingSync.test.ts
+++ b/src/client/slidingSync.test.ts
@@ -496,6 +496,59 @@ describe('SlidingSyncManager room subscription coordination', () => {
     fireLifecycle(SlidingSyncState.Complete);
 
     expect(loadingStates).toEqual([false, true, false]);
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(false);
+  });
+
+  it('stops reporting loading for a room the server never sends data for', () => {
+    const manager = makeManager(makeMockMx());
+    const roomId = '!quiet:example.com';
+    const loadingStates: boolean[] = [];
+
+    manager.onRoomSubscriptionStatus(roomId, (loading) => loadingStates.push(loading));
+    manager.subscribeToRoom(roomId);
+    manager.attach();
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(true);
+
+    // The cycle the subscription was requested in carries no data for it.
+    fireLifecycle(SlidingSyncState.Complete);
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(true);
+
+    // A full cycle later the room is quiet: nothing is coming.
+    fireLifecycle(SlidingSyncState.Complete);
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(false);
+    expect(loadingStates).toEqual([false, true, false]);
+  });
+
+  it('stops reporting loading as soon as the subscription is dropped', () => {
+    const manager = makeManager(makeMockMx());
+    const roomId = '!quiet:example.com';
+
+    manager.subscribeToRoom(roomId);
+    manager.attach();
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(true);
+
+    manager.unsubscribeFromRoom(roomId);
+
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(false);
+  });
+
+  it('keeps reporting loading for a resubscribed room until its cycles elapse', () => {
+    const manager = makeManager(makeMockMx());
+    const roomId = '!quiet:example.com';
+
+    manager.subscribeToRoom(roomId);
+    manager.attach();
+    fireLifecycle(SlidingSyncState.Complete);
+    fireLifecycle(SlidingSyncState.Complete);
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(false);
+
+    manager.unsubscribeFromRoom(roomId);
+    manager.subscribeToRoom(roomId);
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(true);
+
+    fireLifecycle(SlidingSyncState.Complete);
+    fireLifecycle(SlidingSyncState.Complete);
+    expect(manager.isRoomSubscriptionLoading(roomId)).toBe(false);
   });
 
   it('uses the active subscription while a room is also an image-pack room', () => {

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -341,6 +341,14 @@ export class SlidingSyncManager {
 
   private readonly roomDataAwaitingSyncCompletion = new Set<string>();
 
+  /**
+   * Sync cycle each room subscription was requested in. A quiet room can be
+   * subscribed to without the server ever sending a RoomData envelope for it,
+   * so the loading flag needs a deadline of its own rather than waiting on
+   * pendingRoomDataListeners, which would never fire.
+   */
+  private readonly roomSubscriptionLoadingSince = new Map<string, number>();
+
   /** Wall-clock time recorded in attach() — used to compute true initial-sync latency. */
   private attachTime: number | null = null;
 
@@ -431,6 +439,16 @@ export class SlidingSyncManager {
       this.roomDataAwaitingSyncCompletion.clear();
 
       this.syncCount += 1;
+
+      // A subscription that saw no room data is settled once a full cycle has
+      // completed after the one it was requested in: the server had nothing to
+      // send for it. The extra cycle is the grace period for the request that
+      // actually carried the subscription.
+      this.roomSubscriptionLoadingSince.forEach((since, roomId) => {
+        if (this.syncCount < since + 2) return;
+        this.roomSubscriptionLoadingSince.delete(roomId);
+        this.notifyRoomSubscriptionStatus(roomId, false);
+      });
       Sentry.metrics.count('sable.sync.cycle', 1, {
         attributes: { transport: 'sliding' },
       });
@@ -606,6 +624,7 @@ export class SlidingSyncManager {
     });
 
     this.pendingRoomDataListeners.clear();
+    this.roomSubscriptionLoadingSince.clear();
     this.optimisticallyJoinedRoomIds.clear();
     this.responseProcessing = false;
     this.responseSettledListeners.clear();
@@ -1169,7 +1188,8 @@ export class SlidingSyncManager {
 
   public isRoomSubscriptionLoading(roomId: string): boolean {
     return (
-      this.pendingRoomDataListeners.has(roomId) || this.roomDataAwaitingSyncCompletion.has(roomId)
+      this.roomSubscriptionLoadingSince.has(roomId) ||
+      this.roomDataAwaitingSyncCompletion.has(roomId)
     );
   }
 
@@ -1229,9 +1249,11 @@ export class SlidingSyncManager {
       });
       this.slidingSync.removeListener(SlidingSyncEvent.RoomData, onFirstRoomData);
       this.pendingRoomDataListeners.delete(roomId);
+      this.roomSubscriptionLoadingSince.delete(roomId);
       this.roomDataAwaitingSyncCompletion.add(roomId);
     };
     this.pendingRoomDataListeners.set(roomId, onFirstRoomData);
+    this.roomSubscriptionLoadingSince.set(roomId, this.syncCount);
     this.slidingSync.on(SlidingSyncEvent.RoomData, onFirstRoomData);
     this.notifyRoomSubscriptionStatus(roomId, true);
     return true;
@@ -1244,6 +1266,7 @@ export class SlidingSyncManager {
       this.slidingSync.removeListener(SlidingSyncEvent.RoomData, pendingListener);
       this.pendingRoomDataListeners.delete(roomId);
     }
+    this.roomSubscriptionLoadingSince.delete(roomId);
     this.roomDataAwaitingSyncCompletion.delete(roomId);
     this.notifyRoomSubscriptionStatus(roomId, false);
     this.activeRoomSubscriptions.delete(roomId);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

sliding sync: subscription loading was only cleared when a RoomData envelope arrived. quiet rooms never send one, so the timeline stayed behind the spinner. it now clears after a full sync cycle.

timeline:

  - row memo ignored permissions, so power level changes left stale redact/react/pin buttons
  - merged rows share itemIndex -1, so jumping to an edit highlighted all of them
  - new messages divider was dropped when the read marker sat on a filtered event
  - reading on another device left the green line and unread chips behind
  - failed backfill on an empty room showed placeholders with the retry unreachable

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
