### PR TITLE
fix(persona): serialize per-message-profile account data writes

### DIFF
--- a/src/app/hooks/usePerMessageProfile.proxy.test.ts
+++ b/src/app/hooks/usePerMessageProfile.proxy.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import type { MatrixClient } from '$types/matrix-sdk';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   extractCircumfixProxyTagsFromKey,
@@ -8,6 +9,8 @@ import {
   type PerMessageProfileProxyAssociationV1,
   proxyNeedsMigration,
   createProxyKey,
+  setCurrentlyUsedPerMessageProfileIdForAccount,
+  setCurrentlyUsedPerMessageProfileIdForRoom,
 } from './usePerMessageProfile';
 
 describe('migratePerMessageProfileProxyAssociation', () => {
@@ -130,5 +133,62 @@ describe('parsePerMessageProfileProxyAssociation', () => {
     const parsed = parsePerMessageProfileProxyAssociation(assoc);
     expect(parsed.regex.test('[ok]')).toBe(true);
     expect(parsed.regex.test('[no] trailing')).toBe(false);
+  });
+});
+
+describe('per-message profile persistence', () => {
+  it('serializes room writes and reads the latest account data snapshot', async () => {
+    const associations: Record<string, { profileId: string }> = {};
+    const writes: unknown[] = [];
+    let releaseFirstWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+
+    const mx = {
+      getAccountData: vi.fn<() => { getContent: () => { associations: typeof associations } }>(
+        () => ({ getContent: () => ({ associations }) })
+      ),
+      setAccountData: vi.fn<
+        (_event: unknown, content: { associations: typeof associations }) => Promise<void>
+      >(async (_event, content) => {
+        writes.push(content);
+        if (writes.length === 1) await firstWrite;
+        Object.assign(associations, content.associations);
+      }),
+    } as unknown as MatrixClient;
+
+    const first = setCurrentlyUsedPerMessageProfileIdForRoom(mx, '!room:example.org', 'first');
+    const second = setCurrentlyUsedPerMessageProfileIdForRoom(mx, '!room:example.org', 'second');
+
+    await vi.waitFor(() => expect(writes).toHaveLength(1));
+
+    releaseFirstWrite();
+    await Promise.all([first, second]);
+
+    expect(writes).toHaveLength(2);
+    expect((writes[1] as { associations: typeof associations }).associations).toEqual({
+      '!room:example.org': { profileId: 'second' },
+    });
+  });
+
+  it('continues queued account writes after a rejected write', async () => {
+    const writes: string[] = [];
+    const mx = {
+      setAccountData: vi.fn<
+        (_event: unknown, content: { association: { profileId: string } }) => Promise<void>
+      >(async (_event, content) => {
+        writes.push(content.association.profileId);
+        if (writes.length === 1) throw new Error('write failed');
+      }),
+      deleteAccountData: vi.fn<(...args: unknown[]) => void>(),
+    } as unknown as MatrixClient;
+
+    const first = setCurrentlyUsedPerMessageProfileIdForAccount(mx, 'first');
+    const second = setCurrentlyUsedPerMessageProfileIdForAccount(mx, 'second');
+
+    await expect(first).rejects.toThrow('write failed');
+    await expect(second).resolves.toBeUndefined();
+    expect(writes).toEqual(['first', 'second']);
   });
 });

--- a/src/app/hooks/usePerMessageProfile.ts
+++ b/src/app/hooks/usePerMessageProfile.ts
@@ -4,15 +4,19 @@ import type { PronounSet } from '$utils/pronouns';
 import type { MatrixClient } from '$types/matrix-sdk';
 import { CustomAccountDataEvent } from '$types/matrix/accountData';
 import type { ColorSet } from './useUserProfile';
-import { MATRIX_UNSTABLE_COLORS } from '$unstable/prefixes';
 import {
+  MATRIX_UNSTABLE_COLORS,
   MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_CIRCUMFIX_PROPERTY_NAME,
   MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_SUFFIX_PROPERTY_NAME,
   MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME,
   MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME,
 } from '$unstable/prefixes';
+import { createKeyedQueue } from '$utils/keyedQueue';
 
 const ACCOUNT_DATA_PREFIX = CustomAccountDataEvent.SablePerProfileMessageProfiles;
+
+/** Account data is read-modify-written, so writes to the same key must not interleave. */
+const enqueueProfilePersistence = createKeyedQueue();
 
 /**
  * @deprecated in favour if {@link PerMessageProfileMsc4461}
@@ -622,32 +626,34 @@ export async function setCurrentlyUsedPerMessageProfileIdForRoom(
   validUntil?: number,
   reset?: boolean
 ) {
-  const accountData = mx.getAccountData(
-    `${ACCOUNT_DATA_PREFIX}.roomassociation` as Parameters<typeof mx.getAccountData>[0]
-  );
-  const content: PerMessageProfileRoomAssociationWrapper | undefined = accountData?.getContent();
-  const associations = getAssociationsMap(content);
+  return enqueueProfilePersistence('roomassociation', async () => {
+    const accountData = mx.getAccountData(
+      `${ACCOUNT_DATA_PREFIX}.roomassociation` as Parameters<typeof mx.getAccountData>[0]
+    );
+    const content: PerMessageProfileRoomAssociationWrapper | undefined = accountData?.getContent();
+    const associations = getAssociationsMap(content);
 
-  if (reset) {
-    associations.delete(roomId);
+    if (reset) {
+      associations.delete(roomId);
+      await mx.setAccountData(
+        `${ACCOUNT_DATA_PREFIX}.roomassociation` as Parameters<typeof mx.setAccountData>[0],
+        { associations: associationsMapToObject(associations) } as Parameters<
+          typeof mx.setAccountData
+        >[1]
+      );
+      return;
+    }
+    if (!profileId) {
+      throw new Error("profile Id is empty, yet it isn't a reset");
+    }
+    associations.set(roomId, { profileId, validUntil });
     await mx.setAccountData(
       `${ACCOUNT_DATA_PREFIX}.roomassociation` as Parameters<typeof mx.setAccountData>[0],
       { associations: associationsMapToObject(associations) } as Parameters<
         typeof mx.setAccountData
       >[1]
     );
-    return;
-  }
-  if (!profileId) {
-    throw new Error("profile Id is empty, yet it isn't a reset");
-  }
-  associations.set(roomId, { profileId, validUntil });
-  await mx.setAccountData(
-    `${ACCOUNT_DATA_PREFIX}.roomassociation` as Parameters<typeof mx.setAccountData>[0],
-    { associations: associationsMapToObject(associations) } as Parameters<
-      typeof mx.setAccountData
-    >[1]
-  );
+  });
 }
 
 /**
@@ -659,22 +665,24 @@ export async function setCurrentlyUsedPerMessageProfileIdForAccount(
   validUntil?: number,
   reset?: boolean
 ) {
-  if (reset) {
-    await mx.deleteAccountData(
-      `${ACCOUNT_DATA_PREFIX}.globalassociation` as Parameters<typeof mx.setAccountData>[0]
+  return enqueueProfilePersistence('globalassociation', async () => {
+    if (reset) {
+      await mx.deleteAccountData(
+        `${ACCOUNT_DATA_PREFIX}.globalassociation` as Parameters<typeof mx.setAccountData>[0]
+      );
+      return;
+    }
+    if (!profileId) {
+      throw new Error("profile Id is empty, yet it isn't a reset");
+    }
+
+    const association: PerMessageProfileRoomAssociation = { profileId, validUntil };
+
+    await mx.setAccountData(
+      `${ACCOUNT_DATA_PREFIX}.globalassociation` as Parameters<typeof mx.setAccountData>[0],
+      { association: association } as Parameters<typeof mx.setAccountData>[1]
     );
-    return;
-  }
-  if (!profileId) {
-    throw new Error("profile Id is empty, yet it isn't a reset");
-  }
-
-  const association: PerMessageProfileRoomAssociation = { profileId, validUntil };
-
-  await mx.setAccountData(
-    `${ACCOUNT_DATA_PREFIX}.globalassociation` as Parameters<typeof mx.setAccountData>[0],
-    { association: association } as Parameters<typeof mx.setAccountData>[1]
-  );
+  });
 }
 
 /*

--- a/src/app/utils/keyedQueue.ts
+++ b/src/app/utils/keyedQueue.ts
@@ -1,0 +1,20 @@
+/** Serializes operations per key so read-modify-write sequences cannot interleave. */
+export function createKeyedQueue() {
+  const tails = new Map<string, Promise<void>>();
+
+  return function run<T>(key: string, operation: () => T | PromiseLike<T>): Promise<T> {
+    const previous = tails.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const tail = current.then(
+      () => undefined,
+      () => undefined
+    );
+
+    tails.set(key, tail);
+    void tail.then(() => {
+      if (tails.get(key) === tail) tails.delete(key);
+    });
+
+    return current;
+  };
+}


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

the per-message-profile setters read account data, changed it, wrote it back, and never awaited the write. two at once and you lose an association.

both go through a per-key queue now so writes to the same key can't overlap.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
