### PR TITLE
fix(composer): scope scheduled send state to the room composer

### DIFF
--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -515,9 +515,25 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     const queryClient = useQueryClient();
     const delayedEventsSupported = useAtomValue(delayedEventsSupportedAtom);
-    const [scheduledTime, setScheduledTime] = useAtom(roomIdToScheduledTimeAtomFamily(roomId));
-    const [editingScheduledDelayId, setEditingScheduledDelayId] = useAtom(
+    const [roomScheduledTime, setRoomScheduledTime] = useAtom(
+      roomIdToScheduledTimeAtomFamily(roomId)
+    );
+    const [roomEditingScheduledDelayId, setRoomEditingScheduledDelayId] = useAtom(
       roomIdToEditingScheduledDelayIdAtomFamily(roomId)
+    );
+    const scheduledTime = threadRootId ? null : roomScheduledTime;
+    const editingScheduledDelayId = threadRootId ? null : roomEditingScheduledDelayId;
+    const setScheduledTime = useCallback(
+      (value: Date | null) => {
+        if (!threadRootId) setRoomScheduledTime(value);
+      },
+      [setRoomScheduledTime, threadRootId]
+    );
+    const setEditingScheduledDelayId = useCallback(
+      (value: string | null) => {
+        if (!threadRootId) setRoomEditingScheduledDelayId(value);
+      },
+      [setRoomEditingScheduledDelayId, threadRootId]
     );
     const [AddMenuAnchor, setAddMenuAnchor] = useState<RectCords>();
     const [showAttachmentSheet, setShowAttachmentSheet] = useState(false);

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -129,6 +129,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react';
 import {
   delayedEventsSupportedAtom,
+  getScheduledMessageStateKey,
   roomIdToScheduledTimeAtomFamily,
   roomIdToEditingScheduledDelayIdAtomFamily,
   serverMaxDelayMsAtom,
@@ -515,11 +516,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     const queryClient = useQueryClient();
     const delayedEventsSupported = useAtomValue(delayedEventsSupportedAtom);
+    const scheduledStateKey = getScheduledMessageStateKey(mx.getSafeUserId(), roomId);
     const [roomScheduledTime, setRoomScheduledTime] = useAtom(
-      roomIdToScheduledTimeAtomFamily(roomId)
+      roomIdToScheduledTimeAtomFamily(scheduledStateKey)
     );
     const [roomEditingScheduledDelayId, setRoomEditingScheduledDelayId] = useAtom(
-      roomIdToEditingScheduledDelayIdAtomFamily(roomId)
+      roomIdToEditingScheduledDelayIdAtomFamily(scheduledStateKey)
     );
     const scheduledTime = threadRootId ? null : roomScheduledTime;
     const editingScheduledDelayId = threadRootId ? null : roomEditingScheduledDelayId;

--- a/src/app/features/room/schedule-send/ScheduledMessagesList.test.tsx
+++ b/src/app/features/room/schedule-send/ScheduledMessagesList.test.tsx
@@ -54,6 +54,7 @@ vi.mock('$state/scheduledMessages', async () => {
 
   return {
     delayedEventsSupportedAtom: atom(true),
+    getScheduledMessageStateKey: (userId: string, roomId: string) => `${userId}\0${roomId}`,
     roomIdToScheduledTimeAtomFamily: () => scheduledTimeAtom,
     roomIdToEditingScheduledDelayIdAtomFamily: () => editingScheduledDelayIdAtom,
   };

--- a/src/app/features/room/schedule-send/ScheduledMessagesList.tsx
+++ b/src/app/features/room/schedule-send/ScheduledMessagesList.tsx
@@ -21,6 +21,7 @@ import {
 } from '$utils/delayedEvents';
 import {
   delayedEventsSupportedAtom,
+  getScheduledMessageStateKey,
   roomIdToScheduledTimeAtomFamily,
   roomIdToEditingScheduledDelayIdAtomFamily,
 } from '$state/scheduledMessages';
@@ -159,11 +160,12 @@ export function ScheduledMessagesList({ room, onEditMessage }: ScheduledMessages
   const mx = useMatrixClient();
   const queryClient = useQueryClient();
   const supported = useAtomValue(delayedEventsSupportedAtom);
-  const setScheduledTime = useSetAtom(roomIdToScheduledTimeAtomFamily(room.roomId));
+  const scheduledStateKey = getScheduledMessageStateKey(mx.getSafeUserId(), room.roomId);
+  const setScheduledTime = useSetAtom(roomIdToScheduledTimeAtomFamily(scheduledStateKey));
   const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
   const [expanded, setExpanded] = useState(false);
   const [editingDelayId, setEditingDelayId] = useAtom(
-    roomIdToEditingScheduledDelayIdAtomFamily(room.roomId)
+    roomIdToEditingScheduledDelayIdAtomFamily(scheduledStateKey)
   );
   const [cancellationStates, setCancellationStates] = useState<Record<string, CancellationState>>(
     {}

--- a/src/app/state/scheduledMessages.test.ts
+++ b/src/app/state/scheduledMessages.test.ts
@@ -1,0 +1,21 @@
+import { createStore } from 'jotai';
+import { describe, expect, it } from 'vitest';
+import {
+  getScheduledMessageStateKey,
+  roomIdToEditingScheduledDelayIdAtomFamily,
+  roomIdToScheduledTimeAtomFamily,
+} from './scheduledMessages';
+
+describe('scheduled message state', () => {
+  it('isolates the same room across accounts', () => {
+    const store = createStore();
+    const aliceKey = getScheduledMessageStateKey('@alice:example.org', '!room:example.org');
+    const bobKey = getScheduledMessageStateKey('@bob:example.org', '!room:example.org');
+
+    store.set(roomIdToScheduledTimeAtomFamily(aliceKey), new Date(1_000));
+    store.set(roomIdToEditingScheduledDelayIdAtomFamily(aliceKey), 'alice-delay');
+
+    expect(store.get(roomIdToScheduledTimeAtomFamily(bobKey))).toBeNull();
+    expect(store.get(roomIdToEditingScheduledDelayIdAtomFamily(bobKey))).toBeNull();
+  });
+});

--- a/src/app/state/scheduledMessages.ts
+++ b/src/app/state/scheduledMessages.ts
@@ -3,6 +3,9 @@ import { atomFamily } from 'jotai/utils';
 
 export const delayedEventsSupportedAtom = atom(false);
 
+export const getScheduledMessageStateKey = (userId: string, roomId: string): string =>
+  `${userId}\0${roomId}`;
+
 export const roomIdToScheduledTimeAtomFamily = atomFamily<
   string,
   ReturnType<typeof atom<Date | null>>


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

scheduled send state is a per-room atom so a thread composer in the same room was reading and writing the room composer's scheduled time and delay id.

thread composers read null now and their setters do nothing. scheduling stays room-only.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
