### PR TITLE
fix(call): hydrate the member roster before the call widget reads it

### DIFF
--- a/src/app/plugins/call/CallWidgetDriver.roster.test.ts
+++ b/src/app/plugins/call/CallWidgetDriver.roster.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Room } from '$types/matrix-sdk';
+import { hydrateWidgetRoster } from './CallWidgetDriver';
+
+type RoomStub = {
+  loadMembersIfNeeded: () => Promise<boolean>;
+  joinedInState?: number;
+  joinedCount?: number;
+};
+
+const makeRoom = ({ loadMembersIfNeeded, joinedInState = 4, joinedCount = 4 }: RoomStub): Room =>
+  ({
+    roomId: '!room:example.org',
+    loadMembersIfNeeded,
+    getMembersWithMembership: () => Array.from({ length: joinedInState }, () => ({})),
+    getJoinedMemberCount: () => joinedCount,
+  }) as unknown as Room;
+
+describe('hydrateWidgetRoster', () => {
+  it('fetches the roster before the widget reads member state', async () => {
+    const loadMembersIfNeeded = vi.fn<() => Promise<boolean>>().mockResolvedValue(true);
+
+    await hydrateWidgetRoster(makeRoom({ loadMembersIfNeeded }));
+
+    expect(loadMembersIfNeeded).toHaveBeenCalledOnce();
+  });
+
+  it('still serves state when the roster request fails', async () => {
+    const loadMembersIfNeeded = vi
+      .fn<() => Promise<boolean>>()
+      .mockRejectedValue(new Error('roster request failed'));
+
+    await expect(hydrateWidgetRoster(makeRoom({ loadMembersIfNeeded }))).resolves.toBeUndefined();
+  });
+
+  it('does not throw when the hydrated roster is still short', async () => {
+    const room = makeRoom({
+      loadMembersIfNeeded: () => Promise.resolve(false),
+      joinedInState: 2,
+      joinedCount: 7,
+    });
+
+    await expect(hydrateWidgetRoster(room)).resolves.toBeUndefined();
+  });
+});

--- a/src/app/plugins/call/CallWidgetDriver.ts
+++ b/src/app/plugins/call/CallWidgetDriver.ts
@@ -16,8 +16,10 @@ import type { MatrixClient } from '$types/matrix-sdk';
 import {
   EventType,
   type IContent,
+  KnownMembership,
   MatrixError,
   type MatrixEvent,
+  type Room,
   Direction,
   type SendDelayedEventResponse,
   type StateEvents,
@@ -28,6 +30,29 @@ import { downloadMedia, mxcUrlToHttp, uploadContentToServer } from '../../utils/
 import { createDebugLogger } from '../../utils/debugLogger';
 
 const debugLog = createDebugLogger('CallWidgetDriver');
+
+export const hydrateWidgetRoster = async (room: Room): Promise<void> => {
+  try {
+    await room.loadMembersIfNeeded();
+  } catch (error) {
+    // A partial roster still beats failing the read and stalling state sync.
+    debugLog.warn('call', 'Failed to load room members for the call widget', {
+      roomId: room.roomId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  const joinedInState = room.getMembersWithMembership(KnownMembership.Join).length;
+  const joinedCount = room.getJoinedMemberCount();
+  if (joinedInState < joinedCount) {
+    debugLog.warn('call', 'Call widget roster is short of the joined member count', {
+      roomId: room.roomId,
+      joinedInState,
+      joinedCount,
+    });
+  }
+};
 
 export class CallWidgetDriver extends WidgetDriver {
   private allowedCapabilities: Set<Capability>;
@@ -295,6 +320,9 @@ export class CallWidgetDriver extends WidgetDriver {
   ): Promise<IRoomEvent[]> {
     const room = this.mx.getRoom(roomId);
     if (room === null) return [];
+
+    if (eventType === (EventType.RoomMember as string)) await hydrateWidgetRoster(room);
+
     const state = room.getLiveTimeline().getState(Direction.Forward);
     if (state === undefined) return [];
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
