### PR TITLE
Fix the member roster when sliding sync only lazy-loads it

### DIFF
--- a/.changeset/fix-lazy-loaded-member-roster.md
+++ b/.changeset/fix-lazy-loaded-member-roster.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Refill the room member list from the server when sliding sync only delivered lazy-loaded members, so mention autocomplete and the members panel are complete.

--- a/src/app/hooks/useRoomMemberHydration.ts
+++ b/src/app/hooks/useRoomMemberHydration.ts
@@ -33,7 +33,7 @@ export const useRoomMemberHydration = (
 
     if (member && profileDisplayName && profileDisplayName !== member.rawDisplayName) {
       let disposed = false;
-      void hydrateRoomMember(mx, room.roomId, userId, true).then(() => {
+      void hydrateRoomMember(mx, room.roomId, userId, { force: true }).then(() => {
         if (!disposed && room.getMember(userId)) setVersion((v) => v + 1);
       });
       return () => {

--- a/src/app/hooks/useRoomMembers.ts
+++ b/src/app/hooks/useRoomMembers.ts
@@ -1,6 +1,7 @@
 import type { MatrixClient, MatrixEvent, RoomMember } from '$types/matrix-sdk';
 import { EventType, RoomMemberEvent, RoomStateEvent } from '$types/matrix-sdk';
 import { useEffect, useState } from 'react';
+import { hydrateAllRoomMembers } from '$client/roomMemberHydration';
 
 export const useRoomMembers = (mx: MatrixClient, roomId: string, enabled = true): RoomMember[] => {
   const [members, setMembers] = useState<RoomMember[]>([]);
@@ -23,11 +24,13 @@ export const useRoomMembers = (mx: MatrixClient, roomId: string, enabled = true)
 
     if (room) {
       setMembers(room.getMembers());
-      room.loadMembersIfNeeded().then(() => {
+      const stopLoading = () => {
         loadingMembers = false;
         if (disposed) return;
         updateMemberList();
-      });
+        void hydrateAllRoomMembers(mx, roomId).then(() => updateMemberList());
+      };
+      room.loadMembersIfNeeded().then(stopLoading, stopLoading);
     }
 
     const handleStateEvent = (event: MatrixEvent) => {

--- a/src/client/roomMemberHydration.test.ts
+++ b/src/client/roomMemberHydration.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { MatrixClient, Room, RoomMember } from '$types/matrix-sdk';
 import { EventType } from '$types/matrix-sdk';
 
-import { hydrateRoomMember, hydrateRoomMembers } from './roomMemberHydration';
+import {
+  hydrateAllRoomMembers,
+  hydrateRoomMember,
+  hydrateRoomMembers,
+} from './roomMemberHydration';
 
 const ROOM_ID = '!room:server';
 const USER_ID = '@ghost:server';
@@ -129,7 +133,7 @@ describe('hydrateRoomMember (force)', () => {
     const { mx, getStateEvent, setStateEvents, getMember } = makeFakes();
     getMember.mockReturnValue({ rawDisplayName: 'OldName' } as RoomMember);
 
-    await hydrateRoomMember(mx, ROOM_ID, USER_ID, true);
+    await hydrateRoomMember(mx, ROOM_ID, USER_ID, { force: true });
 
     expect(getStateEvent).toHaveBeenCalledTimes(1);
     expect(setStateEvents).toHaveBeenCalledTimes(1);
@@ -139,19 +143,136 @@ describe('hydrateRoomMember (force)', () => {
     const { mx, getStateEvent, getMember } = makeFakes();
     getMember.mockReturnValue({ rawDisplayName: 'OldName' } as RoomMember);
 
-    await hydrateRoomMember(mx, ROOM_ID, USER_ID, true);
-    await hydrateRoomMember(mx, ROOM_ID, USER_ID, true);
+    await hydrateRoomMember(mx, ROOM_ID, USER_ID, { force: true });
+    await hydrateRoomMember(mx, ROOM_ID, USER_ID, { force: true });
 
     expect(getStateEvent).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(10 * 60_000 + 1);
-    await hydrateRoomMember(mx, ROOM_ID, USER_ID, true);
+    await hydrateRoomMember(mx, ROOM_ID, USER_ID, { force: true });
+
+    expect(getStateEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('can bypass the refresh cooldown when current state becomes stale again', async () => {
+    const { mx, getStateEvent, getMember } = makeFakes();
+    getMember.mockReturnValue({ rawDisplayName: 'OldName' } as RoomMember);
+
+    await hydrateRoomMember(mx, ROOM_ID, USER_ID, { force: true });
+    await hydrateRoomMember(mx, ROOM_ID, USER_ID, {
+      force: true,
+      bypassRefreshCooldown: true,
+    });
 
     expect(getStateEvent).toHaveBeenCalledTimes(2);
   });
 });
 
+type BulkFakeSetup = {
+  mx: MatrixClient;
+  members: ReturnType<typeof vi.fn>;
+  setStateEvents: ReturnType<typeof vi.fn>;
+};
+
+const makeBulkFakes = (
+  joinedMembers: number,
+  joinedCount: number,
+  knownMemberIds: string[] = []
+): BulkFakeSetup => {
+  const setStateEvents = vi.fn<() => void>();
+  const room = {
+    roomId: ROOM_ID,
+    getJoinedMembers: () => Array.from({ length: joinedMembers }, () => ({}) as RoomMember),
+    getJoinedMemberCount: () => joinedCount,
+    getMember: (userId: string) => (knownMemberIds.includes(userId) ? ({} as RoomMember) : null),
+    currentState: { setStateEvents },
+  } as unknown as Room;
+  const members = vi.fn<() => Promise<object>>(() =>
+    Promise.resolve({
+      chunk: [
+        {
+          type: EventType.RoomMember,
+          state_key: USER_ID,
+          room_id: ROOM_ID,
+          sender: USER_ID,
+          content: { membership: 'join' },
+        },
+      ],
+    })
+  );
+  const mx = {
+    getRoom: () => room,
+    members,
+  } as unknown as MatrixClient;
+  return { mx, members, setStateEvents };
+};
+
+describe('hydrateAllRoomMembers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches the full member list when the roster is short of the joined count', async () => {
+    const { mx, members, setStateEvents } = makeBulkFakes(2, 20);
+
+    await hydrateAllRoomMembers(mx, ROOM_ID);
+
+    expect(members).toHaveBeenCalledWith(ROOM_ID, undefined, 'leave');
+    const [events] = setStateEvents.mock.calls[0] as [Array<{ getType: () => string }>];
+    expect(events[0]?.getType()).toBe(EventType.RoomMember);
+  });
+
+  it('skips members the room already knows', async () => {
+    const { mx, setStateEvents } = makeBulkFakes(2, 20, [USER_ID]);
+
+    await hydrateAllRoomMembers(mx, ROOM_ID);
+
+    expect(setStateEvents).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the roster already matches the joined count', async () => {
+    const { mx, members } = makeBulkFakes(20, 20);
+
+    await hydrateAllRoomMembers(mx, ROOM_ID);
+
+    expect(members).not.toHaveBeenCalled();
+  });
+
+  it('does not refetch within the TTL and retries after it', async () => {
+    const { mx, members } = makeBulkFakes(2, 20);
+
+    await hydrateAllRoomMembers(mx, ROOM_ID);
+    await hydrateAllRoomMembers(mx, ROOM_ID);
+    expect(members).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    await hydrateAllRoomMembers(mx, ROOM_ID);
+    expect(members).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows a failed fetch', async () => {
+    const { mx, members, setStateEvents } = makeBulkFakes(2, 20);
+    members.mockRejectedValueOnce(new Error('403'));
+
+    await expect(hydrateAllRoomMembers(mx, ROOM_ID)).resolves.toBeUndefined();
+    expect(setStateEvents).not.toHaveBeenCalled();
+  });
+});
+
 describe('hydrateRoomMembers', () => {
+  it('forwards force=true to each member hydration', async () => {
+    const { mx, getStateEvent, getMember } = makeFakes();
+    getMember.mockReturnValue({ rawDisplayName: 'OldName' } as RoomMember);
+
+    await hydrateRoomMembers(mx, ROOM_ID, [USER_ID], { force: true });
+
+    expect(getStateEvent).toHaveBeenCalledOnce();
+  });
+
   it('dedups user ids and filters non-user ids', async () => {
     const { mx, getStateEvent } = makeFakes();
 

--- a/src/client/roomMemberHydration.ts
+++ b/src/client/roomMemberHydration.ts
@@ -1,5 +1,5 @@
 import type { MatrixClient } from '$types/matrix-sdk';
-import { EventType, MatrixEvent } from '$types/matrix-sdk';
+import { EventType, KnownMembership, MatrixEvent } from '$types/matrix-sdk';
 
 const inFlight = new WeakMap<MatrixClient, Map<string, Promise<void>>>();
 
@@ -13,6 +13,11 @@ const requestQueues = new WeakMap<MatrixClient, Array<() => void>>();
 
 const REFRESH_TTL_MS = 10 * 60_000;
 const refreshedAt = new WeakMap<MatrixClient, Map<string, number>>();
+
+export type RoomMemberHydrationOptions = {
+  force?: boolean;
+  bypassRefreshCooldown?: boolean;
+};
 
 const scheduleRequest = <T>(mx: MatrixClient, task: () => Promise<T>): Promise<T> =>
   new Promise<T>((resolve, reject) => {
@@ -42,7 +47,7 @@ export const hydrateRoomMember = (
   mx: MatrixClient,
   roomId: string,
   userId: string,
-  force = false
+  { force = false, bypassRefreshCooldown = false }: RoomMemberHydrationOptions = {}
 ): Promise<void> => {
   const room = mx.getRoom(roomId);
   if (!room) return Promise.resolve();
@@ -50,7 +55,7 @@ export const hydrateRoomMember = (
 
   const key = `${roomId}\u0000${userId}`;
 
-  if (force) {
+  if (force && !bypassRefreshCooldown) {
     const lastRefreshed = refreshedAt.get(mx)?.get(key);
     if (lastRefreshed !== undefined && Date.now() - lastRefreshed < REFRESH_TTL_MS)
       return Promise.resolve();
@@ -86,7 +91,7 @@ export const hydrateRoomMember = (
   })
     .then(() => {
       failedAt.get(mx)?.delete(key);
-      if (force) {
+      if (force && !bypassRefreshCooldown) {
         const refreshMap = refreshedAt.get(mx) ?? new Map<string, number>();
         refreshedAt.set(mx, refreshMap);
         refreshMap.set(key, Date.now());
@@ -103,13 +108,58 @@ export const hydrateRoomMember = (
   return request;
 };
 
+// The SDK only fetches /members when the sync store holds no out-of-band member
+// set for the room. Sliding sync sends $LAZY members, so a room whose stored set
+// predates most joins keeps a short roster forever. Refill it from the server.
+const BULK_TTL_MS = 5 * 60_000;
+const bulkInFlight = new WeakMap<MatrixClient, Map<string, Promise<void>>>();
+const bulkAttemptedAt = new WeakMap<MatrixClient, Map<string, number>>();
+
+export const hydrateAllRoomMembers = (mx: MatrixClient, roomId: string): Promise<void> => {
+  const room = mx.getRoom(roomId);
+  if (!room) return Promise.resolve();
+  if (room.getJoinedMembers().length >= room.getJoinedMemberCount()) return Promise.resolve();
+
+  const attemptedTs = bulkAttemptedAt.get(mx)?.get(roomId);
+  if (attemptedTs !== undefined && Date.now() - attemptedTs < BULK_TTL_MS) return Promise.resolve();
+
+  const pending = bulkInFlight.get(mx) ?? new Map<string, Promise<void>>();
+  bulkInFlight.set(mx, pending);
+  const existing = pending.get(roomId);
+  if (existing) return existing;
+
+  const attempts = bulkAttemptedAt.get(mx) ?? new Map<string, number>();
+  bulkAttemptedAt.set(mx, attempts);
+  attempts.set(roomId, Date.now());
+
+  const request = mx
+    .members(roomId, undefined, KnownMembership.Leave)
+    .then(({ chunk }) => {
+      const currentRoom = mx.getRoom(roomId);
+      if (!currentRoom || !chunk) return;
+      // The response is current state, which may be ahead of our sync position,
+      // so only fill in members we are missing rather than overwriting known ones.
+      const missing = chunk.filter(
+        (event) => event.state_key && !currentRoom.getMember(event.state_key)
+      );
+      if (missing.length === 0) return;
+      currentRoom.currentState.setStateEvents(missing.map((event) => new MatrixEvent(event)));
+    })
+    .catch(() => undefined)
+    .finally(() => pending.delete(roomId));
+
+  pending.set(roomId, request);
+  return request;
+};
+
 export const hydrateRoomMembers = (
   mx: MatrixClient,
   roomId: string,
-  userIds: Iterable<string>
+  userIds: Iterable<string>,
+  options: RoomMemberHydrationOptions = {}
 ): Promise<void[]> =>
   Promise.all(
     [...new Set(userIds)]
       .filter((userId) => userId.startsWith('@'))
-      .map((userId) => hydrateRoomMember(mx, roomId, userId))
+      .map((userId) => hydrateRoomMember(mx, roomId, userId, options))
   );


### PR DESCRIPTION
Sliding sync returns heroes rather than the full membership, so anything
reading the roster directly saw a partial set: member lists, read receipts and
mention autocomplete all under-reported. Hydrate on demand, with a refresh
cooldown so repeated reads of the same room do not re-request, and a force
option for callers that need the roster to be authoritative.

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
