### PR TITLE
fix(user-profile): respect 24-hour clock setting for local time

### DIFF
--- a/.changeset/fix_an_inconsistency_where_a_user_profiles_local_time_did_not_respect_the_24_hour_time_format_setting.md
+++ b/.changeset/fix_an_inconsistency_where_a_user_profiles_local_time_did_not_respect_the_24_hour_time_format_setting.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix an inconsistency where a user profile's local time did not respect the "24-Hour Time Format" setting

--- a/src/app/components/user-profile/UserRoomProfile.tsx
+++ b/src/app/components/user-profile/UserRoomProfile.tsx
@@ -106,6 +106,8 @@ function UserExtendedSection({
   const [miscDataIndex, setMiscDataIndex] = useState(-1);
 
   const [renderAnimals] = useSetting(settingsAtom, 'renderAnimals');
+  const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
+
   const isCat = profile.isCat === true;
   const hasCats = profile.hasCats === true;
   const isAnimal = profile.isAnimal ?? (isCat && 'cat');
@@ -139,11 +141,12 @@ function UserExtendedSection({
         hour: 'numeric',
         minute: '2-digit',
         timeZone: profile.timezone.replaceAll(/^["']|["']$/g, ''),
+        hour12: !hour24Clock,
       }).format(new Date());
     } catch {
       return null;
     }
-  }, [profile.timezone]);
+  }, [profile.timezone, hour24Clock]);
 
   const bioContent = useMemo(() => {
     let rawBio =


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fixes an inconsistency where a user profile's local time did not respect the "24-Hour Time Format" setting. This was just a small annoyance I noticed, therefore there is no corresponding issue.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ Does not apply
- [ ] ~~I have made corresponding changes to the documentation~~ Does not apply
- [x] My changes generate no new warnings

### AI disclosure:

No artificial intelligence tools have been used while making this patch.

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
