### PR TITLE
Increase Node max-old-space-size to stop build crash

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@ min_version = '2026.7.11'
 
 [env]
 _.path = ["{{config_root}}/node_modules/.bin"]
+NODE_OPTIONS = "--max-old-space-size=4192"
 
 [settings]
 idiomatic_version_file_enable_tools = ["pnpm", "node"]


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Basic fix to stop builds crashing when running `mise build`.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

it's a one line change in a toml file

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
