### PR TITLE
fix: make iOS nightly builds visible as updates in AltStore/SideStore

### DIFF
--- a/.github/scripts/set-tauri-version.mjs
+++ b/.github/scripts/set-tauri-version.mjs
@@ -7,11 +7,12 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 
-const version = process.argv[2];
-const updaterEndpoint = process.argv[3];
+const args = process.argv.slice(2);
+const foldNightlyIntoPatch = args.includes('--apple-short-version');
+const [version, updaterEndpoint] = args.filter((arg) => !arg.startsWith('--'));
 if (!version || !/^\d+\.\d+\.\d+/.test(version)) {
   console.error(
-    `Usage: set-tauri-version.mjs <version> [updater-endpoint]  (got: ${version ?? '<none>'})`
+    `Usage: set-tauri-version.mjs <version> [updater-endpoint] [--apple-short-version]  (got: ${version ?? '<none>'})`
   );
   process.exit(1);
 }
@@ -33,10 +34,21 @@ const sanitizedVersion = version.replace(/^(\d+\.\d+\.\d+-nightly)\.(.+)$/, (_, 
   return `${prefix}.${sanitizedBuild}`;
 });
 
-config.version = sanitizedVersion;
+// AltStore/SideStore only compare CFBundleShortVersionString, which Tauri fills with
+// major.minor.patch, so the nightly stamp has to go in patch to be seen as a new version.
+let stampedVersion = sanitizedVersion;
+if (foldNightlyIntoPatch) {
+  stampedVersion = sanitizedVersion.replace(/^(\d+\.\d+)\.\d+-nightly\.(\d+)$/, '$1.$2');
+  if (stampedVersion === sanitizedVersion) {
+    console.error(`--apple-short-version needs a nightly version (got: ${sanitizedVersion})`);
+    process.exit(1);
+  }
+}
+
+config.version = stampedVersion;
 if (updaterEndpoint) {
   config.plugins.updater.endpoints = [updaterEndpoint];
 }
 writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
-console.log(`Set ${file} version to ${version}`);
+console.log(`Set ${file} version to ${stampedVersion}`);
 if (updaterEndpoint) console.log(`Set ${file} updater endpoint to ${updaterEndpoint}`);

--- a/.github/scripts/update-altstore-source.mjs
+++ b/.github/scripts/update-altstore-source.mjs
@@ -5,7 +5,7 @@
 // IPA asset, then prints the updated file. Used by .github/workflows/tauri-build.yml.
 //
 // Usage: update-altstore-source.mjs <source.json> <version> <build> <ipa-size> <downloadURL> <date> [description]
-// Env:   none
+// Env:   ALTSTORE_MAX_VERSIONS - how many version entries to keep (default 20)
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
@@ -60,8 +60,15 @@ const idx = versions.findIndex((v) => v.version === normalizedVersion);
 if (idx >= 0) versions[idx] = entry;
 else versions.unshift(entry);
 
-// Keep only the most recent 20 versions in the manifest.
-app.versions = versions.slice(0, 20);
+// Keep only the most recent versions in the manifest.
+const maxVersions = Number(process.env.ALTSTORE_MAX_VERSIONS ?? 20);
+if (!Number.isInteger(maxVersions) || maxVersions <= 0) {
+  console.error(
+    `ALTSTORE_MAX_VERSIONS must be a positive integer (got: ${process.env.ALTSTORE_MAX_VERSIONS})`
+  );
+  process.exit(1);
+}
+app.versions = versions.slice(0, maxVersions);
 
 writeFileSync(sourcePath, `${JSON.stringify(source, null, 2)}\n`);
 console.log(

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -455,7 +455,14 @@ jobs:
 
       - name: Stamp release version into tauri.conf.json
         shell: bash
-        run: node .github/scripts/set-tauri-version.mjs "$VERSION"
+        env:
+          IS_NIGHTLY: ${{ needs.setup-release.outputs.nightly }}
+        run: |
+          if [ "$IS_NIGHTLY" = "true" ]; then
+            node .github/scripts/set-tauri-version.mjs "$VERSION" --apple-short-version
+          else
+            node .github/scripts/set-tauri-version.mjs "$VERSION"
+          fi
 
       - name: Set up iOS
         shell: bash
@@ -541,6 +548,8 @@ jobs:
           set -euo pipefail
           if [ "$NIGHTLY" = "true" ]; then
             SOURCE_FILE="altstore-source-nightly.json"
+            # Superseded nightly IPAs get deleted, so older entries would be dead links.
+            export ALTSTORE_MAX_VERSIONS=1
           else
             SOURCE_FILE="altstore-source.json"
           fi


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->

i used the clanker i'm so tired of not getting update
