### PR TITLE
fix: use Alloy CEF media permissions

### DIFF
--- a/scripts/cef/copy-libs.sh
+++ b/scripts/cef/copy-libs.sh
@@ -12,15 +12,6 @@ PROFILE="${1:-debug}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEST="${2:-$ROOT/src-tauri/target/$PROFILE}"
 
-CEF_DIR="$(
-  find "$ROOT/src-tauri/target/$PROFILE/build" \
-    -type d -name cef_linux_x86_64 -print -quit 2>/dev/null || true
-)"
-if [ -z "$CEF_DIR" ]; then
-  echo "❌ CEF dist not found under target/$PROFILE/build — build with --features cef first." >&2
-  exit 1
-fi
-
 CEF_VERSION="$(awk '
   /^\[\[package\]\]$/ { in_cef=0 }
   /^name = "cef"$/ { in_cef=1 }
@@ -35,6 +26,18 @@ if [ -z "$CEF_VERSION" ]; then
   exit 1
 fi
 CEF_MAJOR="${CEF_VERSION%%.*}"
+
+CEF_DIR=""
+while IFS= read -r candidate; do
+  if grep -q "^#define CEF_VERSION_MAJOR $CEF_MAJOR$" "$candidate/include/cef_version.h" 2>/dev/null; then
+    CEF_DIR="$candidate"
+    break
+  fi
+done < <(find "$ROOT/src-tauri/target/$PROFILE/build" -type d -name cef_linux_x86_64 2>/dev/null)
+if [ -z "$CEF_DIR" ]; then
+  echo "❌ CEF $CEF_MAJOR dist not found under target/$PROFILE/build — build with --features cef first." >&2
+  exit 1
+fi
 
 CEF_LIB="$CEF_DIR/libcef.so"
 if [ ! -f "$CEF_LIB" ]; then

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6957,7 +6957,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime-cef"
 version = "0.1.0"
-source = "git+https://github.com/SableClient/tauri-runtime-cef?branch=main#92d67142bf830fd983905da65a60a44665eee52d"
+source = "git+https://github.com/SableClient/tauri-runtime-cef?branch=main#c0d9ff8ecf0eac8504c1947932274e7fe7d9fb8c"
 dependencies = [
  "base64 0.22.1",
  "cef",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -131,7 +131,7 @@ fn main() {
                 .cloned()
                 .collect();
 
-            if permission_kinds.is_empty() {
+            if permission_kinds.is_empty() || permission_kinds.len() != request.kinds.len() {
                 return responder.deny(DenyReason::NoPolicy);
             }
 


### PR DESCRIPTION
### Description

- use the CEF Alloy runtime so tauri://localhost can enumerate named media devices
- restore policy-gated microphone, camera, and desktop-capture requests through the runtime
- retain the native tauri origin and select the CEF distribution matching the resolved dependency

Fixes #1480

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
