### PR TITLE
fix: avoid member hydration after failed load

### DIFF
--- a/src/app/hooks/useRoomMembers.test.tsx
+++ b/src/app/hooks/useRoomMembers.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { MatrixClient, Room, RoomMember } from '$types/matrix-sdk';
+
+const { hydrateAllRoomMembers } = vi.hoisted(() => ({
+  hydrateAllRoomMembers: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+}));
+
+vi.mock('$client/roomMemberHydration', () => ({ hydrateAllRoomMembers }));
+
+import { useRoomMembers } from './useRoomMembers';
+
+describe('useRoomMembers', () => {
+  it('does not retry with a full roster request when the SDK member load fails', async () => {
+    const room = {
+      roomId: '!room:example.org',
+      getMembers: () => [] as RoomMember[],
+      loadMembersIfNeeded: vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(new Error('NetworkError')),
+    } as unknown as Room;
+    const mx = {
+      getRoom: () => room,
+      on: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+    } as unknown as MatrixClient;
+
+    renderHook(() => useRoomMembers(mx, room.roomId));
+
+    await waitFor(() => expect(room.loadMembersIfNeeded).toHaveBeenCalledOnce());
+    await Promise.resolve();
+
+    expect(hydrateAllRoomMembers).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/hooks/useRoomMembers.ts
+++ b/src/app/hooks/useRoomMembers.ts
@@ -28,9 +28,11 @@ export const useRoomMembers = (mx: MatrixClient, roomId: string, enabled = true)
         loadingMembers = false;
         if (disposed) return;
         updateMemberList();
-        void hydrateAllRoomMembers(mx, roomId).then(() => updateMemberList());
       };
-      room.loadMembersIfNeeded().then(stopLoading, stopLoading);
+      room.loadMembersIfNeeded().then(() => {
+        stopLoading();
+        void hydrateAllRoomMembers(mx, roomId).then(() => updateMemberList());
+      }, stopLoading);
     }
 
     const handleStateEvent = (event: MatrixEvent) => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Prevent user with some shenanigan as home server to load sable

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
