### PR TITLE
Fix spoilers not being formed when a newline is introduced

### DIFF
--- a/src/app/plugins/markdown/extensions/matrix-spoiler.ts
+++ b/src/app/plugins/markdown/extensions/matrix-spoiler.ts
@@ -13,7 +13,7 @@ export const matrixSpoilerExtension = {
   ) {
     // Only match if || at the very start of the remaining text
     if (!src.startsWith('||')) return undefined;
-    const rule = /^\|\|(.+?)\|\|/;
+    const rule = /^\|\|(.+?)\|\|/s;
     const match = rule.exec(src);
     if (match) {
       const token = {

--- a/src/app/styles/CustomHtml.css.ts
+++ b/src/app/styles/CustomHtml.css.ts
@@ -63,7 +63,6 @@ export const Code = style([
 const SpoilerBase = style([
   DefaultReset,
   {
-    padding: `0 ${config.space.S100}`,
     backgroundColor: color.SurfaceVariant.ContainerLine,
     borderRadius: config.radii.R300,
     selectors: {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes input like:

```
||foo
bar||
```
<img width="316" height="155" alt="image" src="https://github.com/user-attachments/assets/ad3af270-6d7d-4439-83af-71a9eb6a78b0" />

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
