### PR TITLE
Add PluralKit import, PMP backup/restore/wipe functionality

### DIFF
--- a/.changeset/add_pluralkit_import_pmp_backuprestorewipe_functionality.md
+++ b/.changeset/add_pluralkit_import_pmp_backuprestorewipe_functionality.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add PluralKit import, PMP backup/restore/wipe functionality

--- a/src/app/features/room/persona-picker/PersonaPicker.test.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.test.tsx
@@ -14,6 +14,12 @@ const mocked = vi.hoisted(() => ({
   setAccount: vi.fn<(...args: unknown[]) => Promise<void>>(),
 }));
 
+const grabPersonaButton = (name: string) => {
+  const btn = screen.getByText(name).parentElement!.parentElement!;
+  if (btn.tagName !== 'BUTTON') throw new Error('Not a button, DOM layout changed!');
+  return btn;
+};
+
 vi.mock('$app/persona/catalog', () => ({
   ProfileCatalog: class {
     constructor(private readonly mx: MatrixClient) {}
@@ -100,6 +106,7 @@ vi.mock('folds', async () => {
     Scroll: TestContainer,
     Text: TestContainer,
     config: { space: { S200: 0 } },
+    color: { Surface: { OnContainer: '#000000' } },
     toRem: (value: number) => `${value}rem`,
   };
 });
@@ -187,10 +194,7 @@ describe('PersonaPicker async flows', () => {
     renderPicker();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'First' })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
+      expect(grabPersonaButton('First')).toHaveAttribute('aria-selected', 'true');
     });
 
     roomSync.reject(new Error('room sync failed'));
@@ -204,17 +208,14 @@ describe('PersonaPicker async flows', () => {
     renderPicker();
     await screen.findByText('First');
 
-    fireEvent.click(screen.getByRole('button', { name: 'First' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Second' }));
+    fireEvent.click(grabPersonaButton('First'));
+    fireEvent.click(grabPersonaButton('Second'));
 
     firstWrite.reject(new Error('first write failed'));
     secondWrite.resolve();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Second' })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
+      expect(grabPersonaButton('Second')).toHaveAttribute('aria-selected', 'true');
     });
   });
 
@@ -227,7 +228,7 @@ describe('PersonaPicker async flows', () => {
     const view = renderPicker(mx);
     await screen.findByText('First');
 
-    fireEvent.click(screen.getByRole('button', { name: 'First' }));
+    fireEvent.click(grabPersonaButton('First'));
     view.rerender(
       <TemporaryPersonaPicker
         tab={PersonaPickerTab.PerRoom}
@@ -238,16 +239,13 @@ describe('PersonaPicker async flows', () => {
         latchedPersona={undefined}
       />
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Second' }));
+    fireEvent.click(grabPersonaButton('Second'));
 
     globalWrite.reject(new Error('global write failed'));
     roomWrite.resolve();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Second' })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
+      expect(grabPersonaButton('Second')).toHaveAttribute('aria-selected', 'true');
     });
 
     view.rerender(
@@ -260,10 +258,7 @@ describe('PersonaPicker async flows', () => {
         latchedPersona={undefined}
       />
     );
-    expect(screen.getByRole('button', { name: 'First' })).not.toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    expect(grabPersonaButton('First')).not.toHaveAttribute('aria-selected', 'true');
   });
 
   it('reconciles an optimistic selection when its write is rejected', async () => {
@@ -271,13 +266,10 @@ describe('PersonaPicker async flows', () => {
     renderPicker();
     await screen.findByText('First');
 
-    fireEvent.click(screen.getByRole('button', { name: 'First' }));
+    fireEvent.click(grabPersonaButton('First'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'First' })).not.toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
+      expect(grabPersonaButton('First')).not.toHaveAttribute('aria-selected', 'true');
     });
   });
 });

--- a/src/app/features/room/persona-picker/PersonaPicker.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.tsx
@@ -25,6 +25,7 @@ import {
   Text,
   toRem,
   Badge,
+  color,
 } from 'folds';
 import type { MatrixClient } from 'matrix-js-sdk';
 import {
@@ -361,12 +362,24 @@ function PersonaPickerMenu({
                       </Avatar>
                     }
                   >
-                    <Text
-                      truncate
-                      style={{ color: nameColor(profile) ?? undefined, maxWidth: toRem(150) }}
-                    >
-                      {profile.displayname}
-                    </Text>
+                    <Box direction="Column">
+                      <Text
+                        truncate
+                        style={{ color: nameColor(profile) ?? undefined, maxWidth: toRem(150) }}
+                      >
+                        {profile.displayname}
+                      </Text>
+                      <Text
+                        truncate
+                        size="T200"
+                        style={{
+                          color: `color-mix(${color.Surface.OnContainer}, transparent 20%)`,
+                          maxWidth: toRem(150),
+                        }}
+                      >
+                        {profile.id}
+                      </Text>
+                    </Box>
                   </MenuItem>
                 ))}
               </Scroll>

--- a/src/app/features/settings/Persona/PerMessageProfileOverview.tsx
+++ b/src/app/features/settings/Persona/PerMessageProfileOverview.tsx
@@ -7,7 +7,7 @@ import {
   ProfileCatalog,
 } from '$hooks/usePerMessageProfile';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Button, color, config, Dialog, Header, Spinner, Text } from 'folds';
+import { Box, Button, color, config, Dialog, Header, Spinner, Switch, Text } from 'folds';
 import { generateShortId } from '$utils/shortIdGen';
 import { SequenceCard, SequenceCardStyle } from '$components/sequence-card';
 import { PerMessageProfileListItem } from './PerMessageProfileListItem';
@@ -18,10 +18,15 @@ import {
   MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME,
 } from '$unstable/prefixes';
 import { downloadJsonFile } from '$app/utils/common';
-import { useFilePicker } from '$hooks/useFilePicker';
-import { createUploadAtom, useBindUploadAtom } from '$app/state/upload';
 import { selectFile } from '$app/utils/dom';
 import { ModalOverlay } from '$components/modal-overlay/ModalOverlay';
+import { AsyncError } from '$components/AsyncError';
+import {
+  importPluralkitMembers,
+  type PerMessageProfilePluralkitFormat,
+  type PkImportOptions,
+} from '$app/persona/pluralkit';
+import { readFileToString } from '$app/utils/file';
 
 type PerMessageProfileOverviewProps = {
   onCreateProfile: (profile: PerMessageProfileMsc4461) => void;
@@ -39,6 +44,8 @@ export function PerMessageProfileOverview({
   const [profiles, setProfiles] = useState<PerMessageProfileMsc4461[]>([]);
 
   const [confirmWipeData, setConfirmWipeData] = useState(false);
+  const [confirmPkImport, setConfirmPkImport] = useState(false);
+  const [pkImportSettings, setPkImportSettings] = useState<PkImportOptions | null>(null);
 
   useEffect(() => {
     const fetchProfiles = async () => {
@@ -65,34 +72,42 @@ export function PerMessageProfileOverview({
     }, [mx, onCreateProfile])
   );
 
+  const [handlePkitImportState, handlePkitImport] = useAsyncCallback<void, Error, []>(
+    useCallback(async () => {
+      const file = await selectFile('application/json', false);
+      if (!file) throw new Error('No file provided');
+
+      const text = await readFileToString(file);
+      const { members }: { members: PerMessageProfilePluralkitFormat[] } = JSON.parse(text);
+      if (!members) throw new Error('Personas not found in file');
+
+      const catalog = new ProfileCatalog(mx);
+      await importPluralkitMembers(mx, catalog, members, pkImportSettings ?? {});
+
+      // refetch
+      const fetchedProfiles = await catalog.list();
+      setProfiles(fetchedProfiles);
+      setConfirmPkImport(false);
+    }, [mx, pkImportSettings])
+  );
+
   // import, export, etc
   const [handlePersonaExportState, handlePersonaExport] = useAsyncCallback<void, Error, []>(
     useCallback(async () => {
       const personas = await new ProfileCatalog(mx).list();
       const data = { personas };
-      downloadJsonFile(JSON.stringify(data), "persona");
+      downloadJsonFile(JSON.stringify(data), 'persona');
     }, [mx])
   );
 
   const [handlePersonaImportState, handlePersonaImport] = useAsyncCallback<void, Error, []>(
     useCallback(async () => {
-      const readFile = async (file: File): Promise<string> => {
-        return new Promise((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => resolve(reader.result as string);
-          reader.onerror = () => reject(new Error("Problem reading JSON file."));
+      const file = await selectFile('application/json', false);
+      if (!file) throw new Error('No file provided');
 
-          reader.readAsText(file);
-        })
-      }
-
-      const file = await selectFile("application/json", false);
-      if (!file) throw new Error("No file provided");
-
-      const text = await readFile(file);
+      const text = await readFileToString(file);
       const json = JSON.parse(text);
-      if (!json) throw new Error("JSON parsing failed.");
-      if (!json.personas) throw new Error("Personas not found in file");
+      if (!json.personas) throw new Error('Personas not found in file');
 
       await new ProfileCatalog(mx).overwrite(json.personas as Persona[]);
 
@@ -118,182 +133,245 @@ export function PerMessageProfileOverview({
     if (handlePersonaImportState.status == AsyncStatus.Error) return handlePersonaImportState.error;
     if (handlePersonaWipeState.status == AsyncStatus.Error) return handlePersonaWipeState.error;
     return undefined;
-  }, [])
+  }, [handlePersonaExportState, handlePersonaImportState, handlePersonaWipeState]);
 
   return (
-   <>
-    <Box gap="100" direction="Column">
-      <Text size="L400">Personas</Text>
+    <>
+      <Box gap="100" direction="Column">
+        <Text size="L400">Personas</Text>
 
-      <SequenceCard
-        className={SequenceCardStyle}
-        variant="SurfaceVariant"
-        direction="Column"
-        gap="100"
-      >
-        <SettingTile
-          focusId="create-pmp"
-          title="Create Persona"
-          description="Create Personas to attach custom profiles to messages."
-          after={
-            <Button
-              size="300"
-              radii="300"
-              onClick={handleAdd}
-              disabled={addState.status === AsyncStatus.Loading}
-            >
-              {addState.status === AsyncStatus.Loading ? (
-                <Spinner size="100" variant="Primary" fill="Solid" />
-              ) : (
-                <Text size="B300">Add</Text>
-              )}
-            </Button>
-          }
-        />
-      </SequenceCard>
-
-      {profiles.map((profile) => (
         <SequenceCard
           className={SequenceCardStyle}
           variant="SurfaceVariant"
           direction="Column"
-          key={`profile-list-item-${profile.id}`}
+          gap="100"
         >
-          <PerMessageProfileListItem
-            mx={mx}
-            avatarMxcUrl={profile.avatar_url}
-            displayName={profile.displayname}
-            pronouns={profile[MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME]}
-            profileId={profile.id}
-            nameColorLight={profile[MATRIX_UNSTABLE_COLORS]?.on_light}
-            nameColorDark={profile[MATRIX_UNSTABLE_COLORS]?.on_dark}
-            onOpenEditor={handleEdit}
+          <SettingTile
+            focusId="create-pmp"
+            title="Create Persona"
+            description="Create Personas to attach custom profiles to messages."
+            after={
+              <Button
+                size="300"
+                radii="300"
+                onClick={handleAdd}
+                disabled={addState.status === AsyncStatus.Loading}
+              >
+                {addState.status === AsyncStatus.Loading ? (
+                  <Spinner size="100" variant="Primary" fill="Solid" />
+                ) : (
+                  <Text size="B300">Add</Text>
+                )}
+              </Button>
+            }
           />
         </SequenceCard>
-      ))}
 
+        {profiles.map((profile) => (
+          <SequenceCard
+            className={SequenceCardStyle}
+            variant="SurfaceVariant"
+            direction="Column"
+            key={`profile-list-item-${profile.id}`}
+          >
+            <PerMessageProfileListItem
+              mx={mx}
+              avatarMxcUrl={profile.avatar_url}
+              displayName={profile.displayname}
+              pronouns={profile[MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME]}
+              profileId={profile.id}
+              nameColorLight={profile[MATRIX_UNSTABLE_COLORS]?.on_light}
+              nameColorDark={profile[MATRIX_UNSTABLE_COLORS]?.on_dark}
+              onOpenEditor={handleEdit}
+            />
+          </SequenceCard>
+        ))}
       </Box>
-    <Box gap="100" direction="Column">
-      <Text size="L400">Persona Mass Management</Text>
+      <Box gap="100" direction="Column">
+        <Text size="L400">Persona Management</Text>
 
-      <SequenceCard
-        className={SequenceCardStyle}
-        variant="SurfaceVariant"
-        direction="Column"
-        gap="100"
-      >
-        <SettingTile
-          focusId="pmp-pk-import"
-          title="PluralKit Import"
-          description={<>Add or update PluralKit members from <code>system.json</code>. Consider backing up Persona data before importing.</>}
-          after={
-      
+        <SequenceCard
+          className={SequenceCardStyle}
+          variant="SurfaceVariant"
+          direction="Column"
+          gap="100"
+        >
+          <SettingTile
+            focusId="pmp-pk-import"
+            title="PluralKit Import"
+            description={
+              <>
+                Add or update PluralKit members from <code>system.json</code>. Consider backing up
+                Persona data before importing.
+              </>
+            }
+            after={
               <Button
+                onClick={() => setConfirmPkImport(true)}
                 size="400"
                 radii="300"
                 variant="Primary"
                 fill="Solid"
               >
-                <Text size="B300">Import PK member data</Text>
+                {handlePkitImportState.status === AsyncStatus.Loading ? (
+                  <Spinner variant="Primary" size="400" />
+                ) : (
+                  <Text size="B300">Import PK member data</Text>
+                )}
               </Button>
-        }
-          >
-          </SettingTile>
+            }
+          ></SettingTile>
         </SequenceCard>
-      <SequenceCard
-        className={SequenceCardStyle}
-        variant="SurfaceVariant"
-        direction="Column"
-        gap="100"
-      >
-        <SettingTile
-          focusId="pmp-list-export"
-          title="Persona management"
-          description="Import, export, et cetera." 
-          after={
-          <>
-            {manageError && <Text style={{ color: color.Critical.Main }} size="T300" >{manageError.message}</Text>}
+        <SequenceCard
+          className={SequenceCardStyle}
+          variant="SurfaceVariant"
+          direction="Column"
+          gap="100"
+        >
+          <SettingTile
+            focusId="pmp-list-export"
+            title="Persona data management"
+            description="Backup and restore your persona data."
+          >
+            {manageError && (
+              <Text style={{ color: color.Critical.Main }} size="T300">
+                {manageError.message}
+              </Text>
+            )}
             <Box
               direction="Row"
               justifyContent="End"
+              wrap="WrapReverse"
               gap="200"
               aria-label="PMP List edit buttons"
             >
-                <Button
-                  onClick={handlePersonaExport}
-                  size="400"
-                  radii="300"
-                  variant="Primary"
-                  fill="Solid"
-                >
-                  {handlePersonaExportState.status === AsyncStatus.Loading ? (
-                    <Spinner variant="Primary" size="400" />
-                  ) :
-                    <Text size="B300">Export data</Text>
-                  }
-                </Button>
-                <Button
-                  onClick={handlePersonaImport}
-                  size="400"
-                  radii="300"
-                  variant="Primary"
-                  fill="Soft"
-                >
-                  {handlePersonaImportState.status === AsyncStatus.Loading ? (
-                    <Spinner variant="Primary" size="300" />
-                  ) :
-                    <Text size="B300">Overwrite data from a backup</Text>
-                  }
-                </Button>
-                <Button
-                  onClick={() => setConfirmWipeData(true)}
-                  size="400"
-                  radii="300"
-                  variant="Critical"
-                  fill="Solid"
-                >
-                  <Text size="B300">Wipe all Persona data</Text>
-                </Button>
-            </Box></>
-        }>
+              <Button
+                onClick={handlePersonaExport}
+                size="400"
+                radii="300"
+                variant="Primary"
+                fill="Solid"
+              >
+                {handlePersonaExportState.status === AsyncStatus.Loading ? (
+                  <Spinner variant="Primary" size="400" />
+                ) : (
+                  <Text size="B300">Export data</Text>
+                )}
+              </Button>
+              <Button
+                onClick={handlePersonaImport}
+                size="400"
+                radii="300"
+                variant="Primary"
+                fill="Soft"
+              >
+                {handlePersonaImportState.status === AsyncStatus.Loading ? (
+                  <Spinner variant="Primary" size="300" />
+                ) : (
+                  <Text size="B300">Overwrite data from a backup</Text>
+                )}
+              </Button>
+              <Button
+                onClick={() => setConfirmWipeData(true)}
+                size="400"
+                radii="300"
+                variant="Critical"
+                fill="Solid"
+              >
+                <Text size="B300">Wipe all Persona data</Text>
+              </Button>
+            </Box>
+            {confirmPkImport && (
+              <ModalOverlay requestClose={() => setConfirmPkImport(false)}>
+                <Dialog variant="Surface">
+                  <Header
+                    style={{
+                      padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
+                      borderBottomWidth: config.borderWidth.B300,
+                    }}
+                    variant="Surface"
+                    size="500"
+                  >
+                    <Box grow="Yes">
+                      <Text size="H4">Import PluralKit data</Text>
+                    </Box>
+                  </Header>
+                  <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
+                    <Box direction="Column" justifyContent="SpaceBetween" gap="100">
+                      <Text priority="400" style={{ fontWeight: 'bold' }}>
+                        Configure import
+                      </Text>
 
-          {confirmWipeData && (
-            <ModalOverlay requestClose={() => setConfirmWipeData(false)}>
-              <Dialog variant="Surface">
-                <Header
-                  style={{
-                    padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
-                    borderBottomWidth: config.borderWidth.B300,
-                  }}
-                  variant="Surface"
-                  size="500"
-                >
-                  <Box grow="Yes">
-                    <Text size="H4">Wipe all Persona data</Text>
+                      <SequenceCard
+                        className={SequenceCardStyle}
+                        variant="SurfaceVariant"
+                        direction="Column"
+                        gap="100"
+                      >
+                        <Box direction="Row" justifyContent="SpaceBetween">
+                          <Text>Extract pronouns from display names</Text>
+                          <Switch
+                            variant="Primary"
+                            value={!!pkImportSettings?.extractPronouns}
+                            onChange={(on) =>
+                              setPkImportSettings((opts) => {
+                                return { ...opts, extractPronouns: on };
+                              })
+                            }
+                          />
+                        </Box>
+                      </SequenceCard>
+                      <AsyncError state={handlePkitImportState} prefix="Failed to import" />
+                    </Box>
+                    <Box direction="Row" justifyContent="End" gap="200">
+                      <Button variant="Secondary" onClick={() => setConfirmPkImport(false)}>
+                        <Text size="B400">Cancel</Text>
+                      </Button>
+                      <Button variant="Primary" onClick={handlePkitImport}>
+                        {handlePkitImportState.status === AsyncStatus.Loading ? (
+                          <Spinner variant="Primary" size="300" />
+                        ) : (
+                          <Text size="B400">Import</Text>
+                        )}{' '}
+                      </Button>
+                    </Box>
                   </Box>
-                </Header>
-                <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
-                  <Text priority="400">
-                    Are you sure you want to wipe all Persona data?
-                  </Text>
-                  <Box direction="Column" gap="200">
-                    <Button
-                      variant="Critical"
-                      onClick={handlePersonaWipe}
-                    >
-                      <Text size="B400">Delete all data</Text>
-                    </Button>
-                    <Button variant="Secondary" onClick={() => setConfirmWipeData(false)}>
-                      <Text size="B400">Cancel</Text>
-                    </Button>
+                </Dialog>
+              </ModalOverlay>
+            )}
+
+            {confirmWipeData && (
+              <ModalOverlay requestClose={() => setConfirmWipeData(false)}>
+                <Dialog variant="Surface">
+                  <Header
+                    style={{
+                      padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
+                      borderBottomWidth: config.borderWidth.B300,
+                    }}
+                    variant="Surface"
+                    size="500"
+                  >
+                    <Box grow="Yes">
+                      <Text size="H4">Wipe all Persona data</Text>
+                    </Box>
+                  </Header>
+                  <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
+                    <Text priority="400">Are you sure you want to wipe all Persona data?</Text>
+                    <Box direction="Column" gap="200">
+                      <Button variant="Critical" onClick={handlePersonaWipe}>
+                        <Text size="B400">Delete all data</Text>
+                      </Button>
+                      <Button variant="Secondary" onClick={() => setConfirmWipeData(false)}>
+                        <Text size="B400">Cancel</Text>
+                      </Button>
+                    </Box>
                   </Box>
-                </Box>
-              </Dialog>
-            </ModalOverlay>
-          )}
+                </Dialog>
+              </ModalOverlay>
+            )}
           </SettingTile>
-      </SequenceCard>
-    </Box>
-  </>
+        </SequenceCard>
+      </Box>
+    </>
   );
 }

--- a/src/app/features/settings/Persona/PerMessageProfileOverview.tsx
+++ b/src/app/features/settings/Persona/PerMessageProfileOverview.tsx
@@ -1,12 +1,13 @@
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import type { PerMessageProfileMsc4461 } from '$hooks/usePerMessageProfile';
+import type { PerMessageProfileMsc4461, Persona } from '$hooks/usePerMessageProfile';
 import {
   addOrUpdatePerMessageProfile,
   getAllPerMessageProfiles,
   getPerMessageProfileById,
+  ProfileCatalog,
 } from '$hooks/usePerMessageProfile';
-import { useCallback, useEffect, useState } from 'react';
-import { Box, Button, Spinner, Text } from 'folds';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Box, Button, color, config, Dialog, Header, Spinner, Text } from 'folds';
 import { generateShortId } from '$utils/shortIdGen';
 import { SequenceCard, SequenceCardStyle } from '$components/sequence-card';
 import { PerMessageProfileListItem } from './PerMessageProfileListItem';
@@ -16,6 +17,11 @@ import {
   MATRIX_UNSTABLE_COLORS,
   MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME,
 } from '$unstable/prefixes';
+import { downloadJsonFile } from '$app/utils/common';
+import { useFilePicker } from '$hooks/useFilePicker';
+import { createUploadAtom, useBindUploadAtom } from '$app/state/upload';
+import { selectFile } from '$app/utils/dom';
+import { ModalOverlay } from '$components/modal-overlay/ModalOverlay';
 
 type PerMessageProfileOverviewProps = {
   onCreateProfile: (profile: PerMessageProfileMsc4461) => void;
@@ -31,6 +37,8 @@ export function PerMessageProfileOverview({
 }: PerMessageProfileOverviewProps) {
   const mx = useMatrixClient();
   const [profiles, setProfiles] = useState<PerMessageProfileMsc4461[]>([]);
+
+  const [confirmWipeData, setConfirmWipeData] = useState(false);
 
   useEffect(() => {
     const fetchProfiles = async () => {
@@ -57,7 +65,63 @@ export function PerMessageProfileOverview({
     }, [mx, onCreateProfile])
   );
 
+  // import, export, etc
+  const [handlePersonaExportState, handlePersonaExport] = useAsyncCallback<void, Error, []>(
+    useCallback(async () => {
+      const personas = await new ProfileCatalog(mx).list();
+      const data = { personas };
+      downloadJsonFile(JSON.stringify(data), "persona");
+    }, [mx])
+  );
+
+  const [handlePersonaImportState, handlePersonaImport] = useAsyncCallback<void, Error, []>(
+    useCallback(async () => {
+      const readFile = async (file: File): Promise<string> => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(new Error("Problem reading JSON file."));
+
+          reader.readAsText(file);
+        })
+      }
+
+      const file = await selectFile("application/json", false);
+      if (!file) throw new Error("No file provided");
+
+      const text = await readFile(file);
+      const json = JSON.parse(text);
+      if (!json) throw new Error("JSON parsing failed.");
+      if (!json.personas) throw new Error("Personas not found in file");
+
+      await new ProfileCatalog(mx).overwrite(json.personas as Persona[]);
+
+      // refetch
+      const fetchedProfiles = await getAllPerMessageProfiles(mx);
+      setProfiles(fetchedProfiles);
+    }, [mx])
+  );
+
+  const [handlePersonaWipeState, handlePersonaWipe] = useAsyncCallback<void, Error, []>(
+    useCallback(async () => {
+      await new ProfileCatalog(mx).overwrite([]);
+
+      // refetch
+      const fetchedProfiles = await getAllPerMessageProfiles(mx);
+      setProfiles(fetchedProfiles);
+      setConfirmWipeData(false);
+    }, [mx])
+  );
+
+  const manageError = useMemo(() => {
+    if (handlePersonaExportState.status == AsyncStatus.Error) return handlePersonaExportState.error;
+    if (handlePersonaImportState.status == AsyncStatus.Error) return handlePersonaImportState.error;
+    if (handlePersonaWipeState.status == AsyncStatus.Error) return handlePersonaWipeState.error;
+    return undefined;
+  }, [])
+
   return (
+   <>
     <Box gap="100" direction="Column">
       <Text size="L400">Personas</Text>
 
@@ -107,6 +171,129 @@ export function PerMessageProfileOverview({
           />
         </SequenceCard>
       ))}
+
+      </Box>
+    <Box gap="100" direction="Column">
+      <Text size="L400">Persona Mass Management</Text>
+
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="100"
+      >
+        <SettingTile
+          focusId="pmp-pk-import"
+          title="PluralKit Import"
+          description={<>Add or update PluralKit members from <code>system.json</code>. Consider backing up Persona data before importing.</>}
+          after={
+      
+              <Button
+                size="400"
+                radii="300"
+                variant="Primary"
+                fill="Solid"
+              >
+                <Text size="B300">Import PK member data</Text>
+              </Button>
+        }
+          >
+          </SettingTile>
+        </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="100"
+      >
+        <SettingTile
+          focusId="pmp-list-export"
+          title="Persona management"
+          description="Import, export, et cetera." 
+          after={
+          <>
+            {manageError && <Text style={{ color: color.Critical.Main }} size="T300" >{manageError.message}</Text>}
+            <Box
+              direction="Row"
+              justifyContent="End"
+              gap="200"
+              aria-label="PMP List edit buttons"
+            >
+                <Button
+                  onClick={handlePersonaExport}
+                  size="400"
+                  radii="300"
+                  variant="Primary"
+                  fill="Solid"
+                >
+                  {handlePersonaExportState.status === AsyncStatus.Loading ? (
+                    <Spinner variant="Primary" size="400" />
+                  ) :
+                    <Text size="B300">Export data</Text>
+                  }
+                </Button>
+                <Button
+                  onClick={handlePersonaImport}
+                  size="400"
+                  radii="300"
+                  variant="Primary"
+                  fill="Soft"
+                >
+                  {handlePersonaImportState.status === AsyncStatus.Loading ? (
+                    <Spinner variant="Primary" size="300" />
+                  ) :
+                    <Text size="B300">Overwrite data from a backup</Text>
+                  }
+                </Button>
+                <Button
+                  onClick={() => setConfirmWipeData(true)}
+                  size="400"
+                  radii="300"
+                  variant="Critical"
+                  fill="Solid"
+                >
+                  <Text size="B300">Wipe all Persona data</Text>
+                </Button>
+            </Box></>
+        }>
+
+          {confirmWipeData && (
+            <ModalOverlay requestClose={() => setConfirmWipeData(false)}>
+              <Dialog variant="Surface">
+                <Header
+                  style={{
+                    padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
+                    borderBottomWidth: config.borderWidth.B300,
+                  }}
+                  variant="Surface"
+                  size="500"
+                >
+                  <Box grow="Yes">
+                    <Text size="H4">Wipe all Persona data</Text>
+                  </Box>
+                </Header>
+                <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
+                  <Text priority="400">
+                    Are you sure you want to wipe all Persona data?
+                  </Text>
+                  <Box direction="Column" gap="200">
+                    <Button
+                      variant="Critical"
+                      onClick={handlePersonaWipe}
+                    >
+                      <Text size="B400">Delete all data</Text>
+                    </Button>
+                    <Button variant="Secondary" onClick={() => setConfirmWipeData(false)}>
+                      <Text size="B400">Cancel</Text>
+                    </Button>
+                  </Box>
+                </Box>
+              </Dialog>
+            </ModalOverlay>
+          )}
+          </SettingTile>
+      </SequenceCard>
     </Box>
+  </>
   );
 }

--- a/src/app/features/settings/cosmetics/ThemeImportModal.tsx
+++ b/src/app/features/settings/cosmetics/ThemeImportModal.tsx
@@ -19,6 +19,7 @@ import {
 import { pruneThemeFavorites, pruneThemeTweakFavorites } from '../../../theme/themeLibrary';
 
 import { usePatchSettings } from './themeSettingsPatch';
+import { readFileToString } from '$app/utils/file';
 
 type ThemeImportModalProps = {
   open: boolean;
@@ -128,11 +129,9 @@ export function ThemeImportModal({ open, onClose }: ThemeImportModalProps) {
     if (!file) return;
     setImportFileName(file.name);
     setImportPaste('');
-    const reader = new FileReader();
-    reader.addEventListener('load', () => {
-      setUploadedFileCss(typeof reader.result === 'string' ? reader.result : '');
-    });
-    reader.readAsText(file);
+    readFileToString(file)
+      .then(setUploadedFileCss)
+      .catch((err: Error) => setImportError(err.message));
   };
 
   const handleImportTheme = useCallback(async () => {

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -111,6 +111,8 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'prevent-sending-pmp-fallback',
     'create-pmp',
     'enable-pmp-picker',
+    'pmp-pk-import',
+    'pmp-list-export',
   ],
   appearance: [
     'old-sidebar',

--- a/src/app/hooks/usePerMessageProfile.ts
+++ b/src/app/hooks/usePerMessageProfile.ts
@@ -45,7 +45,7 @@ export async function addOrUpdatePerMessageProfile(
   mx: MatrixClient,
   profile: PerMessageProfileMsc4461
 ) {
-  await new ProfileCatalog(mx).upsert(profile);
+  await new ProfileCatalog(mx).merge(profile);
 }
 
 export async function deletePerMessageProfile(mx: MatrixClient, id: string) {

--- a/src/app/persona/catalog.test.ts
+++ b/src/app/persona/catalog.test.ts
@@ -161,8 +161,8 @@ describe('ProfileCatalog', () => {
     const catalog = new ProfileCatalog(mx);
 
     await Promise.all([
-      catalog.upsert({ id: 'first', displayname: 'First', trigger: { prefix: [] } }),
-      catalog.upsert({ id: 'second', displayname: 'Second', trigger: { prefix: [] } }),
+      catalog.merge({ id: 'first', displayname: 'First', trigger: { prefix: [] } }),
+      catalog.merge({ id: 'second', displayname: 'Second', trigger: { prefix: [] } }),
     ]);
 
     await expect(catalog.list()).resolves.toEqual([

--- a/src/app/persona/catalog.ts
+++ b/src/app/persona/catalog.ts
@@ -2,7 +2,7 @@ import type { AccountDataCompatVersion } from '$types/matrix/accountData';
 import type { MatrixClient } from '$types/matrix-sdk';
 import { CustomAccountDataEvent } from '$types/matrix/accountData';
 import type { ColorSet } from '$hooks/useUserProfile';
-import type { PronounSet } from '$utils/pronouns';
+import { type PronounSet } from '$utils/pronouns';
 import { createKeyedQueue } from '$utils/keyedQueue';
 import {
   MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_CIRCUMFIX_PROPERTY_NAME,
@@ -309,7 +309,7 @@ export class ProfileCatalog {
     return (await this.list({ migrate: false })).find((persona) => persona.id === id);
   }
 
-  async upsert(persona: Persona): Promise<void> {
+  async merge(persona: Persona): Promise<void> {
     await enqueueProfilePersistence('catalog', async () => {
       const personas = await this.load(true);
       const index = personas.findIndex((existing) => existing.id === persona.id);
@@ -317,7 +317,9 @@ export class ProfileCatalog {
         this.mx,
         index === -1
           ? [...personas, persona]
-          : personas.map((existing) => (existing.id === persona.id ? persona : existing))
+          : personas.map((existing) =>
+              existing.id === persona.id ? { ...existing, ...persona } : existing
+            )
       );
     });
   }
@@ -346,7 +348,9 @@ export class ProfileCatalog {
   }
 
   async overwrite(profiles: Persona[]): Promise<void> {
-    await saveCatalog(this.mx, profiles);
+    await enqueueProfilePersistence('catalog', async () => {
+      await saveCatalog(this.mx, profiles);
+    });
   }
 
   async getSelection(

--- a/src/app/persona/catalog.ts
+++ b/src/app/persona/catalog.ts
@@ -345,6 +345,10 @@ export class ProfileCatalog {
     });
   }
 
+  async overwrite(profiles: Persona[]): Promise<void> {
+    await saveCatalog(this.mx, profiles);
+  }
+
   async getSelection(
     scope: 'account' | { roomId: string }
   ): Promise<ResolvedPersonaSelection | undefined> {

--- a/src/app/persona/index.ts
+++ b/src/app/persona/index.ts
@@ -4,6 +4,7 @@ import type {
   MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_CIRCUMFIX_PROPERTY_NAME,
   MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_SUFFIX_PROPERTY_NAME,
   MATRIX_UNSTABLE_COLORS,
+  MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME,
   MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME,
 } from '$unstable/prefixes';
 import type { ColorSet } from '$hooks/useUserProfile';
@@ -17,12 +18,20 @@ export type ProfileTrigger = {
   }[];
 };
 
+export type PkitImport = {
+  id: string;
+  uuid?: string;
+  description?: string;
+  avatar_url?: string;
+};
+
 export type PerMessageProfileMsc4461 = {
   id: string;
   displayname: string;
   avatar_url?: string;
   [MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME]?: PronounSet[];
   [MATRIX_UNSTABLE_COLORS]?: ColorSet;
+  [MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?: PkitImport;
   trigger: ProfileTrigger;
   compat?: AccountDataCompatVersion;
 };

--- a/src/app/persona/pluralkit.test.ts
+++ b/src/app/persona/pluralkit.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MatrixClient } from '$types/matrix-sdk';
+import {
+  MATRIX_UNSTABLE_COLORS,
+  MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME,
+  MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME,
+} from '$unstable/prefixes';
+import { ProfileCatalog } from './catalog';
+import { importPluralkitMembers } from './pluralkit';
+
+function createMatrixClient(accountData: Map<string, unknown>, writable = false) {
+  const setAccountData = vi.fn<(eventType: string, content: unknown) => Promise<void>>(
+    async (eventType, content) => {
+      if (!writable) throw new Error('offline');
+      accountData.set(eventType, content);
+    }
+  );
+  const deleteAccountData = vi.fn<(eventType: string) => Promise<void>>(async (eventType) => {
+    if (!writable) throw new Error('offline');
+    accountData.delete(eventType);
+  });
+  const mx = {
+    getAccountData: vi.fn<(eventType: string) => { getContent: () => unknown } | undefined>(
+      (eventType) => {
+        const content = accountData.get(eventType);
+        return content === undefined ? undefined : { getContent: () => content };
+      }
+    ),
+    setAccountData,
+    deleteAccountData,
+  } as unknown as MatrixClient;
+  return { mx, setAccountData, deleteAccountData };
+}
+
+describe('PluralkitImport', () => {
+  it('noop import', async () => {
+    const { mx } = createMatrixClient(
+      new Map([
+        [
+          MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME,
+          {
+            profiles: [],
+          },
+        ],
+      ]),
+      true
+    );
+
+    const catalog = new ProfileCatalog(mx);
+    await expect(importPluralkitMembers(mx, catalog, [])).resolves.not.toThrow();
+    await expect(catalog.list({ migrate: false })).resolves.toEqual([]);
+  });
+
+  it('basic import', async () => {
+    const { mx } = createMatrixClient(
+      new Map([
+        [
+          MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME,
+          {
+            profiles: [],
+          },
+        ],
+      ]),
+      true
+    );
+
+    const pkData = [
+      {
+        id: '0',
+        name: 'foo',
+        uuid: 'f00b4r',
+        display_name: 'Foo Bar',
+        proxy_tags: [
+          {
+            prefix: 'Foo:',
+            suffix: null,
+          },
+        ],
+      },
+    ];
+
+    const catalog = new ProfileCatalog(mx);
+    await expect(importPluralkitMembers(mx, catalog, pkData)).resolves.not.toThrow();
+    await expect(catalog.list({ migrate: false })).resolves.toEqual([
+      {
+        id: 'foo',
+        displayname: 'Foo Bar',
+        trigger: {
+          prefix: ['Foo:'],
+        },
+        [MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]: { id: '0', uuid: 'f00b4r' },
+      },
+    ]);
+  });
+  it('basic import w prev data', async () => {
+    const { mx } = createMatrixClient(
+      new Map([
+        [
+          MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME,
+          {
+            profiles: [{ id: 'valid', displayname: 'Valid', trigger: { prefix: [] } }],
+          },
+        ],
+      ]),
+      true
+    );
+
+    const pkData = [
+      {
+        id: '0',
+        name: 'foo',
+        uuid: 'f00b4r',
+        display_name: 'Foo Bar',
+        proxy_tags: [
+          {
+            prefix: 'Foo:',
+            suffix: null,
+          },
+        ],
+      },
+    ];
+
+    const catalog = new ProfileCatalog(mx);
+    await expect(importPluralkitMembers(mx, catalog, pkData)).resolves.not.toThrow();
+    await expect(catalog.list()).resolves.toEqual([
+      { id: 'valid', displayname: 'Valid', trigger: { prefix: [] } },
+      {
+        id: 'foo',
+        displayname: 'Foo Bar',
+        trigger: {
+          prefix: ['Foo:'],
+        },
+        [MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]: { id: '0', uuid: 'f00b4r' },
+      },
+    ]);
+  });
+
+  it('basic update-kind import', async () => {
+    const { mx } = createMatrixClient(
+      new Map([
+        [
+          MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME,
+          {
+            profiles: [
+              {
+                id: 'foo',
+                displayname: 'Foo Bar',
+                trigger: {
+                  prefix: ['Foo:'],
+                },
+                [MATRIX_UNSTABLE_COLORS]: {
+                  on_dark: '#ffffff',
+                  on_light: '#000000',
+                },
+                [MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]: { id: '0', uuid: 'f00b4r' },
+              },
+            ],
+          },
+        ],
+      ]),
+      true
+    );
+
+    const pkData = [
+      {
+        id: '0',
+        name: 'bar',
+        uuid: 'f00b4r',
+        display_name: 'Bar Bar',
+        proxy_tags: [
+          {
+            prefix: 'Foo:',
+            suffix: null,
+          },
+        ],
+      },
+    ];
+
+    const catalog = new ProfileCatalog(mx);
+    await expect(importPluralkitMembers(mx, catalog, pkData)).resolves.not.toThrow();
+    await expect(catalog.list()).resolves.toEqual([
+      {
+        id: 'bar',
+        displayname: 'Bar Bar',
+        trigger: {
+          prefix: ['Foo:'],
+        },
+        [MATRIX_UNSTABLE_COLORS]: {
+          on_dark: '#ffffff',
+          on_light: '#000000',
+        },
+        [MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]: { id: '0', uuid: 'f00b4r' },
+      },
+    ]);
+  });
+});

--- a/src/app/persona/pluralkit.ts
+++ b/src/app/persona/pluralkit.ts
@@ -1,0 +1,100 @@
+import { uploadContent } from '$app/utils/matrix';
+import type { MatrixClient, MatrixError } from '$types/matrix-sdk';
+import { getParsedPronouns } from '$utils/pronouns';
+import type { ProfileCatalog } from './catalog';
+import { convertPluralkitFormatToOurPerMessageProfile } from './projection';
+
+/** Used for PluralKit import */
+export type PerMessageProfilePluralkitFormat = {
+  id: string;
+  uuid?: string;
+  name: string;
+  display_name?: string;
+  color?: string;
+  pronouns?: string;
+  avatar_url?: string;
+  description?: string;
+  proxy_tags?: { prefix: string | null; suffix: string | null }[];
+};
+
+export async function fetchPkitAvatar(mx: MatrixClient, url: string): Promise<string> {
+  const req = await fetch(url);
+  if (!req.ok) throw new Error(`Fetch request to ${url} failed with code ${req.status}.`);
+
+  const content = await req.blob();
+  const uploadFile = new File([content], 'filename');
+
+  return new Promise((resolve, reject) => {
+    uploadContent(mx, uploadFile, {
+      onSuccess: resolve,
+      onError: function (error: MatrixError): void {
+        reject(error);
+      },
+    });
+  });
+}
+
+export type PkImportOptions = {
+  extractPronouns?: boolean;
+};
+
+export async function mergePluralkitProfile(
+  mx: MatrixClient,
+  catalog: ProfileCatalog,
+  pkPersona: PerMessageProfilePluralkitFormat,
+  options?: PkImportOptions
+): Promise<void> {
+  const personas = await catalog.list({ migrate: false });
+
+  // extract pronouns before converting to our Persona format
+  if (options?.extractPronouns && !!pkPersona.display_name) {
+    const { cleanedDisplayName, inlinePronoun } = getParsedPronouns(pkPersona.display_name, true);
+
+    if (inlinePronoun) {
+      pkPersona.display_name = cleanedDisplayName;
+      pkPersona.pronouns = inlinePronoun;
+    }
+  }
+  const newPersona = convertPluralkitFormatToOurPerMessageProfile(pkPersona);
+
+  // look for an old pluralkit profile
+  const matchingPersonaIndex = personas.findIndex(
+    ({ ['net.f0rest.pkimport']: record }) =>
+      (!!pkPersona.uuid && record?.uuid == pkPersona.uuid) || record?.id == pkPersona.id
+  );
+  const oldPersona = matchingPersonaIndex !== -1 ? personas[matchingPersonaIndex] : null;
+
+  if (pkPersona.avatar_url) {
+    // check if we can reuse the old avatar url (check pk avatar urls)
+    if (
+      oldPersona &&
+      oldPersona.avatar_url &&
+      oldPersona['net.f0rest.pkimport']?.avatar_url &&
+      oldPersona['net.f0rest.pkimport']?.avatar_url === pkPersona.avatar_url
+    ) {
+      newPersona.avatar_url = oldPersona.avatar_url;
+    } else {
+      newPersona.avatar_url = await fetchPkitAvatar(mx, pkPersona.avatar_url);
+    }
+  }
+
+  // if we find a pluralkit match but the id has changed, rename before merge
+  if (oldPersona && oldPersona.id !== newPersona.id)
+    await catalog.rename(oldPersona.id, newPersona.id);
+  await catalog.merge(newPersona);
+}
+
+export async function importPluralkitMembers(
+  mx: MatrixClient,
+  catalog: ProfileCatalog,
+  pkitPersonas: PerMessageProfilePluralkitFormat[],
+  options?: PkImportOptions
+): Promise<void> {
+  for (const pkPersona of pkitPersonas) {
+    // i don't want to deal with the potential for race conditions,
+    // and i'm fine with an import being slow
+    //
+    // oxlint-disable-next-line no-await-in-loop
+    await mergePluralkitProfile(mx, catalog, pkPersona, options);
+  }
+}

--- a/src/app/persona/projection.ts
+++ b/src/app/persona/projection.ts
@@ -1,8 +1,16 @@
 import {
+  MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_CIRCUMFIX_PROPERTY_NAME,
+  MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_SUFFIX_PROPERTY_NAME,
   MATRIX_UNSTABLE_COLORS,
+  MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME,
   MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME,
 } from '$unstable/prefixes';
-import type { PerMessageProfileBeeperFormat, Persona } from './index';
+import type { PerMessageProfileBeeperFormat, Persona, ProfileTrigger } from './index';
+import chroma from 'chroma-js';
+import { ThemeKind } from '$hooks/useTheme';
+import { accessibleColor } from '$plugins/color';
+import { parsePronounsInput } from '$app/utils/pronouns';
+import type { PerMessageProfilePluralkitFormat } from './pluralkit';
 
 export function convertPerMessageProfileToBeeperFormat(
   profile: Persona,
@@ -46,6 +54,85 @@ export function convertBeeperFormatToOurPerMessageProfile(
 /** Projects a stored persona to the fields that may be sent with a message. */
 export function projectPersona(persona: Persona): PerMessageProfileBeeperFormat {
   return convertPerMessageProfileToBeeperFormat(persona, false);
+}
+
+export function convertPluralkitFormatToOurPerMessageProfile(
+  pkitProfile: PerMessageProfilePluralkitFormat,
+  pkitAvatarUrl?: string
+): Persona {
+  // parse colors
+  const color = { [MATRIX_UNSTABLE_COLORS]: {} };
+  if (pkitProfile.color && chroma.valid(pkitProfile.color)) {
+    const lightness = chroma(pkitProfile.color).lab()[0];
+    const should_be_on_dark = lightness > 50;
+    if (should_be_on_dark) {
+      color[MATRIX_UNSTABLE_COLORS] = {
+        on_dark: '#' + pkitProfile.color,
+        on_light: accessibleColor(ThemeKind.Light, pkitProfile.color),
+      };
+    } else {
+      color[MATRIX_UNSTABLE_COLORS] = {
+        on_dark: accessibleColor(ThemeKind.Dark, pkitProfile.color),
+        on_light: '#' + pkitProfile.color,
+      };
+    }
+  }
+
+  // parse proxy tags
+  const trigger: ProfileTrigger = {
+    prefix: [],
+  };
+  if (pkitProfile.proxy_tags) {
+    pkitProfile.proxy_tags.forEach(
+      ({ prefix, suffix }: { prefix: string | null; suffix: string | null }) => {
+        if (prefix && suffix) {
+          (trigger[MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_CIRCUMFIX_PROPERTY_NAME] ??= []).push({
+            prefix,
+            suffix,
+          });
+        } else if (!prefix && suffix) {
+          (trigger[MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_SUFFIX_PROPERTY_NAME] ??= []).push(suffix);
+        } else if (prefix && !suffix) {
+          trigger.prefix.push(prefix);
+        }
+      }
+    );
+  }
+
+  const profile: Persona = {
+    id: pkitProfile.name,
+    displayname: pkitProfile.display_name ?? pkitProfile.name,
+    avatar_url: pkitAvatarUrl,
+    trigger,
+    [MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME]: parsePronounsInput(pkitProfile.pronouns),
+    [MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]: {
+      id: pkitProfile.id,
+      uuid: pkitProfile.uuid,
+      description: pkitProfile.description,
+      avatar_url: pkitProfile.avatar_url,
+    },
+    ...color,
+  };
+
+  if (!profile.avatar_url) delete profile.avatar_url;
+  if (
+    !profile[MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME] ||
+    profile[MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME].length === 0
+  )
+    delete profile[MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME];
+  if (
+    !profile[MATRIX_UNSTABLE_COLORS] ||
+    !profile[MATRIX_UNSTABLE_COLORS].on_dark ||
+    !profile[MATRIX_UNSTABLE_COLORS].on_light
+  )
+    delete profile[MATRIX_UNSTABLE_COLORS];
+  if (!profile[MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?.avatar_url)
+    delete profile[MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?.avatar_url;
+  if (!profile[MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?.description)
+    delete profile[MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?.description;
+  if (!profile[MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?.uuid)
+    delete profile[MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME]?.uuid;
+  return profile;
 }
 
 export function stripPerMessageProfilePlainBody(formatted_body: string, profile?: Persona): string {

--- a/src/app/utils/file.ts
+++ b/src/app/utils/file.ts
@@ -1,0 +1,11 @@
+export const readFileToString = async (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () =>
+      resolve(typeof reader.result === 'string' ? reader.result : '')
+    );
+    reader.addEventListener('error', () => reject(new Error(`Could not read ${file.name}.`)));
+
+    reader.readAsText(file);
+  });
+};

--- a/src/app/utils/settingsSync.ts
+++ b/src/app/utils/settingsSync.ts
@@ -2,6 +2,7 @@ import { sanitizeThemeRemoteTweakFavorites, type Settings } from '$state/setting
 import { isLocalImportTweakUrl } from '../theme/localImportUrls';
 import { sanitizeShortcutOverrides } from '../keyboard/shortcuts';
 import { saveFileToDevice } from './download';
+import { readFileToString } from './file';
 
 /**
  * Keys excluded from cross-device sync.
@@ -178,17 +179,12 @@ export const importSettingsFromJson = (currentSettings: Settings): Promise<Setti
         resolve(null);
         return;
       }
-      const reader = new FileReader();
-      reader.addEventListener('load', (e) => {
-        try {
-          const data = JSON.parse(e.target?.result as string);
-          resolve(deserializeFromSync(data, currentSettings));
-        } catch {
-          resolve(null);
-        }
-      });
-      reader.addEventListener('error', () => resolve(null));
-      reader.readAsText(file);
+
+      readFileToString(file)
+        .then((result) => {
+          resolve(deserializeFromSync(JSON.parse(result), currentSettings));
+        })
+        .catch(() => resolve(null));
     });
     // oncancel is not widely supported; clicking away without selecting resolves naturally via onchange with empty files
     input.click();

--- a/src/unstable/prefixes/msc/profile.ts
+++ b/src/unstable/prefixes/msc/profile.ts
@@ -28,3 +28,6 @@ export const MATRIX_UNSTABLE_COLORS = 'eu.she-a.color';
 
 export const MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_SUFFIX_PROPERTY_NAME = 'net.f0rest.suffix';
 export const MATRIX_SABLE_UNSTABLE_MSC4461_TRIGGER_CIRCUMFIX_PROPERTY_NAME = 'net.f0rest.circumfix';
+
+/** Unstable prefix for pluralkit imports */
+export const MATRIX_UNSTABLE_PROFILE_PKIT_IMPORT_PROPERTY_NAME = 'net.f0rest.pkimport';


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the ability to mass-manage personas. Also adds the ability to import personas from third party 'Pluralkit', to make usage of Sable in replacement/alongside Discord easier for the user.

~~BLOCKED BY #1621~~

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
