### PR TITLE
fix Call room name positioning

### DIFF
--- a/.changeset/fix_for_the_call_room_name_positioning.md
+++ b/.changeset/fix_for_the_call_room_name_positioning.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix for the call room name positioning

--- a/src/app/features/call-status/CallRoomName.tsx
+++ b/src/app/features/call-status/CallRoomName.tsx
@@ -37,7 +37,13 @@ export function CallRoomName({ room }: CallRoomNameProps) {
       variant="Background"
       radii="Pill"
       before={
-        <RoomIcon size="200" joinRule={room.getJoinRule()} roomType={room.getType()} filled />
+        <RoomIcon
+          size="200"
+          joinRule={room.getJoinRule()}
+          roomType={room.getType()}
+          filled
+          style={{ width: 'auto' }}
+        />
       }
       onClick={() => navigateRoom(room.roomId)}
     >


### PR DESCRIPTION
### Description
This is a patch to fix the awkward position of the Element Call's room name in the bottom left corner. I'm very new to everything, so I thought I'd test the waters with a very small change, because I'm really enjoying Sable and want to contribute more in the future.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
