### PR TITLE
fix(timeline): land at the bottom on initial load

### DIFF
--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -653,11 +653,15 @@ export function RoomTimeline({
         initialScrollTimerRef.current = undefined;
         if (processedEventsRef.current.length > 0) {
           scrollToBottom();
-          // Only mark ready once we've successfully scrolled.  If processedEvents
-          // was empty when the timer fired (e.g. the onLifecycle reset cleared the
-          // timeline within the 80 ms window), defer setIsReady until the recovery
-          // effect below fires once events repopulate.
-          setIsReady(true);
+          // Re-scroll after measurement; defer setIsReady to avoid a flash.
+          requestAnimationFrame(() => {
+            if (processedEventsRef.current.length > 0) {
+              scrollToBottom();
+              setIsReady(true);
+            } else {
+              pendingReadyRef.current = true;
+            }
+          });
         } else {
           pendingReadyRef.current = true;
         }
@@ -859,16 +863,18 @@ export function RoomTimeline({
   }, [syncAtBottom, scrollToBottom]);
 
   // Decrypting rows and late-loading images grow without changing eventsLength,
-  // so useTimelineSync's auto-scroll never re-fires for them.
+  // so useTimelineSync's auto-scroll never re-fires for them. Also catches
+  // scrollSize shrinkage from VList's initial over-estimate being corrected
+  // once items are measured.
   const lastScrollSizeRef = useRef(0);
   useLayoutEffect(() => {
     const v = vListRef.current;
     if (!v) return;
 
-    const grew = v.scrollSize > lastScrollSizeRef.current;
+    const changed = v.scrollSize !== lastScrollSizeRef.current;
     lastScrollSizeRef.current = v.scrollSize;
 
-    if (!grew || !atBottomRef.current || !liveTimelineLinkedRef.current) return;
+    if (!changed || !atBottomRef.current || !liveTimelineLinkedRef.current) return;
 
     scrollToBottom();
   });


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes  the timeline looking empty on initial loads

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
