### PR TITLE
Suggest accessible light/dark name colors when not filled

### DIFF
--- a/src/app/features/settings/Persona/PerMessageProfileEditor.tsx
+++ b/src/app/features/settings/Persona/PerMessageProfileEditor.tsx
@@ -29,6 +29,8 @@ import {
   MATRIX_UNSTABLE_COLORS,
   MATRIX_UNSTABLE_PROFILE_PRONOUNS_PROPERTY_NAME,
 } from '$unstable/prefixes';
+import { accessibleColor } from '$plugins/color';
+import { ThemeKind } from '$hooks/useTheme';
 
 type Shorthand = { prefix?: string; suffix?: string };
 type ShorthandRow = Shorthand & { id: string };
@@ -603,8 +605,22 @@ export function PerMessageProfileEditor({
           description="This persona's name color for a dark theme user."
           focusId={`nameColorDarkTheme-${profileId}`}
           current={currentNameColorDark ?? undefined}
+          newNameColor={newNameColorDark ?? undefined}
           onChange={setNewNameColorDark}
         />
+        {!newNameColorLight && newNameColorDark && (
+          <Box direction="Column" alignItems="End">
+            <Button
+              size="300"
+              fill="Soft"
+              onClick={() => {
+                setNewNameColorLight(accessibleColor(ThemeKind.Light, newNameColorDark));
+              }}
+            >
+              <Text size="T200">Create new color from dark theme</Text>
+            </Button>
+          </Box>
+        )}
       </SequenceCard>
       <SequenceCard
         className={SequenceCardStyle}
@@ -617,8 +633,22 @@ export function PerMessageProfileEditor({
           description="This persona's name color for a light theme user."
           focusId={`nameColorLightTheme-${profileId}`}
           current={currentNameColorLight ?? undefined}
+          newNameColor={newNameColorLight ?? undefined}
           onChange={setNewNameColorLight}
         />
+        {!newNameColorDark && newNameColorLight && (
+          <Box direction="Column" alignItems="End">
+            <Button
+              size="300"
+              fill="Soft"
+              onClick={() => {
+                setNewNameColorDark(accessibleColor(ThemeKind.Dark, newNameColorLight));
+              }}
+            >
+              <Text size="T200">Create new color from light theme</Text>
+            </Button>
+          </Box>
+        )}
       </SequenceCard>
       <Box
         direction="Row"

--- a/src/app/features/settings/account/NameColorEditor.tsx
+++ b/src/app/features/settings/account/NameColorEditor.tsx
@@ -11,6 +11,7 @@ type NameColorEditorProps = {
   description?: string;
   focusId?: string;
   current?: string;
+  newNameColor?: string;
   onChange?: (color: string | null) => void;
   onSave?: (color: string | null) => void;
   disabled?: boolean;
@@ -27,18 +28,27 @@ export function NameColorEditor({
   description,
   focusId,
   current,
+  newNameColor,
   onChange,
   onSave,
   disabled,
 }: Readonly<NameColorEditorProps>) {
-  const [tempColor, setTempColor] = useState(stripQuotes(current) || undefined);
+  const [tempColor, setTempColor] = useState(
+    stripQuotes(newNameColor) || stripQuotes(current) || undefined
+  );
   const [hasChanged, setHasChanged] = useState(false);
 
   useEffect(() => {
-    const sanitized = stripQuotes(current);
+    // this condition stops infinite loops on input clear when onChange is changing newColor in outer scope
+    if (!newNameColor && onChange) return;
+    const sanitized = stripQuotes(newNameColor || current);
     if (sanitized) setTempColor(sanitized);
     else setTempColor(undefined);
-  }, [current]);
+  }, [current, newNameColor, onChange]);
+
+  useEffect(() => {
+    setHasChanged(newNameColor !== current);
+  }, [newNameColor, current]);
 
   // Valid in the sense that it should look like an error during input.
   // It's disruptive to the user to immediately present their input as an error.

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -13,7 +13,7 @@ import { useUserProfile } from '$hooks/useUserProfile';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
 import { UserAvatar } from '$components/user-avatar';
 import { useMediaAuthentication } from '$hooks/useMediaAuthentication';
-import { nameInitials } from '$utils/common';
+import { nameInitials, xor } from '$utils/common';
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { useFilePicker } from '$hooks/useFilePicker';
 import { useObjectURL } from '$hooks/useObjectURL';
@@ -40,6 +40,8 @@ import { AnimalCosmetics } from './AnimalCosmetics';
 import * as prefix from '$unstable/prefixes';
 import { confirm } from '$components/confirm/confirm';
 import { AvatarUploadTile } from '$components/avatar-upload-tile/AvatarUploadTile';
+import { accessibleColor } from '$plugins/color';
+import { ThemeKind } from '$hooks/useTheme';
 
 type PronounSet = {
   summary: string;
@@ -426,21 +428,25 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
     [mx, presence]
   );
 
-  const color_on_dark =
+  const colorOnDark =
     profile.nameColors?.on_dark ??
-    (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as ColorSet | undefined)?.on_dark;
-  const color_on_light =
+    (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as ColorSet | undefined)?.on_dark ??
+    null;
+  const colorOnLight =
     profile.nameColors?.on_light ??
-    (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as ColorSet | undefined)?.on_light;
+    (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as ColorSet | undefined)?.on_light ??
+    null;
+  const [newColorOnDark, setNewColorOnDark] = useState<string | null>(null);
+  const [newColorOnLight, setNewColorOnLight] = useState<string | null>(null);
 
   // Deletes the depricated key, the color specific ones should be depricated too at a later date
   if (profile.nameColor || (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as string)) {
     const fallback =
       profile.nameColor ?? (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as string);
-    if (!color_on_light || !color_on_dark)
+    if (!newColorOnLight || !newColorOnDark)
       handleSaveField(prefix.MATRIX_UNSTABLE_COLORS, {
-        on_dark: color_on_dark ?? fallback,
-        on_light: color_on_light ?? fallback,
+        on_dark: newColorOnDark ?? fallback,
+        on_light: newColorOnLight ?? fallback,
       });
     handleSaveField(prefix.MATRIX_SABLE_UNSTABLE_NAME_COLOR_PROPERTY_NAME, null);
   }
@@ -466,11 +472,13 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
           title="Dark theme Global Name Color"
           description="Your name's color for a dark theme user."
           focusId="name-color-dark-theme"
-          current={color_on_dark}
+          current={colorOnDark ?? undefined}
+          newNameColor={newColorOnDark ?? undefined}
+          onChange={setNewColorOnDark}
           onSave={(color) =>
             handleSaveField(prefix.MATRIX_UNSTABLE_COLORS, {
               on_dark: color,
-              on_light: color_on_light,
+              on_light: newColorOnLight,
             })
           }
         />
@@ -478,14 +486,42 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
           title="Light theme Global Name Color"
           description="Your name's color for a light theme user."
           focusId="name-color-light-theme"
-          current={color_on_light}
+          current={colorOnLight ?? undefined}
+          newNameColor={newColorOnLight ?? undefined}
+          onChange={setNewColorOnLight}
           onSave={(color) =>
             handleSaveField(prefix.MATRIX_UNSTABLE_COLORS, {
-              on_dark: color_on_dark,
+              on_dark: newColorOnDark,
               on_light: color,
             })
           }
         />
+        {xor(newColorOnDark, newColorOnLight) && (
+          <Box direction="Column" alignItems="End">
+            {!newColorOnDark && newColorOnLight && (
+              <Button
+                size="300"
+                fill="Soft"
+                onClick={() => {
+                  setNewColorOnDark(accessibleColor(ThemeKind.Dark, newColorOnLight));
+                }}
+              >
+                <Text size="T200">Create new color from light theme</Text>
+              </Button>
+            )}
+            {newColorOnDark && !newColorOnLight && (
+              <Button
+                size="300"
+                fill="Soft"
+                onClick={() => {
+                  setNewColorOnLight(accessibleColor(ThemeKind.Light, newColorOnDark));
+                }}
+              >
+                <Text size="T200">Create new color from dark theme</Text>
+              </Button>
+            )}
+          </Box>
+        )}
       </SequenceCard>
       <SequenceCard
         className={SequenceCardStyle}

--- a/src/app/utils/common.ts
+++ b/src/app/utils/common.ts
@@ -151,3 +151,7 @@ export const splitWithSpace = (content: string): string[] => {
   if (trimmedContent === '') return [];
   return trimmedContent.split(' ');
 };
+
+export const xor = (left: unknown, right: unknown): boolean => {
+  return !left !== !right;
+};


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Suggest accessible name colors to hopefully encourage people to make name colors easier to read in certain theme kinds.

<img width="554" height="192" alt="image" src="https://github.com/user-attachments/assets/dfb741f1-8843-4544-97bb-c79c904f0675" />


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
