### PR TITLE
fix(a11y): correct name colors by default and stop the legacy color migration overwriting saved colors

### DIFF
--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEventHandler, FormEventHandler } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text, IconButton, Input, Avatar, Button, config, Spinner } from 'folds';
 import { menuIcon, Star, Sun, X } from '$components/icons/phosphor';
 import { useSetAtom } from 'jotai';
@@ -440,16 +440,23 @@ function ProfileExtended({ profile, userId }: Readonly<ProfileProps>) {
   const [newColorOnLight, setNewColorOnLight] = useState<string | null>(null);
 
   // Deletes the depricated key, the color specific ones should be depricated too at a later date
-  if (profile.nameColor || (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as string)) {
-    const fallback =
-      profile.nameColor ?? (profile.extended?.[prefix.MATRIX_UNSTABLE_COLORS] as string);
-    if (!newColorOnLight || !newColorOnDark)
-      handleSaveField(prefix.MATRIX_UNSTABLE_COLORS, {
-        on_dark: newColorOnDark ?? fallback,
-        on_light: newColorOnLight ?? fallback,
-      });
-    handleSaveField(prefix.MATRIX_SABLE_UNSTABLE_NAME_COLOR_PROPERTY_NAME, null);
-  }
+  const legacyColor = profile.nameColor;
+  const migratedLegacyColor = useRef(false);
+  useEffect(() => {
+    if (!legacyColor || migratedLegacyColor.current) return;
+    migratedLegacyColor.current = true;
+
+    const migrate = async () => {
+      if (!colorOnDark || !colorOnLight) {
+        await handleSaveField(prefix.MATRIX_UNSTABLE_COLORS, {
+          on_dark: colorOnDark ?? legacyColor,
+          on_light: colorOnLight ?? legacyColor,
+        });
+      }
+      await handleSaveField(prefix.MATRIX_SABLE_UNSTABLE_NAME_COLOR_PROPERTY_NAME, null);
+    };
+    migrate();
+  }, [legacyColor, colorOnDark, colorOnLight, handleSaveField]);
 
   return (
     <Box direction="Column" gap="100">

--- a/src/app/state/settings.defaults.test.ts
+++ b/src/app/state/settings.defaults.test.ts
@@ -32,6 +32,25 @@ describe('mergePersistedSettings', () => {
     expect(merged.saturationLevel).toBe(0);
   });
 
+  it('seeds the name color correction once for clients persisted before the migration', () => {
+    localStorage.setItem('settings', JSON.stringify({ nameColorLightnessCorrection: 'off' }));
+    const merged = mergePersistedSettings(localStorage.getItem('settings'), {});
+    expect(merged.nameColorLightnessCorrection).toBe('strong');
+    expect(merged.nameColorLightnessCorrectionMigrated).toBe(true);
+  });
+
+  it('keeps the name color correction once the migration has run', () => {
+    localStorage.setItem(
+      'settings',
+      JSON.stringify({
+        nameColorLightnessCorrection: 'off',
+        nameColorLightnessCorrectionMigrated: true,
+      })
+    );
+    const merged = mergePersistedSettings(localStorage.getItem('settings'), {});
+    expect(merged.nameColorLightnessCorrection).toBe('off');
+  });
+
   it('migrates persisted ringtone preferences to valid values', () => {
     localStorage.setItem(
       'settings',

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -264,6 +264,7 @@ export interface Settings {
   autoplayStickers: boolean;
   autoplayEmojis: boolean;
   nameColorLightnessCorrection: 'off' | 'weak' | 'strong';
+  nameColorLightnessCorrectionMigrated: boolean;
 
   // furry stuff
   renderAnimals: boolean;
@@ -446,7 +447,8 @@ export const defaultSettings: Settings = {
   widgetSidebarWidth: 420,
   isShowingAllRoomsInHome: false,
   sendIndividualAttachmentAsCaption: true,
-  nameColorLightnessCorrection: 'off',
+  nameColorLightnessCorrection: 'strong',
+  nameColorLightnessCorrectionMigrated: true,
 
   // furry stuff
   renderAnimals: true,
@@ -513,6 +515,17 @@ function migrateParsedLocalStorage(parsed: Record<string, unknown>): void {
     parsed.saturationLevel = 100;
   }
   delete parsed.monochromeMode;
+
+  if (parsed.nameColorLightnessCorrectionMigrated !== true) {
+    delete parsed.nameColorLightnessCorrection;
+    parsed.nameColorLightnessCorrectionMigrated = true;
+  } else if (
+    parsed.nameColorLightnessCorrection !== 'off' &&
+    parsed.nameColorLightnessCorrection !== 'weak' &&
+    parsed.nameColorLightnessCorrection !== 'strong'
+  ) {
+    delete parsed.nameColorLightnessCorrection;
+  }
 
   if (typeof parsed.renderUserCards === 'boolean') {
     parsed.renderUserCards = parsed.renderUserCards ? 'both' : 'none';


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->
### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
