### PR TITLE
fix(tauri): limit single-instance thread hop to windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,13 +281,26 @@ pub fn run() {
     // this should always be the first
     #[cfg(desktop)]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-        let handle = app.clone();
-        std::thread::spawn(move || {
-            let app_handle = handle.clone();
-            let _ = handle.run_on_main_thread(move || {
-                let _ = show_or_create_main_window(&app_handle);
+        #[cfg(windows)]
+        {
+            let handle = app.clone();
+            std::thread::spawn(move || {
+                let app_handle = handle.clone();
+                let scheduled = handle.run_on_main_thread(move || {
+                    if let Err(error) = show_or_create_main_window(&app_handle) {
+                        log::warn!("Failed to show main window for second instance: {error}");
+                    }
+                });
+                if let Err(error) = scheduled {
+                    log::warn!("Failed to schedule main window show for second instance: {error}");
+                }
             });
-        });
+        }
+
+        #[cfg(not(windows))]
+        if let Err(error) = show_or_create_main_window(app) {
+            log::warn!("Failed to show main window for second instance: {error}");
+        }
     }));
 
     // macOS needs a standard menu (with the Edit submenu) for keyboard


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
