### PR TITLE
Remove less useful menu

### DIFF
--- a/src/app/pages/client/SidebarNav.tsx
+++ b/src/app/pages/client/SidebarNav.tsx
@@ -39,65 +39,71 @@ export function SidebarNav() {
   return (
     <>
       <Sidebar onContextMenu={handleSidebarContextMenu}>
-        <ResponsiveMenu
-          anchor={sidebarMenu.anchor}
-          position="Right"
-          align="Start"
-          requestClose={sidebarMenu.close}
-          menu={
-            <Menu style={{ maxWidth: toRem(208), width: '100vw' }}>
-              <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
-                <MenuItem
-                  size="300"
-                  radii="300"
-                  aria-pressed={showUnreadCounts}
-                  onClick={() => setShowUnreadCounts(!showUnreadCounts)}
-                  after={<Checkbox size="100" checked={showUnreadCounts} readOnly tabIndex={-1} />}
-                >
-                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
-                    Show Room Counts
-                  </Text>
-                </MenuItem>
-                <MenuItem
-                  size="300"
-                  radii="300"
-                  aria-pressed={badgeCountDMsOnly}
-                  onClick={() => setBadgeCountDMsOnly(!badgeCountDMsOnly)}
-                  after={<Checkbox size="100" checked={badgeCountDMsOnly} readOnly tabIndex={-1} />}
-                >
-                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
-                    Show DM Counts
-                  </Text>
-                </MenuItem>
-                <MenuItem
-                  size="300"
-                  radii="300"
-                  aria-pressed={showPingCounts}
-                  onClick={() => setShowPingCounts(!showPingCounts)}
-                  after={<Checkbox size="100" checked={showPingCounts} readOnly tabIndex={-1} />}
-                >
-                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
-                    Show Mention Counts
-                  </Text>
-                </MenuItem>
-              </Box>
-              <Line variant="Surface" size="300" />
-              <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
-                <MenuItem
-                  size="300"
-                  radii="300"
-                  aria-pressed={uniformIcons}
-                  onClick={() => setUniformIcons(!uniformIcons)}
-                  after={<Checkbox size="100" checked={uniformIcons} readOnly tabIndex={-1} />}
-                >
-                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
-                    Consistent Icon Style
-                  </Text>
-                </MenuItem>
-              </Box>
-            </Menu>
-          }
-        />
+        {!compact && (
+          <ResponsiveMenu
+            anchor={sidebarMenu.anchor}
+            position="Right"
+            align="Start"
+            requestClose={sidebarMenu.close}
+            menu={
+              <Menu style={{ maxWidth: toRem(208), width: '100vw' }}>
+                <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                  <MenuItem
+                    size="300"
+                    radii="300"
+                    aria-pressed={showUnreadCounts}
+                    onClick={() => setShowUnreadCounts(!showUnreadCounts)}
+                    after={
+                      <Checkbox size="100" checked={showUnreadCounts} readOnly tabIndex={-1} />
+                    }
+                  >
+                    <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                      Show Room Counts
+                    </Text>
+                  </MenuItem>
+                  <MenuItem
+                    size="300"
+                    radii="300"
+                    aria-pressed={badgeCountDMsOnly}
+                    onClick={() => setBadgeCountDMsOnly(!badgeCountDMsOnly)}
+                    after={
+                      <Checkbox size="100" checked={badgeCountDMsOnly} readOnly tabIndex={-1} />
+                    }
+                  >
+                    <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                      Show DM Counts
+                    </Text>
+                  </MenuItem>
+                  <MenuItem
+                    size="300"
+                    radii="300"
+                    aria-pressed={showPingCounts}
+                    onClick={() => setShowPingCounts(!showPingCounts)}
+                    after={<Checkbox size="100" checked={showPingCounts} readOnly tabIndex={-1} />}
+                  >
+                    <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                      Show Mention Counts
+                    </Text>
+                  </MenuItem>
+                </Box>
+                <Line variant="Surface" size="300" />
+                <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                  <MenuItem
+                    size="300"
+                    radii="300"
+                    aria-pressed={uniformIcons}
+                    onClick={() => setUniformIcons(!uniformIcons)}
+                    after={<Checkbox size="100" checked={uniformIcons} readOnly tabIndex={-1} />}
+                  >
+                    <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                      Consistent Icon Style
+                    </Text>
+                  </MenuItem>
+                </Box>
+              </Menu>
+            }
+          />
+        )}
         <SidebarContent
           scrollable={
             <Scroll ref={scrollRef} variant="Background" size="0">


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Remove the Show room count menu from mobile since these are settings that may be changes from the settings and that is the regular behavior of most settings, and so that the menu that is specific to each space is readily accessible

(its just adding {compact && (...)} but the formatting found more lines to collapse inshallah

Fixes #1680 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
Written w the assistance of the formatter to just tab most things for the small change fr