### PR TITLE
Fix persona picker showing while editing message on mobile

### DIFF
--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -2356,7 +2356,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                   </IconButton>
                 </>
               )}
-              {pmpPickerEnable && (
+              {pmpPickerEnable && !editingEvent && (
                 <PersistentPersonaPicker
                   tab={personaPickerTab}
                   mx={mx}


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Previously, when editing a message on mobile, the persona picker was displayed. However, the picker has no effect on the edited message which may be confusing to users (me). This change hides the picker when editing a message.

<img width="512" height="120" alt="image" src="https://github.com/user-attachments/assets/6e93ce78-72f0-4105-b916-809e196907bd" />
<img width="515" height="155" alt="image" src="https://github.com/user-attachments/assets/9d7028b7-7d1c-4b42-a817-a973e8c25ee4" />

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
