### PR TITLE
Fix inbox badge counting rooms twice via space aggregates

### DIFF
--- a/src/app/hooks/useInboxNotificationCount.test.ts
+++ b/src/app/hooks/useInboxNotificationCount.test.ts
@@ -20,4 +20,19 @@ describe('countInboxNotifications', () => {
 
     expect(countInboxNotifications(rooms, unread, new Set(['!dm']))).toBe(6);
   });
+
+  it('skips space rooms so aggregated space counts are not double-counted', () => {
+    const space = {
+      roomId: '!space',
+      isSpaceRoom: () => true,
+      getJoinedMemberCount: () => 3,
+    } as unknown as Room;
+    const rooms = [room('!room'), space];
+    const unread = new Map([
+      ['!room', { total: 4, highlight: 1, from: null }],
+      ['!space', { total: 4, highlight: 1, from: new Set(['!room']) }],
+    ]) as RoomToUnread;
+
+    expect(countInboxNotifications(rooms, unread, new Set())).toBe(1);
+  });
 });

--- a/src/app/hooks/useInboxNotificationCount.ts
+++ b/src/app/hooks/useInboxNotificationCount.ts
@@ -13,6 +13,7 @@ export const countInboxNotifications = (
   mDirects: Set<string>
 ): number =>
   rooms.reduce((count, room) => {
+    if (room.isSpaceRoom()) return count;
     const unread = roomToUnread.get(room.roomId);
     if (!unread) return count;
     return count + (isDMRoom(room, mDirects) ? unread.total : unread.highlight);


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
