### PR TITLE
Add hack to fetch profiles when Picker is first loaded.

### DIFF
--- a/src/app/features/room/persona-picker/PersonaPicker.test.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MatrixClient } from 'matrix-js-sdk';
+import { ClientEvent, type MatrixClient, type MatrixEvent } from 'matrix-js-sdk';
 import type { PerMessageProfileMsc4461 } from '$app/persona';
+import { MATRIX_SABLE_UNSTABLE_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME } from '$unstable/prefixes';
 import { PersonaPicker, PersonaPickerTab, useProfiles } from './PersonaPicker';
 
 const mocked = vi.hoisted(() => ({
@@ -21,6 +22,9 @@ const grabPersonaButton = (name: string) => {
 };
 
 vi.mock('$app/persona/catalog', () => ({
+  isPersonaAccountDataEvent: (eventType: string) =>
+    eventType === 'fi.mau.msc4461.per_message_profiles.v2' ||
+    eventType.startsWith('fyi.cisnt.permessageprofile.'),
   ProfileCatalog: class {
     constructor(private readonly mx: MatrixClient) {}
 
@@ -135,7 +139,25 @@ const profiles: PerMessageProfileMsc4461[] = [
   { id: 'second', displayname: 'Second', trigger: { prefix: [] } },
 ];
 
-function renderPicker(mx = {} as MatrixClient, tab = PersonaPickerTab.Global) {
+type TestMatrixClient = MatrixClient & { emitAccountData: (type: string) => void };
+
+function createMatrixClient(): TestMatrixClient {
+  const accountDataHandlers = new Set<(event: MatrixEvent) => void>();
+  return {
+    on(event: ClientEvent, handler: (accountData: MatrixEvent) => void) {
+      if (event === ClientEvent.AccountData) accountDataHandlers.add(handler);
+    },
+    removeListener(event: ClientEvent, handler: (accountData: MatrixEvent) => void) {
+      if (event === ClientEvent.AccountData) accountDataHandlers.delete(handler);
+    },
+    emitAccountData(type: string) {
+      const accountData = { getType: () => type } as MatrixEvent;
+      accountDataHandlers.forEach((handler) => handler(accountData));
+    },
+  } as TestMatrixClient;
+}
+
+function renderPicker(mx: MatrixClient = createMatrixClient(), tab = PersonaPickerTab.Global) {
   return render(
     <PersonaPicker
       tab={tab}
@@ -159,8 +181,8 @@ describe('PersonaPicker async flows', () => {
   });
 
   it('ignores a stale profile fetch after the client changes', async () => {
-    const firstClient = {} as MatrixClient;
-    const secondClient = {} as MatrixClient;
+    const firstClient = createMatrixClient();
+    const secondClient = createMatrixClient();
     const firstFetch = deferred<PerMessageProfileMsc4461[]>();
     const secondFetch = deferred<PerMessageProfileMsc4461[]>();
     mocked.getAll.mockImplementation((client: MatrixClient) =>
@@ -186,6 +208,23 @@ describe('PersonaPicker async flows', () => {
     });
 
     expect(view.result.current.profiles?.[0]?.id).toBe('new');
+  });
+
+  it('refreshes profiles when persona account data arrives after initial sync', async () => {
+    const mx = createMatrixClient();
+    mocked.getAll.mockResolvedValueOnce([]).mockResolvedValueOnce(profiles);
+    const mountedRef = { current: true };
+    const generationRef = { current: 0 };
+    const view = renderHook(() => useProfiles(mx, mountedRef, generationRef));
+
+    await waitFor(() => expect(view.result.current.profiles).toEqual([]));
+    act(() => {
+      mx.emitAccountData(
+        `${MATRIX_SABLE_UNSTABLE_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME}.index`
+      );
+    });
+
+    await waitFor(() => expect(view.result.current.profiles).toEqual(profiles));
   });
 
   it('does not update state when an in-flight profile fetch resolves after unmount', async () => {
@@ -246,7 +285,7 @@ describe('PersonaPicker async flows', () => {
   });
 
   it('rolls back a failed global selection without suppressing a room selection', async () => {
-    const mx = {} as MatrixClient;
+    const mx = createMatrixClient();
     const globalWrite = deferred<void>();
     const roomWrite = deferred<void>();
     mocked.setAccount.mockImplementationOnce(() => globalWrite.promise);

--- a/src/app/features/room/persona-picker/PersonaPicker.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.tsx
@@ -261,7 +261,7 @@ export function PersonaPicker({
   const mountedRef = useRef(false);
   const profileFetchGenerationRef = useRef(0);
 
-  const { profiles } = useProfiles(mx, mountedRef, profileFetchGenerationRef);
+  const { profiles, fetchProfiles } = useProfiles(mx, mountedRef, profileFetchGenerationRef);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { filteredProfiles, filter, clearFilter } = useFilteredProfiles(
@@ -433,6 +433,7 @@ export function PersonaPicker({
       <IconButton
         aria-pressed={!!AddPersonaMenuAnchor}
         onClick={(evt) => {
+          if (profiles && profiles.length === 0) fetchProfiles(); // HACK: Sometimes getting this fails on first load.
           setAddPersonaMenuAnchor(evt.currentTarget.getBoundingClientRect());
         }}
         onPointerDown={suppressEditorRefocus}

--- a/src/app/features/room/persona-picker/PersonaPicker.tsx
+++ b/src/app/features/room/persona-picker/PersonaPicker.tsx
@@ -7,7 +7,8 @@ import {
 import { ResponsiveMenu } from '$components/ResponsiveMenu';
 import { UserAvatar } from '$components/user-avatar/UserAvatar.tsx';
 import type { PerMessageProfileMsc4461, Persona } from '$app/persona';
-import { ProfileCatalog } from '$app/persona/catalog';
+import { isPersonaAccountDataEvent, ProfileCatalog } from '$app/persona/catalog';
+import { useAccountDataCallback } from '$hooks/useAccountDataCallback';
 import { isMobileOrTablet } from '$utils/platform';
 import { nameInitials } from '$utils/common';
 import {
@@ -103,6 +104,16 @@ export function useProfiles(
     };
   }, [fetchProfiles, profileFetchGenerationRef]);
 
+  useAccountDataCallback(
+    mx,
+    useCallback(
+      (event) => {
+        if (isPersonaAccountDataEvent(event.getType())) void fetchProfiles();
+      },
+      [fetchProfiles]
+    )
+  );
+
   return { profiles, fetchProfiles };
 }
 
@@ -172,6 +183,15 @@ function useSelectedProfiles(
   // per-room selections are independent, so one must not invalidate the other's rollback.
   const globalSelectionRef = useRef(0);
   const roomSelectionRef = useRef(0);
+  const [accountDataGeneration, setAccountDataGeneration] = useState(0);
+
+  useAccountDataCallback(
+    mx,
+    useCallback((event) => {
+      if (isPersonaAccountDataEvent(event.getType()))
+        setAccountDataGeneration((generation) => generation + 1);
+    }, [])
+  );
 
   const toggle = async (profile: Persona, isGlobal: boolean) => {
     const previousPersona = isGlobal ? selectedGlobalPersona : selectedRoomPersona;
@@ -237,7 +257,7 @@ function useSelectedProfiles(
     return () => {
       cancelled = true;
     };
-  }, [mx, roomId, latchedPersona, selectedRoomPersona]);
+  }, [mx, roomId, latchedPersona, selectedRoomPersona, accountDataGeneration]);
 
   return {
     room: selectedRoomPersona,
@@ -261,7 +281,7 @@ export function PersonaPicker({
   const mountedRef = useRef(false);
   const profileFetchGenerationRef = useRef(0);
 
-  const { profiles, fetchProfiles } = useProfiles(mx, mountedRef, profileFetchGenerationRef);
+  const { profiles } = useProfiles(mx, mountedRef, profileFetchGenerationRef);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { filteredProfiles, filter, clearFilter } = useFilteredProfiles(
@@ -433,7 +453,6 @@ export function PersonaPicker({
       <IconButton
         aria-pressed={!!AddPersonaMenuAnchor}
         onClick={(evt) => {
-          if (profiles && profiles.length === 0) fetchProfiles(); // HACK: Sometimes getting this fails on first load.
           setAddPersonaMenuAnchor(evt.currentTarget.getBoundingClientRect());
         }}
         onPointerDown={suppressEditorRefocus}

--- a/src/app/features/settings/Persona/PerMessageProfileOverview.tsx
+++ b/src/app/features/settings/Persona/PerMessageProfileOverview.tsx
@@ -6,6 +6,8 @@ import {
   getPerMessageProfileById,
   ProfileCatalog,
 } from '$hooks/usePerMessageProfile';
+import { isPersonaAccountDataEvent } from '$app/persona/catalog';
+import { useAccountDataCallback } from '$hooks/useAccountDataCallback';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Box, Button, color, config, Dialog, Header, Spinner, Switch, Text } from 'folds';
 import { generateShortId } from '$utils/shortIdGen';
@@ -54,6 +56,17 @@ export function PerMessageProfileOverview({
     };
     fetchProfiles();
   }, [mx]);
+
+  useAccountDataCallback(
+    mx,
+    useCallback(
+      (event) => {
+        if (!isPersonaAccountDataEvent(event.getType())) return;
+        void getAllPerMessageProfiles(mx).then(setProfiles);
+      },
+      [mx]
+    )
+  );
 
   const handleEdit = async (profileId: string) => {
     const profile = await getPerMessageProfileById(mx, profileId);

--- a/src/app/persona/catalog.ts
+++ b/src/app/persona/catalog.ts
@@ -84,6 +84,13 @@ type ProxyAssociationWrapper = {
   compat?: AccountDataCompatVersion;
 };
 
+export function isPersonaAccountDataEvent(eventType: string) {
+  return (
+    eventType === MATRIX_UNSTABLE_MSC4461_ACCOUNT_PER_MESSAGE_PROFILES_PROPERTY_NAME ||
+    eventType.startsWith(`${ACCOUNT_DATA_PREFIX}.`)
+  );
+}
+
 function accountData(mx: MatrixClient, eventType: string) {
   return mx.getAccountData(eventType as Parameters<typeof mx.getAccountData>[0]);
 }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Sometimes profiles are fetched as an empty list, so this refetches if that is the case.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
