### PR TITLE
fix: horizontal scrolling triggering swipe gestures

### DIFF
--- a/.changeset/fix_swiping_in_attachment_list.md
+++ b/.changeset/fix_swiping_in_attachment_list.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix swiping in attachment list

--- a/src/app/components/editor/MarkdownToolbar.tsx
+++ b/src/app/components/editor/MarkdownToolbar.tsx
@@ -242,7 +242,7 @@ function MarkdownToolbar() {
 
   return (
     <Box className={`${css.EditorToolbarBase} ${floatingToolbar}`}>
-      <Scroll direction="Horizontal" size="0">
+      <Scroll direction="Horizontal" size="0" data-gestures="scroll">
         <Box className={css.EditorToolbar} alignItems="Center" gap="300">
           <Box shrink="No" gap="100">
             <MarkdownInlineButton

--- a/src/app/components/page/MobileNavDrawer.test.tsx
+++ b/src/app/components/page/MobileNavDrawer.test.tsx
@@ -43,6 +43,42 @@ const touchList = (target: HTMLElement, clientX: number, clientY: number) => {
   return { touches: [point], targetTouches: [point], changedTouches: [point] };
 };
 
+function ChatSwipeProbe({
+  scrollerWidth,
+  contentsWidth,
+  move,
+}: {
+  scrollerWidth: number;
+  contentsWidth: number;
+  move: (distanceX: number) => void;
+}) {
+  const drawer = useMobileNavDrawer();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el || !drawer) return undefined;
+    return drawer.registerChatSwipe(el, {
+      move,
+      end: vi.fn<(gesture: { distanceX: number; velocityX: number }) => void>(),
+      cancel: vi.fn<() => void>(),
+    });
+  }, [drawer, move]);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    vi.spyOn(el, 'clientWidth', 'get').mockReturnValue(scrollerWidth);
+    vi.spyOn(el, 'scrollWidth', 'get').mockReturnValue(contentsWidth);
+  }, [scrollerWidth, contentsWidth]);
+  return (
+    <div ref={containerRef} data-chat-swipe data-gestures="ignore">
+      <div ref={scrollRef} data-gestures="scroll">
+        <div data-testid="scrollContents">hi</div>
+      </div>
+    </div>
+  );
+}
+
 describe('MobileNavDrawer', () => {
   // The panels sit side by side in a track twice the viewport wide, moved by transform.
   // `hidden` leaves a scrollport that focus or scrollIntoView scrolls a full panel width,
@@ -93,5 +129,47 @@ describe('MobileNavDrawer', () => {
     fireEvent.touchMove(image, touchList(image, 200, 100));
 
     expect(move).toHaveBeenCalled();
+  });
+
+  describe('Scroll swipe gesture', () => {
+    it('should call chat swipe when swiping on a non-scrollable scrolling element', () => {
+      const move = vi.fn<(distanceX: number) => void>();
+
+      render(
+        <MemoryRouter initialEntries={['/home']}>
+          <MobileNavDrawer
+            nav={<ChatSwipeProbe scrollerWidth={100} contentsWidth={50} move={move} />}
+          >
+            <div>content</div>
+          </MobileNavDrawer>
+        </MemoryRouter>
+      );
+
+      const image = screen.getByTestId('scrollContents');
+      fireEvent.touchStart(image, touchList(image, 260, 100));
+      fireEvent.touchMove(image, touchList(image, 200, 100));
+
+      expect(move).toHaveBeenCalled();
+    });
+
+    it('should not call chat swipe when swiping on a scrollable scrolling element', () => {
+      const move = vi.fn<(distanceX: number) => void>();
+
+      render(
+        <MemoryRouter initialEntries={['/home']}>
+          <MobileNavDrawer
+            nav={<ChatSwipeProbe scrollerWidth={100} contentsWidth={150} move={move} />}
+          >
+            <div>content</div>
+          </MobileNavDrawer>
+        </MemoryRouter>
+      );
+
+      const image = screen.getByTestId('scrollContents');
+      fireEvent.touchStart(image, touchList(image, 260, 100));
+      fireEvent.touchMove(image, touchList(image, 200, 100));
+
+      expect(move).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/components/page/MobileNavDrawer.tsx
+++ b/src/app/components/page/MobileNavDrawer.tsx
@@ -351,14 +351,21 @@ export function MobileNavDrawer({ nav, rail, bottomNav, children }: MobileNavDra
         const messageElement = target.closest<HTMLElement>('[data-message-swipe]');
         const chatElement = target.closest<HTMLElement>('[data-chat-swipe]');
         const ignoredElement = target.closest<HTMLElement>('[data-gestures="ignore"]');
+        const scrollingElement = target.closest<HTMLElement>('[data-gestures="scroll"]');
         const message = messageElement ? messageTargetsRef.current.get(messageElement) : undefined;
         const chat = chatElement ? chatTargetsRef.current.get(chatElement) : undefined;
         // Nested ignore markers (e.g. inline media) don't block swipe if they're part of
         // this message/chat's own surface, only if they sit outside it.
-        const blocked =
+        const blockedIgnored =
           ignoredElement !== null &&
           !(messageElement && messageElement.contains(ignoredElement)) &&
           !(chatElement && chatElement.contains(ignoredElement));
+
+        // If the element is horizontally scrollable (scrollWidth > clientWidth), block gestures
+        const blockedScroll =
+          scrollingElement !== null && scrollingElement.scrollWidth > scrollingElement.clientWidth;
+
+        const blocked = blockedScroll || blockedIgnored;
 
         gestureRef.current = {
           startX: touch.clientX,

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -432,7 +432,14 @@ export const UrlPreviewHolder = as<'div'>(({ children, ...props }, ref) => {
       ref={ref}
       style={{ marginTop: config.space.S200, position: 'relative' }}
     >
-      <Scroll ref={scrollRef} direction="Horizontal" size="0" visibility="Hover" hideTrack>
+      <Scroll
+        ref={scrollRef}
+        direction="Horizontal"
+        size="0"
+        visibility="Hover"
+        hideTrack
+        data-gestures="scroll"
+      >
         <Box shrink="No" alignItems="Center">
           {canScrollLeft && (
             <>

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -2052,7 +2052,13 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                   }
                 >
                   {uploadBoard && (
-                    <Scroll direction="Horizontal" size="300" hideTrack visibility="Hover">
+                    <Scroll
+                      direction="Horizontal"
+                      size="300"
+                      hideTrack
+                      visibility="Hover"
+                      data-gestures="scroll"
+                    >
                       <UploadBoardContent>
                         {Array.from(selectedFiles)
                           .toReversed()


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

When starting a gesture, check first if the user is trying to scroll something horizontally, and if so don't trigger the gesture.

Tested on firefox mobile devtools and tauri android.

Fixes #1734

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
