### PR TITLE
fix: save Android gallery images from source URL

### DIFF
--- a/src/app/components/image-viewer/ImageViewer.test.tsx
+++ b/src/app/components/image-viewer/ImageViewer.test.tsx
@@ -193,6 +193,21 @@ describe('ImageViewer', () => {
     expect(screen.getByText('Save to Gallery')).toBeInTheDocument();
   });
 
+  it("saves the Matrix source behind Android's sable-media URL to the gallery", async () => {
+    mockPlatform('android');
+    const source = 'https://matrix.example.org/_matrix/client/v1/media/download/example.org/kitten';
+    const src = `https://sable-media.localhost/${encodeURIComponent(source)}?__sable_media_cache=3`;
+    saveMediaToGallery.mockClear();
+
+    renderViewer({ src, info: { mimetype: 'image/png' } });
+    fireEvent.contextMenu(screen.getByAltText('kitten.png'));
+    fireEvent.click(screen.getByText('Save to Gallery'));
+
+    await waitFor(() =>
+      expect(saveMediaToGallery).toHaveBeenCalledWith(source, 'kitten.png', 'image/png')
+    );
+  });
+
   it('labels the primary action Save to Photos on iOS without duplicating it in the overflow menu', () => {
     mockPlatform('ios');
 

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -234,7 +234,11 @@ export const ImageViewer = as<'div', ImageViewerProps>(
     const nextActivation = useMobileTapActivation(isMobile, () => onNext?.());
     const galleryActivation = useMobileTapActivation(isMobile, () => {
       closeMenu();
-      void saveMediaToGallery(src, downloadFilename, galleryMimeType!);
+      void saveMediaToGallery(
+        getTauriMediaSourceUrl(src) ?? src,
+        downloadFilename,
+        galleryMimeType!
+      );
     });
     const resetZoomMenuActivation = useMobileTapActivation(isMobile, () => {
       resetTransforms();

--- a/src/app/utils/download.test.ts
+++ b/src/app/utils/download.test.ts
@@ -169,6 +169,42 @@ describe('saveMediaToGallery', () => {
     expect(showToast).toHaveBeenCalledWith('Saved to Gallery');
   });
 
+  it('writes all fetched Android image bytes before publishing the gallery file', async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    mocks.fetch.mockResolvedValueOnce(new Response(bytes, { status: 200 }));
+
+    await saveMediaToGallery('https://matrix.example.org/photo', 'photo.png', 'image/png');
+
+    expect(androidFs.writeFile).toHaveBeenCalledWith('content://media/image', bytes);
+    expect(androidFs.writeFile.mock.invocationCallOrder[0]).toBeLessThan(
+      androidFs.setPublicFilePending.mock.invocationCallOrder[0]!
+    );
+    expect(androidFs.setPublicFilePending).toHaveBeenCalledWith('content://media/image', false);
+  });
+
+  it('does not create a gallery file when Android storage permission is denied', async () => {
+    androidFs.checkPublicFilesPermission.mockResolvedValue(false);
+    androidFs.requestPublicFilesPermission.mockResolvedValue(false);
+
+    await saveMediaToGallery(new Blob(['data']), 'photo.png', 'image/png');
+
+    expect(androidFs.createNewPublicImageFile).not.toHaveBeenCalled();
+    expect(androidFs.writeFile).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(
+      'Failed to save to gallery: Storage permission was denied'
+    );
+  });
+
+  it('does not clean up when Android fails before creating a gallery file', async () => {
+    androidFs.createNewPublicImageFile.mockRejectedValue(new Error('create failed'));
+
+    await saveMediaToGallery(new Blob(['data']), 'photo.png', 'image/png');
+
+    expect(androidFs.writeFile).not.toHaveBeenCalled();
+    expect(androidFs.removeFile).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith('Failed to save to gallery: create failed');
+  });
+
   it('rejects video media explicitly without touching any backend or falling back', async () => {
     await expect(saveMediaToGallery(new Blob(['data']), 'clip.mp4', 'video/mp4')).rejects.toThrow(
       'Only image media can be saved to the gallery'
@@ -189,6 +225,18 @@ describe('saveMediaToGallery', () => {
     expect(showToast).toHaveBeenCalledWith('Failed to save to gallery: write failed');
     expect(invoke).not.toHaveBeenCalled();
     expect(FileSaver.saveAs).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['publishing', 'setPublicFilePending', new Error('publish failed')],
+    ['scanning', 'scanPublicFile', new Error('scan failed')],
+  ] as const)('cleans up the Android gallery file when %s fails', async (_, method, error) => {
+    androidFs[method].mockRejectedValue(error);
+
+    await saveMediaToGallery(new Blob(['data']), 'photo.png', 'image/png');
+
+    expect(androidFs.removeFile).toHaveBeenCalledWith('content://media/image');
+    expect(showToast).toHaveBeenCalledWith(`Failed to save to gallery: ${error.message}`);
   });
 
   it('sends media bytes to the native Photos command on iOS', async () => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
