### PR TITLE
fix(timeline): preserve bottom anchor on viewport resize

### DIFF
--- a/src/app/features/room/RoomTimeline.test.tsx
+++ b/src/app/features/room/RoomTimeline.test.tsx
@@ -439,6 +439,22 @@ describe('RoomTimeline content ResizeObserver', () => {
     );
   });
 
+  it('re-pins to the bottom when the timeline viewport shrinks while pinned and live', async () => {
+    const { container } = renderTimeline();
+
+    await settleInitialScroll();
+    vListHandle.scrollToIndex.mockClear();
+
+    const timeline = container.querySelector('[data-testid="timeline"]');
+    expect(timeline).toBeTruthy();
+    act(() => fireResize(timeline!));
+
+    expect(vListHandle.scrollToIndex).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({ align: 'end' })
+    );
+  });
+
   it('does not re-pin on content growth after scrolling off the bottom', async () => {
     const { container } = renderTimeline();
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -953,6 +953,7 @@ export function RoomTimeline({
     }
 
     const observer = new ResizeObserver(() => {
+      if (scrollOwnerRef.current === 'live' && atBottomRef.current) scrollToBottom();
       syncAtBottom();
     });
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Keeps a live timeline at the bottom when its viewport resizes, including Android soft-keyboard opening. Adds a regression for a pinned timeline viewport shrink.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
