### PR TITLE
fix: hide desktop updater when disabled

### DIFF
--- a/scripts/tauri.js
+++ b/scripts/tauri.js
@@ -68,6 +68,9 @@ async function main() {
     logger.info('Building without the auto-updater (--no-updater)');
   }
 
+  // The frontend is built before Cargo, so mirror the updater feature into Vite.
+  process.env.VITE_DESKTOP_UPDATER_ENABLED = String(!noUpdater);
+
   const features = noUpdater ? platform : `${platform},updater`;
   const args = [cmd, '--features', features, ...tauriArgs];
   if (!tauriArgs.includes('--')) {

--- a/src/app/components/tauri/DesktopUpdatePill.tsx
+++ b/src/app/components/tauri/DesktopUpdatePill.tsx
@@ -1,5 +1,6 @@
 import { useAtom, useAtomValue } from 'jotai';
 import { hasCustomDesktopTitlebar } from '$utils/tauriTitlebar';
+import { isDesktopUpdaterEnabled } from '$utils/platform';
 import { useDesktopSetting } from '$state/hooks/desktopSettings';
 import { updatePhaseAtom, updateBannerVisibleAtom } from '$state/desktopUpdate';
 import type { UpdatePhase } from '$state/desktopUpdate';
@@ -24,7 +25,7 @@ export function DesktopUpdatePill() {
   const [useCustomTitleBar] = useDesktopSetting('useCustomTitleBar');
   const status = !bannerVisible ? phaseToStatusView(phase) : null;
 
-  if (!hasCustomDesktopTitlebar(useCustomTitleBar)) return null;
+  if (!isDesktopUpdaterEnabled() || !hasCustomDesktopTitlebar(useCustomTitleBar)) return null;
 
   return (
     <SyncConnectionStatusTitlebar

--- a/src/app/features/settings/about/About.tsx
+++ b/src/app/features/settings/about/About.tsx
@@ -10,7 +10,7 @@ import { useMatrixClient } from '$hooks/useMatrixClient';
 import { Method } from '$types/matrix-sdk';
 import { useOpenShallowRoute } from '$pages/client/useShallowRoute';
 import { getBugReportPath } from '$pages/pathUtils';
-import { isDesktopTauri } from '$utils/platform';
+import { isDesktopTauri, isDesktopUpdaterEnabled } from '$utils/platform';
 import {
   updatePhaseAtom,
   updateBannerVisibleAtom,
@@ -299,7 +299,7 @@ export function About({ requestBack, requestClose }: Readonly<AboutProps>) {
               </Box>
               <Box direction="Column" gap="100">
                 <Text size="L400">Options</Text>
-                {isDesktopTauri() && (
+                {isDesktopTauri() && isDesktopUpdaterEnabled() && (
                   <SequenceCard
                     className={SequenceCardStyle}
                     variant="SurfaceVariant"

--- a/src/app/pages/client/DesktopUpdater.test.tsx
+++ b/src/app/pages/client/DesktopUpdater.test.tsx
@@ -7,13 +7,16 @@ import { DesktopUpdatePill } from '$components/tauri/DesktopUpdatePill';
 import { getDebugLogger } from '$utils/debugLogger';
 import { DesktopUpdater } from './DesktopUpdater';
 
-const { checkFn } = vi.hoisted(() => ({ checkFn: vi.fn<() => Promise<unknown>>() }));
+const { checkFn, updaterEnabled } = vi.hoisted(() => ({
+  checkFn: vi.fn<() => Promise<unknown>>(),
+  updaterEnabled: vi.fn<() => boolean>(),
+}));
 
 vi.mock('@tauri-apps/plugin-updater', () => ({ check: checkFn }));
 
 vi.mock('$utils/platform', async (importOriginal) => {
   const mod = (await importOriginal()) as Record<string, unknown>;
-  return { ...mod, isDesktopTauri: () => true };
+  return { ...mod, isDesktopTauri: () => true, isDesktopUpdaterEnabled: updaterEnabled };
 });
 
 vi.mock('$state/hooks/desktopSettings', async (importOriginal) => ({
@@ -73,6 +76,7 @@ function makeUpdate(version: string) {
 
 beforeEach(() => {
   localStorage.clear();
+  updaterEnabled.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -80,6 +84,23 @@ afterEach(() => {
 });
 
 describe('DesktopUpdater', () => {
+  it('does not check for or display updates when the updater is disabled at build time', async () => {
+    updaterEnabled.mockReturnValue(false);
+    localStorage.setItem('sable_fake_desktop_update', '1');
+
+    render(
+      <Provider>
+        <DesktopUpdatePill />
+        <DesktopUpdater />
+        <BannersProbe />
+      </Provider>
+    );
+
+    await waitFor(() => expect(checkFn).not.toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: 'Update Available' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('banner-desktop-update-ready')).not.toBeInTheDocument();
+  });
+
   it('reopens the update banner from the pill after dismissing it', async () => {
     localStorage.setItem('sable_fake_desktop_update', '1');
 

--- a/src/app/pages/client/DesktopUpdater.tsx
+++ b/src/app/pages/client/DesktopUpdater.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import type { Update } from '@tauri-apps/plugin-updater';
-import { isDesktopTauri } from '$utils/platform';
+import { isDesktopTauri, isDesktopUpdaterEnabled } from '$utils/platform';
 import { autoUpdateCheckAtom } from '$state/autoUpdateCheck';
 import { createLogger } from '$utils/debug';
 import { getDebugLogger } from '$utils/debugLogger';
@@ -61,6 +61,7 @@ export function DesktopUpdater() {
   }, []);
 
   useEffect(() => {
+    if (!isDesktopUpdaterEnabled()) return undefined;
     if (!isDesktopTauri()) return undefined;
     if (triggerCount === 0 && !autoUpdateCheck && !fakeDesktopUpdate()) return undefined;
 
@@ -223,6 +224,7 @@ export function DesktopUpdater() {
   }, [setBannerVisible]);
 
   const bannerData = useMemo<GlobalBanner | null>(() => {
+    if (!isDesktopUpdaterEnabled()) return null;
     if (!bannerVisible || !updateInfo || dismissed) return null;
 
     if (isInstalled) {

--- a/src/app/utils/platform.ts
+++ b/src/app/utils/platform.ts
@@ -70,6 +70,10 @@ export function isDesktopTauri(): boolean {
   return getDesktopTauriPlatform() !== undefined;
 }
 
+export function isDesktopUpdaterEnabled(): boolean {
+  return DESKTOP_UPDATER_ENABLED;
+}
+
 export function isMobileTauri(): boolean {
   const tauriOS = getTauriOS();
   return tauriOS === 'ios' || tauriOS === 'android';

--- a/src/ext.d.ts
+++ b/src/ext.d.ts
@@ -5,6 +5,7 @@ declare const SABLE_BUILD_FLAVOR: string;
 declare const APP_VERSION: string;
 declare const BUILD_HASH: string;
 declare const IS_RELEASE_TAG: boolean;
+declare const DESKTOP_UPDATER_ENABLED: boolean;
 
 declare module 'browser-encrypt-attachment' {
   export interface EncryptedAttachmentInfo {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,7 @@ const tauriDevHost = process.env.TAURI_DEV_HOST;
 const isTauriBuild = Boolean(process.env.TAURI_ENV_PLATFORM);
 const isTauriDebug = process.env.TAURI_ENV_DEBUG === 'true';
 const tauriBuildMinify = !isTauriDebug ? 'esbuild' : false;
+const desktopUpdaterEnabled = process.env.VITE_DESKTOP_UPDATER_ENABLED !== 'false';
 const sentryUploadEnabled = Boolean(
   process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT
 );
@@ -151,6 +152,7 @@ export default defineConfig(({ command }) => {
       IS_RELEASE_TAG: JSON.stringify(isReleaseTag),
       SABLE_PRODUCT_NAME: JSON.stringify(baseProductName),
       SABLE_BUILD_FLAVOR: JSON.stringify(buildFlavor),
+      DESKTOP_UPDATER_ENABLED: JSON.stringify(desktopUpdaterEnabled),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
