### PR TITLE
fix: preserve media types in native downloads

### DIFF
--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -181,7 +181,11 @@ export const ImageViewer = as<'div', ImageViewerProps>(
         showToast(`Failed to download file: ${message}`);
         return;
       }
-      await saveFileToDevice(fileContent, downloadFilename);
+      await saveFileToDevice(
+        fileContent,
+        downloadFilename,
+        galleryMimeType || fileContent.type || undefined
+      );
     };
 
     const menu = useMenuAnchor<HTMLElement>();

--- a/src/app/utils/download.test.ts
+++ b/src/app/utils/download.test.ts
@@ -122,6 +122,24 @@ describe('saveFileToDevice', () => {
     expect(FileSaver.saveAs).toHaveBeenCalledWith(expect.any(Blob), 'file.txt');
   });
 
+  it('uses authenticated media transport before saving a URL in the browser', async () => {
+    vi.mocked(isTauri).mockReturnValue(false);
+    const blob = new Blob(['data'], { type: 'image/png' });
+    mocks.fetchMediaBlob.mockResolvedValue(blob);
+
+    await expect(
+      saveFileToDevice(
+        'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo',
+        'photo.png'
+      )
+    ).resolves.toBe('saved');
+
+    expect(mocks.fetchMediaBlob).toHaveBeenCalledWith(
+      'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo'
+    );
+    expect(FileSaver.saveAs).toHaveBeenCalledWith(blob, 'photo.png');
+  });
+
   it('uses authenticated media transport when saving a URL on Android', async () => {
     const blob = new Blob(['data'], { type: 'image/png' });
     mocks.fetchMediaBlob.mockResolvedValue(blob);
@@ -136,6 +154,26 @@ describe('saveFileToDevice', () => {
     expect(mocks.fetchMediaBlob).toHaveBeenCalledWith(
       'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo'
     );
+  });
+
+  it('uses authenticated media transport when saving a URL on desktop', async () => {
+    vi.mocked(osType).mockReturnValue('linux');
+    mocks.fetchMediaBlob.mockResolvedValue(new Blob(['data'], { type: 'image/png' }));
+
+    await expect(
+      saveFileToDevice(
+        'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo',
+        'photo.png'
+      )
+    ).resolves.toBe('saved');
+
+    expect(mocks.fetchMediaBlob).toHaveBeenCalledWith(
+      'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo'
+    );
+    expect(invoke).toHaveBeenCalledWith('save_download', {
+      filename: 'photo.png',
+      bytes: [100, 97, 116, 97],
+    });
   });
 });
 
@@ -268,6 +306,26 @@ describe('saveMediaToGallery', () => {
     });
     expect(showToast).toHaveBeenCalledWith('Saved to Photos');
     expect(androidFs.createNewPublicImageFile).not.toHaveBeenCalled();
+  });
+
+  it('uses authenticated media transport before saving a URL to iOS Photos', async () => {
+    vi.mocked(osType).mockReturnValue('ios');
+    mocks.fetchMediaBlob.mockResolvedValue(new Blob(['data'], { type: 'image/png' }));
+
+    await saveMediaToGallery(
+      'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo',
+      'photo.png',
+      'image/png'
+    );
+
+    expect(mocks.fetchMediaBlob).toHaveBeenCalledWith(
+      'https://matrix.example.org/_matrix/client/v1/media/download/example.org/photo'
+    );
+    expect(invoke).toHaveBeenCalledWith('save_media_to_photos', {
+      filename: 'photo.png',
+      mimeType: 'image/png',
+      bytes: [100, 97, 116, 97],
+    });
   });
 
   it('shows a failure toast when the iOS Photos command rejects', async () => {

--- a/src/app/utils/download.ts
+++ b/src/app/utils/download.ts
@@ -11,6 +11,9 @@ const BIDI_CONTROL_CHARS = /[\u202a-\u202e\u2066-\u2069]/g;
 const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
 const MAX_FILENAME_LENGTH = 255;
 
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 const nonEmptyString = (value: unknown): string | undefined => {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
@@ -99,8 +102,7 @@ export async function saveMediaToGallery(
       showToast('Saved to Gallery');
     } catch (error) {
       if (uri) await AndroidFs.removeFile(uri).catch(() => undefined);
-      const message = error instanceof Error ? error.message : 'unknown error';
-      showToast(`Failed to save to gallery: ${message}`);
+      showToast(`Failed to save to gallery: ${getErrorMessage(error)}`);
     }
     return;
   }
@@ -116,8 +118,7 @@ export async function saveMediaToGallery(
     });
     showToast('Saved to Photos');
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown error';
-    showToast(`Failed to save to photos: ${message}`);
+    showToast(`Failed to save to photos: ${getErrorMessage(error)}`);
   }
 }
 
@@ -126,9 +127,16 @@ export async function saveFileToDevice(
   filename: string,
   mimeType?: string
 ): Promise<'saved' | 'cancelled' | 'failed'> {
+  let blob: Blob;
+  try {
+    blob = await resolveBlob(input);
+  } catch (error) {
+    showToast(`Failed to save file: ${getErrorMessage(error)}`);
+    return 'failed';
+  }
+
   if (isTauri()) {
     try {
-      const blob = await resolveBlob(input);
       const bytes = new Uint8Array(await blob.arrayBuffer());
 
       if (osType() === 'android') {
@@ -173,13 +181,12 @@ export async function saveFileToDevice(
       if (saved) showToast('File saved');
       return saved ? 'saved' : 'cancelled';
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'unknown error';
-      showToast(`Failed to save file: ${message}`);
+      showToast(`Failed to save file: ${getErrorMessage(error)}`);
       return 'failed';
     }
   }
 
-  FileSaver.saveAs(input, filename);
+  FileSaver.saveAs(blob, filename);
   return 'saved';
 }
 


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
