### PR TITLE
fix: keep devices sorted by last active time when some last active ti…

### DIFF
--- a/.changeset/fix_sorting_devices_by_last_active_time_when_some_devices_have_a_missing_last_active_time.md
+++ b/.changeset/fix_sorting_devices_by_last_active_time_when_some_devices_have_a_missing_last_active_time.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix sorting devices by last active time when some devices have a missing last active time.

--- a/src/app/features/settings/devices/OtherDevices.tsx
+++ b/src/app/features/settings/devices/OtherDevices.tsx
@@ -186,8 +186,7 @@ export function OtherDevices({ devices, refreshDeviceList, showVerification }: O
         )}
         {devices
           .toSorted((d1, d2) => {
-            if (!d1.last_seen_ts || !d2.last_seen_ts) return 0;
-            return d1.last_seen_ts < d2.last_seen_ts ? 1 : -1;
+            return (d1.last_seen_ts ?? 0) < (d2.last_seen_ts ?? 0) ? 1 : -1;
           })
           .map((device) => (
             <SequenceCard


### PR DESCRIPTION
…mes are null

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

Fix null last active times messing up the sorting.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
