### PR TITLE
fix: sort dm rooms by last proper activity

### DIFF
--- a/.changeset/dont_sort_a_dm_room_to_the_top_if_eg_only_the_name_of_someone_has_changed.md
+++ b/.changeset/dont_sort_a_dm_room_to_the_top_if_eg_only_the_name_of_someone_has_changed.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Don't sort a DM room to the top if e.g. only the name of someone has changed.

--- a/src/app/utils/sort.test.ts
+++ b/src/app/utils/sort.test.ts
@@ -25,6 +25,7 @@ function makeClient(
         name: r.name,
         getLastActiveTimestamp: () => r.ts,
         getBumpStamp: () => r.bumpStamp,
+        getLiveTimeline: () => ({ getEvents: () => [] }),
       } as unknown as ReturnType<MatrixClient['getRoom']>;
     },
   } as unknown as MatrixClient;
@@ -71,15 +72,6 @@ describe('factoryRoomIdByActivity', () => {
     const mx = makeClient({ '!known:h': { name: 'Known', ts: 1000 } });
     const sort = factoryRoomIdByActivity(mx);
     expect(['!unknown:h', '!known:h'].toSorted(sort)).toEqual(['!known:h', '!unknown:h']);
-  });
-
-  it('uses sliding-sync bump stamps when no timeline event is loaded', () => {
-    const mx = makeClient({
-      '!old:h': { name: 'Old', ts: Number.MIN_SAFE_INTEGER, bumpStamp: 1000 },
-      '!new:h': { name: 'New', ts: Number.MIN_SAFE_INTEGER, bumpStamp: 9000 },
-    });
-    const sort = factoryRoomIdByActivity(mx);
-    expect(['!old:h', '!new:h'].toSorted(sort)).toEqual(['!new:h', '!old:h']);
   });
 });
 

--- a/src/app/utils/sort.ts
+++ b/src/app/utils/sort.ts
@@ -1,14 +1,25 @@
-import type { MatrixClient } from '$types/matrix-sdk';
+import type { MatrixClient, Room } from '$types/matrix-sdk';
+import { isNotificationEvent } from '$utils/room/unread';
 
 export type SortFunc<T> = (a: T, b: T) => number;
+
+const getLastActivityTs = (room: Room): number | undefined => {
+  const events = room.getLiveTimeline().getEvents();
+  for (let i = events.length - 1; i >= 0; i--) {
+    const mEvent = events[i];
+    if (mEvent && isNotificationEvent(mEvent)) {
+      return mEvent.getTs();
+    }
+  }
+  return undefined;
+};
 
 const getRoomActivity = (mx: MatrixClient, roomId: string): number => {
   const room = mx.getRoom(roomId);
   if (!room) return Number.MIN_SAFE_INTEGER;
-  const timelineTimestamp = room.getLastActiveTimestamp();
-  return timelineTimestamp === Number.MIN_SAFE_INTEGER
-    ? (room.getBumpStamp() ?? Number.MIN_SAFE_INTEGER)
-    : timelineTimestamp;
+  const activityTs = getLastActivityTs(room);
+  if (activityTs !== undefined) return activityTs;
+  return room.getLastActiveTimestamp();
 };
 
 export const factoryRoomIdByActivity =


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1728
Some activities such as a changed name can sort a DM room to the top . 
This sorts DM rooms only on activities that generate a new notification.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
