### PR TITLE
fix(direct): reuse the existing chat when messaging a user getDMRoom

### DIFF
--- a/src/app/pages/client/direct/DirectCreate.tsx
+++ b/src/app/pages/client/direct/DirectCreate.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Box, IconButton, Scroll } from 'folds';
 import { ArrowLeft, At, composerIcon, dropzoneIcon } from '$components/icons/phosphor';
 import { useMatrixClient } from '$hooks/useMatrixClient';
+import { useRoomNavigate } from '$hooks/useRoomNavigate';
 import { getDirectCreateSearchParams } from '$pages/pathSearchParam';
-import { getDirectRoomPath } from '$pages/pathUtils';
 import { getDMRoomFor } from '$utils/matrix';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 import {
@@ -17,26 +17,22 @@ import {
 } from '$components/page';
 import { BackRouteHandler } from '$components/BackRouteHandler';
 import { CreateChat } from '$features/create-chat';
-import { useDirectRooms } from './useDirectRooms';
 
 export function DirectCreate() {
   const mx = useMatrixClient();
   const screenSize = useScreenSizeContext();
 
-  const navigate = useNavigate();
+  const { navigateRoom } = useRoomNavigate();
   const [searchParams] = useSearchParams();
   const { userId } = getDirectCreateSearchParams(searchParams);
 
-  const directs = useDirectRooms();
-
   useEffect(() => {
-    if (userId) {
-      const roomId = getDMRoomFor(mx, userId)?.roomId;
-      if (roomId && directs.includes(roomId)) {
-        navigate(getDirectRoomPath(roomId), { replace: true });
-      }
+    if (!userId) return;
+    const roomId = getDMRoomFor(mx, userId)?.roomId;
+    if (roomId) {
+      navigateRoom(roomId, undefined, { replace: true });
     }
-  }, [mx, navigate, directs, userId]);
+  }, [mx, navigateRoom, userId]);
 
   return (
     <Page>

--- a/src/app/utils/matrix.test.ts
+++ b/src/app/utils/matrix.test.ts
@@ -21,7 +21,8 @@ vi.mock('@tauri-apps/api/core', () => tauriApi);
 vi.mock('./mediaTransport', () => mediaTransport);
 vi.mock('./room/relations', () => reactions);
 
-const { mxcUrlToHttp, rewriteAuthenticatedMediaUrl, toggleReaction } = await import('./matrix');
+const { getDMRoomFor, mxcUrlToHttp, rewriteAuthenticatedMediaUrl, toggleReaction } =
+  await import('./matrix');
 
 describe('rewriteAuthenticatedMediaUrl', () => {
   beforeEach(() => {
@@ -143,5 +144,104 @@ describe('mxcUrlToHttp', () => {
     expect(mxcUrlToHttp(mx, 'mxc://example.org/video', false)).toBe(
       `sable-media://${legacyUrl}?__sable_media_cache=3&__sable_media_session=%40user%3Aexample.com`
     );
+  });
+});
+
+type MockRoom = {
+  roomId: string;
+  memberships?: Record<string, string>;
+  encrypted?: boolean;
+  lastActive?: number;
+};
+
+const makeClient = (rooms: MockRoom[], mDirect?: Record<string, string[]>): MatrixClient => {
+  const roomMap = new Map(
+    rooms.map((mock) => [
+      mock.roomId,
+      {
+        roomId: mock.roomId,
+        getMyMembership: () => 'join',
+        getMember: (userId: string) => {
+          const membership = mock.memberships?.[userId];
+          return membership ? { userId, membership } : null;
+        },
+        getMembers: () =>
+          Object.entries(mock.memberships ?? {}).map(([userId, membership]) => ({
+            userId,
+            membership,
+          })),
+        hasEncryptionStateEvent: () => mock.encrypted ?? false,
+        getLastActiveTimestamp: () => mock.lastActive ?? 0,
+        getBumpStamp: () => undefined,
+      },
+    ])
+  );
+
+  return {
+    getRooms: () => Array.from(roomMap.values()),
+    getRoom: (roomId: string) => roomMap.get(roomId) ?? null,
+    getAccountData: () => (mDirect ? { getContent: () => mDirect } : undefined),
+  } as unknown as MatrixClient;
+};
+
+describe('getDMRoomFor', () => {
+  const otherUserId = '@other:example.org';
+
+  it('reuses a tagged room which is unencrypted and has a member who left', () => {
+    const mx = makeClient(
+      [
+        {
+          roomId: '!dm:example.org',
+          memberships: { [otherUserId]: 'join', '@left:example.org': 'leave' },
+        },
+      ],
+      { [otherUserId]: ['!dm:example.org'] }
+    );
+
+    expect(getDMRoomFor(mx, otherUserId)?.roomId).toBe('!dm:example.org');
+  });
+
+  it('prefers a tagged room the user is still part of', () => {
+    const mx = makeClient(
+      [
+        {
+          roomId: '!abandoned:example.org',
+          lastActive: 20,
+          memberships: { [otherUserId]: 'leave' },
+        },
+        { roomId: '!active:example.org', lastActive: 10, memberships: { [otherUserId]: 'join' } },
+      ],
+      { [otherUserId]: ['!abandoned:example.org', '!active:example.org'] }
+    );
+
+    expect(getDMRoomFor(mx, otherUserId)?.roomId).toBe('!active:example.org');
+  });
+
+  it('picks the most recently active tagged room', () => {
+    const mx = makeClient(
+      [
+        { roomId: '!old:example.org', lastActive: 10, memberships: { [otherUserId]: 'join' } },
+        { roomId: '!recent:example.org', lastActive: 30, memberships: { [otherUserId]: 'join' } },
+      ],
+      { [otherUserId]: ['!old:example.org', '!recent:example.org'] }
+    );
+
+    expect(getDMRoomFor(mx, otherUserId)?.roomId).toBe('!recent:example.org');
+  });
+
+  it('falls back to an encrypted one to one room when m.direct has no entry', () => {
+    const mx = makeClient([
+      { roomId: '!dm:example.org', encrypted: true, memberships: { [otherUserId]: 'join' } },
+    ]);
+
+    expect(getDMRoomFor(mx, otherUserId)?.roomId).toBe('!dm:example.org');
+  });
+
+  it('returns undefined when no room is shared with the user', () => {
+    const mx = makeClient([{ roomId: '!other:example.org', encrypted: true, memberships: {} }], {
+      '@someone:example.org': ['!other:example.org'],
+    });
+
+    expect(getDMRoomFor(mx, otherUserId)).toBeUndefined();
   });
 });

--- a/src/app/utils/matrix.ts
+++ b/src/app/utils/matrix.ts
@@ -25,6 +25,7 @@ import type { IImageInfo, IThumbnailContent, IVideoInfo } from '$types/matrix/co
 import * as Sentry from '@sentry/react';
 import { encryptBlobInWorker } from '$utils/mediaWorker';
 import { encryptAttachmentStreaming } from '$utils/attachmentCrypto';
+import { factoryRoomIdByActivity } from './sort';
 import { getEventReactions } from './room/relations';
 import { getStateEvent } from './room/hierarchy';
 import { getReactionContent } from './messageReaction';
@@ -366,7 +367,30 @@ export const factoryEventSentBy = (senderId: string) => (ev: MatrixEvent) =>
 export const eventWithShortcode = (ev: MatrixEvent) =>
   typeof ev.getContent().shortcode === 'string';
 
+const PRESENT_MEMBERSHIPS = new Set<string>([KnownMembership.Join, KnownMembership.Invite]);
+
+/**
+ * "m.direct" is the reliable signal, the member count heuristic below is only a
+ * fallback: it misses direct rooms which are unencrypted or hold members who left.
+ */
 export const getDMRoomFor = (mx: MatrixClient, userId: string): Room | undefined => {
+  const mDirects = mx.getAccountData(
+    EventType.Direct as string as unknown as keyof AccountDataEvents
+  );
+  const directRoomIds: unknown = mDirects?.getContent()[userId];
+  const tagged = (Array.isArray(directRoomIds) ? (directRoomIds as string[]) : [])
+    .toSorted(factoryRoomIdByActivity(mx))
+    .map((roomId) => mx.getRoom(roomId))
+    .filter((room): room is Room => room?.getMyMembership() === (KnownMembership.Join as string));
+
+  if (tagged.length > 0) {
+    // Prefer a room the other user is still part of over an abandoned one.
+    return (
+      tagged.find((room) => PRESENT_MEMBERSHIPS.has(room.getMember(userId)?.membership ?? '')) ??
+      tagged[0]
+    );
+  }
+
   const dmLikeRooms = mx
     .getRooms()
     .filter(


### PR DESCRIPTION

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

For ignored m.direct and only matched encrypted rooms with at most two members, so an unencrypted chat or one holding a member who left was never found. DirectCreate then dropped any match that was not in the m.direct room list, leaving the create form to make a duplicate room.


### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
