### PR TITLE
fix(ios): anchor the pwa viewport and banner to visualViewport.offsetTop

### DIFF
--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -201,14 +201,13 @@ export function NotificationBanner() {
       if (!container) return;
 
       const visualViewport = window.visualViewport!;
-      // Calculate how much of the screen is covered by the keyboard
-      // When keyboard opens, visualViewport.height shrinks
-      const keyboardHeight = window.innerHeight - visualViewport.height;
+      // The banner is fixed to the layout viewport, so iOS scrolls it off the top when the
+      // keyboard pushes the visual viewport down. offsetTop is that shift.
+      const shift = Math.round(visualViewport.offsetTop);
 
-      // Position the banner down by the keyboard height so it appears at the top of the visible area
-      // This puts it "halfway down the page" when keyboard covers half the screen
-      if (keyboardHeight > 0) {
-        container.style.top = `${keyboardHeight}px`;
+      if (shift > 0) {
+        // Keep the safe-area inset, otherwise the banner slides under the status bar.
+        container.style.top = `calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + ${shift}px)`;
       } else {
         // Reset to CSS default (env(safe-area-inset-top))
         container.style.top = '';

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -89,14 +89,14 @@ describe('android edge-to-edge inset contract', () => {
     expect(indexCss).toContain('var(--sable-ios-pwa-viewport-height, 100dvh)');
     expect(indexTsx).toContain('installIosPwaViewportHeight();');
     expect(iosPwaViewport).toContain("window.matchMedia('(display-mode: standalone)').matches");
-    expect(iosPwaViewport).toContain('const MIN_KEYBOARD_HEIGHT = 100');
-    expect(iosPwaViewport).toContain('isEditableFocused()');
-    expect(iosPwaViewport).toContain('const layoutHeight = window.innerHeight');
-    expect(iosPwaViewport).toContain('layoutHeight - visibleHeight > MIN_KEYBOARD_HEIGHT');
+    expect(iosPwaViewport).toContain('viewport.height + viewport.offsetTop');
     expect(iosPwaViewport).toContain('window.setTimeout(updateHeight, 350)');
     expect(iosPwaViewport).not.toContain('fullHeight');
     expect(iosPwaViewport).not.toContain('viewportWidth');
     expect(iosPwaViewport).not.toContain('window.screen');
+    // The height must not depend on keyboard detection or on a stale window.innerHeight.
+    expect(iosPwaViewport).not.toContain('MIN_KEYBOARD_HEIGHT');
+    expect(iosPwaViewport).not.toContain('isEditableFocused');
   });
 
   it('removes the scattered safe-area css consumers', () => {

--- a/src/app/utils/iosPwaViewport.ts
+++ b/src/app/utils/iosPwaViewport.ts
@@ -1,15 +1,8 @@
 const IOS_PWA_VIEWPORT_HEIGHT = '--sable-ios-pwa-viewport-height';
-const MIN_KEYBOARD_HEIGHT = 100;
 
 const isStandaloneIosPwa = (): boolean =>
   window.matchMedia('(display-mode: standalone)').matches &&
   CSS.supports('-webkit-touch-callout: none');
-
-const isEditableFocused = (): boolean => {
-  const el = document.activeElement as HTMLElement | null;
-  if (!el) return false;
-  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable;
-};
 
 export function installIosPwaViewportHeight(): void {
   if (!isStandaloneIosPwa()) return;
@@ -20,14 +13,14 @@ export function installIosPwaViewportHeight(): void {
   const updateHeight = () => {
     frame = 0;
     const viewport = window.visualViewport;
-    const visibleHeight = viewport?.height ?? window.innerHeight;
-    const visibleBottom = visibleHeight + (viewport?.offsetTop ?? 0);
+    // Reach the bottom of the visible area. window.innerHeight is unusable here: iOS shrinks it
+    // on the first keyboard open and never restores it until the app is force-quit.
+    const visibleBottom = viewport ? viewport.height + viewport.offsetTop : window.innerHeight;
 
-    const layoutHeight = window.innerHeight;
-    const keyboardOpen = isEditableFocused() && layoutHeight - visibleHeight > MIN_KEYBOARD_HEIGHT;
-    const height = keyboardOpen ? visibleBottom : layoutHeight;
-
-    document.documentElement.style.setProperty(IOS_PWA_VIEWPORT_HEIGHT, `${Math.round(height)}px`);
+    document.documentElement.style.setProperty(
+      IOS_PWA_VIEWPORT_HEIGHT,
+      `${Math.round(visibleBottom)}px`
+    );
   };
 
   const scheduleUpdate = () => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
