### PR TITLE
fix(android): retry a media save when MediaStore runs out of unique names

### DIFF
--- a/src/app/utils/download.test.ts
+++ b/src/app/utils/download.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   osType: vi.fn<() => string>(),
   showToast: vi.fn<(text: string, durationMs?: number) => void>(),
   fetchMediaBlob: vi.fn<(input: string) => Promise<Blob>>(),
+  captureException: vi.fn<(error: unknown, context?: unknown) => void>(),
 }));
 const { androidFs, save, writeFile } = mocks;
 
@@ -33,6 +34,7 @@ vi.mock('@tauri-apps/api/core', () => ({
   isTauri: mocks.isTauri,
 }));
 vi.mock('@tauri-apps/plugin-os', () => ({ type: mocks.osType }));
+vi.mock('@sentry/react', () => ({ captureException: mocks.captureException }));
 vi.mock('$state/toast', () => ({ showToast: mocks.showToast }));
 vi.mock('$utils/mediaTransport', () => ({ fetchMediaBlob: mocks.fetchMediaBlob }));
 vi.mock('tauri-plugin-android-fs-api', () => ({
@@ -77,6 +79,57 @@ describe('saveFileToDevice', () => {
     expect(androidFs.setPublicFilePending).toHaveBeenCalledWith('content://download/file', false);
     expect(androidFs.scanPublicFile).toHaveBeenCalledWith('content://download/file');
     expect(showToast).toHaveBeenCalledWith('Saved to Downloads');
+  });
+
+  // MediaStore resolves the final name when the pending flag is cleared, so the
+  // 32-name wall is hit after the bytes are written, not on create.
+  const uniqueFileError = new Error(
+    'Failed to build unique file: /storage/emulated/0/Download/Screenshot 2026-08-13 at 20.07.50.png' +
+      ' _display_name=Screenshot 2026-08-13 at 20.07.50.png mime_type=image/png' +
+      ' _data=/storage/emulated/0/Download/Screenshot 2026-08-13 at 20.07.50.png relative_path=Download/'
+  );
+
+  it('retries the whole save under a unique name when clearing the pending flag fails', async () => {
+    androidFs.setPublicFilePending.mockRejectedValueOnce(uniqueFileError);
+
+    const result = await saveFileToDevice(
+      new Blob(['data'], { type: 'image/png' }),
+      'Screenshot 2026-08-13 at 20.07.50.png'
+    );
+
+    expect(result).toBe('saved');
+    expect(androidFs.createNewPublicFile).toHaveBeenCalledTimes(2);
+    expect(androidFs.createNewPublicFile).toHaveBeenLastCalledWith(
+      'Download',
+      expect.stringMatching(/^Screenshot 2026-08-13 at 20\.07\.50-\d+\.png$/),
+      'image/png',
+      { isPending: true, requestPermission: true }
+    );
+    expect(androidFs.removeFile).toHaveBeenCalledWith('content://download/file');
+    expect(showToast).toHaveBeenCalledWith('Saved to Downloads');
+  });
+
+  it('reports a scrubbed error to Sentry when the unique-name retry also fails', async () => {
+    androidFs.setPublicFilePending.mockRejectedValue(uniqueFileError);
+
+    const result = await saveFileToDevice(
+      new Blob(['data'], { type: 'image/png' }),
+      'Screenshot 2026-08-13 at 20.07.50.png'
+    );
+
+    expect(result).toBe('failed');
+    expect(androidFs.createNewPublicFile).toHaveBeenCalledTimes(2);
+
+    const [reported, context] = mocks.captureException.mock.calls[0] as [
+      Error,
+      { tags: Record<string, string>; extra: Record<string, unknown> },
+    ];
+    expect(reported.message).toContain('Failed to build unique file');
+    expect(reported.message).not.toContain('Screenshot');
+    expect(reported.message).not.toContain('20.07.50');
+    expect(reported.message).not.toContain('/storage/emulated');
+    expect(context.tags).toMatchObject({ feature: 'media-save', target: 'downloads' });
+    expect(context.extra).toMatchObject({ mimeType: 'image/png' });
   });
 
   it('cleans up an Android file and shows an error toast when writing fails', async () => {

--- a/src/app/utils/download.ts
+++ b/src/app/utils/download.ts
@@ -1,4 +1,5 @@
 import FileSaver from 'file-saver';
+import * as Sentry from '@sentry/react';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { type as osType } from '@tauri-apps/plugin-os';
 import { showToast } from '$state/toast';
@@ -55,6 +56,47 @@ export const getDownloadFilename = (
   fallback = 'download'
 ): string => sanitizeDownloadFilename(getAttachmentFilename(filename, body, fallback), fallback);
 
+const splitExtension = (filename: string): [stem: string, extension: string] => {
+  const at = filename.lastIndexOf('.');
+  return at > 0 ? [filename.slice(0, at), filename.slice(at)] : [filename, ''];
+};
+
+// MediaStore only probes 32 numbered variants of a name before failing with
+// "Failed to build unique file". A pending file sits under a `.pending-` name,
+// so creation succeeds and the wall is only hit when the flag is cleared and
+// the file takes its final name — so the whole save is retried, not the create.
+const saveWithUniqueName = async (
+  filename: string,
+  save: (filename: string) => Promise<void>
+): Promise<void> => {
+  try {
+    await save(filename);
+  } catch {
+    const [stem, extension] = splitExtension(filename);
+    await save(sanitizeDownloadFilename(`${stem}-${Date.now()}${extension}`));
+  }
+};
+
+const reportSaveFailure = (
+  error: unknown,
+  target: 'downloads' | 'gallery' | 'photos',
+  filename: string,
+  mimeType?: string
+): void => {
+  // Names contain spaces, so the name goes first: `\S*` would otherwise stop at
+  // the first space and leave the rest of it in the message.
+  const scrubbed = getErrorMessage(error)
+    .split(splitExtension(filename)[0])
+    .join('[FILENAME]')
+    .replace(/\/(?:storage|data|var|Users|home)\/\S*/g, '[PATH]')
+    .replace(/\b(_display_name|_data|title|relative_path)=\S*/g, '$1=[REDACTED]');
+
+  Sentry.captureException(new Error(scrubbed), {
+    tags: { feature: 'media-save', target, platform: osType() },
+    extra: { mimeType },
+  });
+};
+
 async function resolveBlob(input: Blob | string): Promise<Blob> {
   if (typeof input !== 'string') return input;
   return fetchMediaBlob(getTauriMediaSourceUrl(input) ?? input);
@@ -80,7 +122,6 @@ export async function saveMediaToGallery(
 
   if (platform === 'android') {
     const { AndroidFs, AndroidPublicImageDir } = await import('tauri-plugin-android-fs-api');
-    let uri: Awaited<ReturnType<typeof AndroidFs.createNewPublicImageFile>> | undefined;
     try {
       const blob = await resolveBlob(input);
       const bytes = new Uint8Array(await blob.arrayBuffer());
@@ -90,18 +131,25 @@ export async function saveMediaToGallery(
         if (!granted) throw new Error('Storage permission was denied');
       }
 
-      uri = await AndroidFs.createNewPublicImageFile(
-        AndroidPublicImageDir.Pictures,
-        filename,
-        mediaMimeType,
-        { isPending: true, requestPermission: true }
-      );
-      await AndroidFs.writeFile(uri, bytes);
-      await AndroidFs.setPublicFilePending(uri, false);
-      await AndroidFs.scanPublicFile(uri);
+      await saveWithUniqueName(filename, async (name) => {
+        const uri = await AndroidFs.createNewPublicImageFile(
+          AndroidPublicImageDir.Pictures,
+          name,
+          mediaMimeType,
+          { isPending: true, requestPermission: true }
+        );
+        try {
+          await AndroidFs.writeFile(uri, bytes);
+          await AndroidFs.setPublicFilePending(uri, false);
+          await AndroidFs.scanPublicFile(uri);
+        } catch (error) {
+          await AndroidFs.removeFile(uri).catch(() => undefined);
+          throw error;
+        }
+      });
       showToast('Saved to Gallery');
     } catch (error) {
-      if (uri) await AndroidFs.removeFile(uri).catch(() => undefined);
+      reportSaveFailure(error, 'gallery', filename, mediaMimeType);
       showToast(`Failed to save to gallery: ${getErrorMessage(error)}`);
     }
     return;
@@ -118,6 +166,7 @@ export async function saveMediaToGallery(
     });
     showToast('Saved to Photos');
   } catch (error) {
+    reportSaveFailure(error, 'photos', filename, mediaMimeType);
     showToast(`Failed to save to photos: ${getErrorMessage(error)}`);
   }
 }
@@ -142,28 +191,29 @@ export async function saveFileToDevice(
       if (osType() === 'android') {
         const { AndroidFs, AndroidPublicGeneralPurposeDir } =
           await import('tauri-plugin-android-fs-api');
-        let uri: Awaited<ReturnType<typeof AndroidFs.createNewPublicFile>> | undefined;
-        try {
-          if (!(await AndroidFs.checkPublicFilesPermission())) {
-            const granted = await AndroidFs.requestPublicFilesPermission();
-            if (!granted) throw new Error('Storage permission was denied');
-          }
+        if (!(await AndroidFs.checkPublicFilesPermission())) {
+          const granted = await AndroidFs.requestPublicFilesPermission();
+          if (!granted) throw new Error('Storage permission was denied');
+        }
 
-          uri = await AndroidFs.createNewPublicFile(
+        await saveWithUniqueName(filename, async (name) => {
+          const uri = await AndroidFs.createNewPublicFile(
             AndroidPublicGeneralPurposeDir.Download,
-            filename,
+            name,
             mimeType || blob.type || null,
             { isPending: true, requestPermission: true }
           );
-          await AndroidFs.writeFile(uri, bytes);
-          await AndroidFs.setPublicFilePending(uri, false);
-          await AndroidFs.scanPublicFile(uri);
-          showToast('Saved to Downloads');
-          return 'saved';
-        } catch (error) {
-          if (uri) await AndroidFs.removeFile(uri).catch(() => undefined);
-          throw error;
-        }
+          try {
+            await AndroidFs.writeFile(uri, bytes);
+            await AndroidFs.setPublicFilePending(uri, false);
+            await AndroidFs.scanPublicFile(uri);
+          } catch (error) {
+            await AndroidFs.removeFile(uri).catch(() => undefined);
+            throw error;
+          }
+        });
+        showToast('Saved to Downloads');
+        return 'saved';
       }
 
       if (osType() === 'ios') {
@@ -181,6 +231,7 @@ export async function saveFileToDevice(
       if (saved) showToast('File saved');
       return saved ? 'saved' : 'cancelled';
     } catch (error) {
+      reportSaveFailure(error, 'downloads', filename, mimeType || blob.type || undefined);
       showToast(`Failed to save file: ${getErrorMessage(error)}`);
       return 'failed';
     }


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
