### PR TITLE
fix: switch to fully client side klipy gif fetching

### DIFF
--- a/.changeset/klipy-direct-link-gifs.md
+++ b/.changeset/klipy-direct-link-gifs.md
@@ -1,0 +1,5 @@
+---
+sable: minor
+---
+
+Replace proxy KLIPY GIF messages with direct fetching to comply with Klipy's integration requirements. The gif proxy system is no longer used and gifs are sent as normal messages with some metadata. Previous GIFs and favorites are decoded client-side.

--- a/config.json
+++ b/config.json
@@ -46,7 +46,6 @@
   },
 
   "gifs": {
-    "proxyUrl": "gifs.sable.moe",
     "klipyApiKey": "IfeIBlDMvq0av2BcKPDuxwRqbnYRbS90yNqFHEkK2Ja207tkR5nssh3NIlJRCr76"
   }
 }

--- a/src/app/components/RenderMessageContent.test.tsx
+++ b/src/app/components/RenderMessageContent.test.tsx
@@ -29,19 +29,32 @@ vi.mock('./message/PollEvent', () => ({
   PollEvent: () => <div data-testid="poll-event" />,
 }));
 
+const matrixClient = {
+  getAccountData: () => undefined,
+  on: () => undefined,
+  removeListener: () => undefined,
+} as never;
+
 function renderMessage(body: string) {
+  return renderMessageWithContent({ body });
+}
+
+function renderMessageWithContent(content: Record<string, unknown>, room?: unknown) {
   return render(
     <ClientConfigProvider value={{}}>
-      <RenderMessageContent
-        displayName="Alice"
-        msgType={MsgType.Text}
-        ts={0}
-        getContent={() => ({ body }) as never}
-        urlPreview
-        clientUrlPreview
-        htmlReactParserOptions={{}}
-        linkifyOpts={{}}
-      />
+      <MatrixClientProvider value={matrixClient}>
+        <RenderMessageContent
+          displayName="Alice"
+          msgType={typeof content.msgtype === 'string' ? content.msgtype : (MsgType.Text as string)}
+          ts={0}
+          getContent={() => content as never}
+          urlPreview
+          clientUrlPreview
+          htmlReactParserOptions={{}}
+          linkifyOpts={{}}
+          room={room as never}
+        />
+      </MatrixClientProvider>
     </ClientConfigProvider>
   );
 }
@@ -49,7 +62,7 @@ function renderMessage(body: string) {
 function renderFileMessage(content: Record<string, unknown>) {
   return render(
     <ClientConfigProvider value={{}}>
-      <MatrixClientProvider value={{} as never}>
+      <MatrixClientProvider value={matrixClient}>
         <RenderMessageContent
           displayName="Alice"
           msgType={MsgType.File}
@@ -62,6 +75,18 @@ function renderFileMessage(content: Record<string, unknown>) {
     </ClientConfigProvider>
   );
 }
+
+const externalGifContent = {
+  msgtype: MsgType.Text,
+  body: 'https://klipy.com/gif/reaction',
+  'pet.plz.gif': {
+    v: 1,
+    provider: 'klipy',
+    media_url: 'https://static.klipy.com/ii/reaction.gif',
+    w: 480,
+    h: 270,
+  },
+};
 
 beforeEach(() => {
   vi.stubGlobal('location', { origin: 'https://app.example' } as Location);
@@ -96,6 +121,45 @@ describe('RenderMessageContent', () => {
 
     expect(screen.getByTestId('url-preview-holder')).toBeInTheDocument();
     expect(screen.getByTestId('url-preview-card')).toHaveTextContent('https://example.com');
+  });
+
+  it('does not request external GIF media by default in encrypted rooms', () => {
+    renderMessageWithContent(externalGifContent, {
+      hasEncryptionStateEvent: () => true,
+    });
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Load GIF' })).toBeInTheDocument();
+  });
+
+  it('keeps normal URL previews when external GIF metadata is invalid', () => {
+    renderMessageWithContent({
+      msgtype: MsgType.Text,
+      body: 'https://example.com',
+      'pet.plz.gif': {
+        v: 1,
+        provider: 'klipy',
+        media_url: 'https://attacker.example/track.gif',
+        w: 480,
+        h: 270,
+      },
+    });
+
+    expect(screen.getByTestId('url-preview-card')).toHaveTextContent('https://example.com');
+  });
+
+  it('renders historical Soliditas MXC GIFs through the external GIF path', () => {
+    renderMessageWithContent(
+      {
+        msgtype: MsgType.Image,
+        body: 'Reaction',
+        url: 'mxc://gifs.sable.moe/klipy_ZXhhbXBsZS5naWY',
+        info: { w: 480, h: 270, mimetype: 'image/gif' },
+      },
+      { hasEncryptionStateEvent: () => true }
+    );
+
+    expect(screen.getByRole('button', { name: 'Load GIF' })).toBeInTheDocument();
   });
 
   it('render url previews for text starting with paranthesis', () => {

--- a/src/app/components/RenderMessageContent.test.tsx
+++ b/src/app/components/RenderMessageContent.test.tsx
@@ -128,6 +128,7 @@ describe('RenderMessageContent', () => {
       hasEncryptionStateEvent: () => true,
     });
 
+    expect(screen.getByText(externalGifContent.body)).toBeInTheDocument();
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Load GIF' })).toBeInTheDocument();
   });

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -54,6 +54,12 @@ import { PollEvent } from './message/PollEvent';
 import { M_POLL_START, M_TEXT } from 'matrix-js-sdk';
 import type { IImageInfo, IGalleryContent } from '$types/matrix/common';
 import { GALLERY_MSGTYPE } from '$types/matrix/common';
+import { parseExternalGif } from '$utils/externalGif';
+import { parseLegacyKlipyGif } from '$utils/klipy';
+import {
+  MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME,
+  MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME,
+} from '$unstable/prefixes';
 import {
   convertBeeperFormatToOurPerMessageProfile,
   type PerMessageProfileBeeperFormat,
@@ -127,6 +133,23 @@ function RenderMessageContentInternal({
   const [captionPosition] = useSetting(settingsAtom, 'captionPosition');
   const [themeChatSableWidgets] = useSetting(settingsAtom, 'themeChatSableWidgetsEnabled');
   const [multiplePreviews] = useSetting(settingsAtom, 'multiplePreviews');
+  const [externalGifAutoLoadEncrypted] = useSetting(settingsAtom, 'externalGifAutoLoadEncrypted');
+  const externalGif = useMemo(
+    () =>
+      msgType === (MsgType.Text as string)
+        ? parseExternalGif(content)
+        : msgType === (MsgType.Image as string)
+          ? parseLegacyKlipyGif(content)
+          : undefined,
+    [content, msgType]
+  );
+  const roomEncryptionKnown =
+    room !== undefined && typeof room.hasEncryptionStateEvent === 'function';
+  const isEncryptedRoom = roomEncryptionKnown ? room.hasEncryptionStateEvent() : false;
+  const externalGifAutoLoad =
+    roomEncryptionKnown &&
+    (!isEncryptedRoom || externalGifAutoLoadEncrypted) &&
+    (mediaAutoLoad ?? true);
   const settingsLinkBaseUrl = useSettingsLinkBaseUrl();
   const captionPositionMap = {
     [CaptionPosition.Above]: 'column-reverse',
@@ -217,8 +240,13 @@ function RenderMessageContentInternal({
     ),
     [urlPreview]
   );
-  const messageUrlsPreview = urlPreview || themeChatSableWidgets ? renderUrlsPreview : undefined;
-  const messageBundlePreview = bundledPreview ? renderBundledPreviews : undefined;
+  const hasExternalGifMetadata = !!externalGif;
+  const messageUrlsPreview =
+    !hasExternalGifMetadata && (urlPreview || themeChatSableWidgets)
+      ? renderUrlsPreview
+      : undefined;
+  const messageBundlePreview =
+    !hasExternalGifMetadata && bundledPreview ? renderBundledPreviews : undefined;
 
   const renderCaption = () => {
     const hasCaption = content.body && (content.body as string).trim().length > 0;
@@ -266,6 +294,48 @@ function RenderMessageContentInternal({
     }
     return null;
   };
+
+  if (externalGif) {
+    const markedAsSpoiler = content[MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME] === true;
+    return (
+      <Box direction="Column" style={{ maxWidth: '100%' }}>
+        <ImageContent
+          url={externalGif.media_url}
+          body={externalGif.title}
+          info={{
+            w: externalGif.w,
+            h: externalGif.h,
+            mimetype: externalGif.mimetype,
+            size: externalGif.size,
+            [MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME]: externalGif.blurhash,
+          }}
+          autoPlay={externalGifAutoLoad && !markedAsSpoiler}
+          markedAsSpoiler={markedAsSpoiler}
+          favoriteShareUrl={
+            msgType === (MsgType.Text as string) && typeof content.body === 'string'
+              ? content.body
+              : externalGif.media_url
+          }
+          loadLabel="Load GIF"
+          loadDescription={`External GIF from ${externalGif.provider.toUpperCase()}`}
+          deferMediaLoad
+          style={{ borderRadius: config.radii.R300, overflow: 'hidden' }}
+          onOpenViewer={mEvent ? () => onOpenMedia?.(mEvent) ?? false : undefined}
+          renderImage={(p) => {
+            if (!autoplayGifs && p.src) {
+              return (
+                <ClientSideHoverFreeze src={p.src}>
+                  <Image info={p.info} {...p} loading="lazy" />
+                </ClientSideHoverFreeze>
+              );
+            }
+            return <Image info={p.info} {...p} loading="lazy" />;
+          }}
+          renderViewer={(p) => <ImageViewer {...p} />}
+        />
+      </Box>
+    );
+  }
 
   function renderCaptionedAttachment(attachment: JSX.Element, isInGallery?: boolean): JSX.Element {
     return (

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -104,6 +104,7 @@ const isSableChatEmbedCandidate = (url: string): boolean =>
 
 const CAPTION_STYLE: CSSProperties = { marginTop: config.space.S200, maxWidth: '100%' };
 const TEXT_STYLE: CSSProperties = { maxWidth: '100%' };
+const EXTERNAL_GIF_MAX_SIZE = 400;
 
 function RenderMessageContentInternal({
   displayName,
@@ -297,8 +298,23 @@ function RenderMessageContentInternal({
 
   if (externalGif) {
     const markedAsSpoiler = content[MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME] === true;
+    const externalGifWidth =
+      externalGif.h >= externalGif.w
+        ? `${(EXTERNAL_GIF_MAX_SIZE * externalGif.w) / externalGif.h}px`
+        : undefined;
     return (
       <Box direction="Column" style={{ maxWidth: '100%' }}>
+        {msgType === (MsgType.Text as string) && typeof content.body === 'string' && (
+          <Box
+            style={{
+              marginBottom: config.space.S200,
+              maxWidth: '100%',
+              wordBreak: 'break-word',
+            }}
+          >
+            <MText edited={edited} content={content} renderBody={renderBody} style={TEXT_STYLE} />
+          </Box>
+        )}
         <ImageContent
           url={externalGif.media_url}
           body={externalGif.title}
@@ -319,7 +335,13 @@ function RenderMessageContentInternal({
           loadLabel="Load GIF"
           loadDescription={`External GIF from ${externalGif.provider.toUpperCase()}`}
           deferMediaLoad
-          style={{ borderRadius: config.radii.R300, overflow: 'hidden' }}
+          style={{
+            borderRadius: config.radii.R300,
+            overflow: 'hidden',
+            width: externalGifWidth,
+            maxWidth: `min(100%, ${EXTERNAL_GIF_MAX_SIZE}px)`,
+            maxHeight: `${EXTERNAL_GIF_MAX_SIZE}px`,
+          }}
           onOpenViewer={mEvent ? () => onOpenMedia?.(mEvent) ?? false : undefined}
           renderImage={(p) => {
             if (!autoplayGifs && p.src) {

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -64,6 +64,7 @@ import { useGifSearch } from './useGifSearch';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 import * as css from './components/styles.css';
 import { useMobileSheetClose } from '$components/MobileSwipeDownModal';
+import { isAllowedKlipyMediaUrl } from '$utils/externalGif';
 
 const RECENT_GROUP_ID = 'recent_group';
 const SEARCH_GROUP_ID = 'search_group';
@@ -173,10 +174,14 @@ const useItemRenderer = (tab: EmojiBoardTab, saveStickerEmojiBandwidth: boolean)
     if (tab === EmojiBoardTab.Gif) {
       const gif = item as GifData;
 
-      let initialGifUrl = gif.preview_url ?? gif.url;
-      let gifUrl = initialGifUrl.startsWith('mxc://')
-        ? (mxcUrlToHttp(mx, initialGifUrl, useAuthentication) ?? '')
-        : initialGifUrl;
+      const previewUrl = gif.preview_url;
+      const gifUrl =
+        (previewUrl && isAllowedKlipyMediaUrl(previewUrl) ? previewUrl : undefined) ??
+        (isAllowedKlipyMediaUrl(gif.mediaUrl)
+          ? gif.mediaUrl
+          : gif.mediaUrl.startsWith('mxc://')
+            ? (mxcUrlToHttp(mx, gif.mediaUrl, useAuthentication) ?? '')
+            : '');
       const aspectRatio =
         gif.width && gif.height && gif.width > 0 && gif.height > 0
           ? `${gif.width} / ${gif.height}`
@@ -187,18 +192,20 @@ const useItemRenderer = (tab: EmojiBoardTab, saveStickerEmojiBandwidth: boolean)
           key={gif.id + index}
           label={gif.title}
           type={EmojiType.Gif}
-          data={gif.url}
+          data={gif.mediaUrl}
           shortcode={gif.title}
           gif={gif}
           style={{ aspectRatio }}
         >
-          <MediaImage
-            loading="lazy"
-            alt=""
-            aria-hidden
-            src={gifUrl}
-            style={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover' }}
-          />
+          {gifUrl && (
+            <MediaImage
+              loading="lazy"
+              alt=""
+              aria-hidden
+              src={gifUrl}
+              style={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          )}
         </GifItem>
       );
     }

--- a/src/app/components/emoji-board/components/Item.tsx
+++ b/src/app/components/emoji-board/components/Item.tsx
@@ -13,8 +13,6 @@ import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
 import { Star, Eye, EyeSlash, menuIcon } from '$components/icons/phosphor';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '$unstable/prefixes';
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import { useClientConfig } from '$hooks/useClientConfig';
-import { getKlipyMxcUrl } from '$utils/klipy';
 
 const ANIMATED_MIME_TYPES = new Set(['image/gif', 'image/apng']);
 
@@ -173,27 +171,18 @@ export function GifItem({
 }) {
   const [isHovered, setIsHovered] = useState(false);
   const favoritedContent = useFavoriteGifs();
-  const clientConfig = useClientConfig();
 
-  const mxcUrl = gif?.url ? getKlipyMxcUrl(gif.url, clientConfig.gifs?.proxyUrl) : '';
+  const mediaUrl = gif.mediaUrl;
 
   const [favorited, setFavorited] = useState(
-    favoritedContent.gifs.some((v) => {
-      const vMxc = getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl);
-      return vMxc === mxcUrl && mxcUrl !== '';
-    })
+    favoritedContent.gifs.some((v) => v.mediaUrl === mediaUrl && mediaUrl !== '')
   );
   const [isSpoiler, setIsSpoiler] = useState(false);
   const mx = useMatrixClient();
 
   useEffect(() => {
-    setFavorited(
-      favoritedContent.gifs.some((v) => {
-        const vMxc = getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl);
-        return vMxc === mxcUrl && mxcUrl !== '';
-      })
-    );
-  }, [favoritedContent, mxcUrl, clientConfig.gifs?.proxyUrl]);
+    setFavorited(favoritedContent.gifs.some((v) => v.mediaUrl === mediaUrl && mediaUrl !== ''));
+  }, [favoritedContent, mediaUrl]);
 
   return (
     <Box
@@ -234,8 +223,9 @@ export function GifItem({
                         gifs: [
                           ...favoritedContent.gifs,
                           {
+                            shareUrl: gif.shareUrl,
+                            mediaUrl,
                             title: gif.title,
-                            url: mxcUrl,
                             width: gif.width,
                             height: gif.height,
                             size: gif.size,
@@ -248,9 +238,7 @@ export function GifItem({
                     setFavorited(false);
                     await mx
                       .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-                        gifs: favoritedContent.gifs.filter(
-                          (v) => getKlipyMxcUrl(v.url, clientConfig.gifs?.proxyUrl) !== mxcUrl
-                        ),
+                        gifs: favoritedContent.gifs.filter((v) => v.mediaUrl !== mediaUrl),
                       })
                       .catch(() => setFavorited(true));
                   }

--- a/src/app/components/emoji-board/types.ts
+++ b/src/app/components/emoji-board/types.ts
@@ -21,10 +21,12 @@ export type EmojiItemInfo = {
 export type GifData = {
   id: string;
   title: string;
-  url: string;
+  shareUrl: string;
+  mediaUrl: string;
   preview_url?: string;
   width?: number;
   height?: number;
   size?: number;
   mimetype?: string;
+  blurhash?: string;
 };

--- a/src/app/components/emoji-board/useGifSearch.test.tsx
+++ b/src/app/components/emoji-board/useGifSearch.test.tsx
@@ -35,6 +35,7 @@ const responseFor = (id: string): Response =>
           {
             id,
             title: id,
+            itemurl: `https://klipy.com/gifs/${id}`,
             file: { xs: { gif: { url: `https://${id}.preview` } } },
           },
         ],
@@ -82,6 +83,7 @@ describe('useGifSearch', () => {
       await flushPromises();
     });
     expect(result.current.gifs.gifs[0]?.id).toBe('second');
+    expect(result.current.gifs.gifs[0]?.shareUrl).toBe('https://klipy.com/gifs/second');
     expect(result.current.loading).toBe(false);
 
     first.resolve(responseFor('first'));

--- a/src/app/components/emoji-board/useGifSearch.test.tsx
+++ b/src/app/components/emoji-board/useGifSearch.test.tsx
@@ -35,7 +35,7 @@ const responseFor = (id: string): Response =>
           {
             id,
             title: id,
-            itemurl: `https://klipy.com/gifs/${id}`,
+            slug: `test-${id}`,
             file: { xs: { gif: { url: `https://${id}.preview` } } },
           },
         ],
@@ -83,7 +83,7 @@ describe('useGifSearch', () => {
       await flushPromises();
     });
     expect(result.current.gifs.gifs[0]?.id).toBe('second');
-    expect(result.current.gifs.gifs[0]?.shareUrl).toBe('https://klipy.com/gifs/second');
+    expect(result.current.gifs.gifs[0]?.shareUrl).toBe('https://klipy.com/gifs/test-second');
     expect(result.current.loading).toBe(false);
 
     first.resolve(responseFor('first'));

--- a/src/app/components/emoji-board/useGifSearch.ts
+++ b/src/app/components/emoji-board/useGifSearch.ts
@@ -18,8 +18,8 @@ type KlipyFormat = { gif?: KlipyFile };
 
 type KlipyResult = {
   id?: string | number;
+  slug?: string;
   title?: string;
-  itemurl?: string;
   file?: Partial<Record<'xs' | 'sm' | 'md' | 'hd', KlipyFormat>>;
 };
 
@@ -39,7 +39,9 @@ const parseKlipyResult = (klipyResult: KlipyResult): GifData => {
   return {
     id: klipyResult.id === undefined ? '' : String(klipyResult.id),
     title: klipyResult.title || 'GIF',
-    shareUrl: klipyResult.itemurl ?? fullRes?.url ?? '',
+    shareUrl: klipyResult.slug
+      ? `https://klipy.com/gifs/${encodeURIComponent(klipyResult.slug)}`
+      : (fullRes?.url ?? ''),
     mediaUrl: fullRes?.url ?? '',
     preview_url: preview?.url ?? fullRes?.url ?? '',
     width: fullRes?.width ?? preview?.width ?? 0,

--- a/src/app/components/emoji-board/useGifSearch.ts
+++ b/src/app/components/emoji-board/useGifSearch.ts
@@ -17,8 +17,9 @@ type KlipyFile = {
 type KlipyFormat = { gif?: KlipyFile };
 
 type KlipyResult = {
-  id?: string;
+  id?: string | number;
   title?: string;
+  itemurl?: string;
   file?: Partial<Record<'xs' | 'sm' | 'md' | 'hd', KlipyFormat>>;
 };
 
@@ -36,9 +37,10 @@ const parseKlipyResult = (klipyResult: KlipyResult): GifData => {
   fullRes ??= formats.md?.gif ?? preview;
 
   return {
-    id: klipyResult.id ?? '',
+    id: klipyResult.id === undefined ? '' : String(klipyResult.id),
     title: klipyResult.title || 'GIF',
-    url: fullRes?.url ?? '',
+    shareUrl: klipyResult.itemurl ?? fullRes?.url ?? '',
+    mediaUrl: fullRes?.url ?? '',
     preview_url: preview?.url ?? fullRes?.url ?? '',
     width: fullRes?.width ?? preview?.width ?? 0,
     height: fullRes?.height ?? preview?.height ?? 0,

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -124,6 +124,10 @@ export type ImageContentProps = {
   info?: IImageInfo;
   encInfo?: EncryptedAttachmentInfo;
   autoPlay?: boolean;
+  favoriteShareUrl?: string;
+  loadLabel?: string;
+  loadDescription?: string;
+  deferMediaLoad?: boolean;
   markedAsSpoiler?: boolean;
   spoilerReason?: string;
   renderViewer: (props: RenderViewerProps) => ReactNode;
@@ -148,6 +152,10 @@ export const ImageContent = as<'div', ImageContentProps>(
       info,
       encInfo,
       autoPlay,
+      favoriteShareUrl,
+      loadLabel,
+      loadDescription,
+      deferMediaLoad = false,
       markedAsSpoiler,
       spoilerReason,
       renderViewer,
@@ -168,6 +176,7 @@ export const ImageContent = as<'div', ImageContentProps>(
 
     const [load, setLoad] = useState(false);
     const [error, setError] = useState(false);
+    const [loadRequested, setLoadRequested] = useState(autoPlay ?? false);
     // Tauri only: each retry gets a distinct sable-media:// src.
     const retryRevisionRef = useRef(0);
     const [viewer, setViewer] = useState(false);
@@ -177,7 +186,7 @@ export const ImageContent = as<'div', ImageContentProps>(
 
     const favoritedContent = useFavoriteGifs();
     const [favorited, setFavorited] = useState(
-      favoritedContent.gifs.find((v) => v.url == url) != undefined
+      favoritedContent.gifs.find((v) => v.mediaUrl == url) != undefined
     );
 
     const isGif = checkIfGif(url, info?.mimetype, body);
@@ -207,7 +216,10 @@ export const ImageContent = as<'div', ImageContentProps>(
       return mxcUrlToHttp(mx, url, useAuthentication) ?? undefined;
     }, [mx, url, useAuthentication, usesThumbnail, thumbWidth, thumbHeight]);
 
-    const resolvedMediaUrl = useRenderableMediaUrl(encInfo ? undefined : rawMediaUrl);
+    const shouldResolveMedia = !deferMediaLoad || autoPlay || loadRequested;
+    const resolvedMediaUrl = useRenderableMediaUrl(
+      encInfo || !shouldResolveMedia ? undefined : rawMediaUrl
+    );
 
     const createObjectURL = useCreateObjectURL();
 
@@ -269,12 +281,14 @@ export const ImageContent = as<'div', ImageContentProps>(
     };
 
     const handleRetry = () => {
+      setLoadRequested(true);
       setError(false);
       retryRevisionRef.current += 1;
       loadSrc().catch(() => undefined);
     };
 
     const handleView = async () => {
+      setLoadRequested(true);
       if (srcState.status !== AsyncStatus.Idle) return;
       try {
         const src = await loadSrc();
@@ -398,8 +412,11 @@ export const ImageContent = as<'div', ImageContentProps>(
             className={css.AbsoluteContainer}
             alignItems="Center"
             justifyContent="Center"
+            direction="Column"
+            gap="200"
             {...viewActivation}
           >
+            {loadDescription && <Text size="T300">{loadDescription}</Text>}
             <Button
               variant="Secondary"
               fill="Solid"
@@ -407,7 +424,7 @@ export const ImageContent = as<'div', ImageContentProps>(
               size="300"
               before={sizedIcon(Image, 'Inherit', { filled: true })}
             >
-              <Text size="B300">View</Text>
+              <Text size="B300">{loadLabel ?? 'View'}</Text>
             </Button>
           </Box>
         )}
@@ -444,6 +461,7 @@ export const ImageContent = as<'div', ImageContentProps>(
             justifyContent="Center"
             onClick={() => {
               setBlurred(false);
+              setLoadRequested(true);
               if (srcState.status === AsyncStatus.Idle) {
                 loadSrc().catch(() => undefined);
               }
@@ -456,6 +474,7 @@ export const ImageContent = as<'div', ImageContentProps>(
               outlined
               onClick={() => {
                 setBlurred(false);
+                setLoadRequested(true);
                 if (srcState.status === AsyncStatus.Idle) {
                   loadSrc().catch(() => undefined);
                 }
@@ -522,6 +541,7 @@ export const ImageContent = as<'div', ImageContentProps>(
                   onClick={(e) => {
                     e.preventDefault();
                     if (srcState.status === AsyncStatus.Idle) {
+                      setLoadRequested(true);
                       loadSrc().catch(() => undefined);
                       setBlurred(false);
                     } else setBlurred(!blurred);
@@ -547,11 +567,17 @@ export const ImageContent = as<'div', ImageContentProps>(
                                 ...favoritedContent.gifs,
                                 {
                                   title: body ?? '',
-                                  url: url,
+                                  shareUrl: favoriteShareUrl ?? url,
+                                  mediaUrl: url,
                                   width: imageW,
                                   height: imageH,
                                   size: info?.size,
                                   mimetype: info?.mimetype,
+                                  ...(info?.[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME]
+                                    ? {
+                                        blurhash: info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME],
+                                      }
+                                    : {}),
                                 },
                               ],
                             })
@@ -560,7 +586,7 @@ export const ImageContent = as<'div', ImageContentProps>(
                           setFavorited(false);
                           await mx
                             .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-                              gifs: favoritedContent.gifs.filter((v) => v.url != url),
+                              gifs: favoritedContent.gifs.filter((v) => v.mediaUrl != url),
                             })
                             .catch(() => setFavorited(true));
                         }

--- a/src/app/components/message/modals/Options.tsx
+++ b/src/app/components/message/modals/Options.tsx
@@ -68,8 +68,7 @@ import {
   MATRIX_UNSTABLE_PER_MESSAGE_PROFILE_PROPERTY_NAME,
 } from '$unstable/prefixes';
 import { useFavoriteGifs } from '$hooks/useFavoriteGifs';
-import type { IImageInfo } from '$types/matrix/common';
-import { getIncomingMediaMxcUrl } from '../MsgTypeRenderers';
+import { getFavoriteGifFromMessageContent } from '$utils/favoriteGif';
 import { TemporaryPersonaPicker } from '$features/room/persona-picker/PersonaPicker';
 import { type PerMessageProfileMsc4461 } from '$hooks/usePerMessageProfile';
 import { buildReplacementPmpContent } from '$features/room/buildReplacementContent';
@@ -289,36 +288,29 @@ const MessageFavoriteGifItem = as<
 >(({ room, mEvent, onClose, ...props }, ref) => {
   const mx = useMatrixClient();
   const content = mEvent.getContent();
-  const url = getIncomingMediaMxcUrl(content.file?.url ?? content.url) ?? '';
+  const favoriteGif = getFavoriteGifFromMessageContent(content);
+  const url = favoriteGif?.mediaUrl ?? '';
   const favoritedContent = useFavoriteGifs();
   const [favorited, setFavorited] = useState(
-    favoritedContent.gifs.find((v) => v.url == url) != undefined
+    favoritedContent.gifs.find((v) => v.mediaUrl == url) != undefined
   );
   const handleClick = async () => {
+    if (!favoriteGif) {
+      onClose?.();
+      return;
+    }
     if (!favorited) {
-      const info: IImageInfo | undefined = content?.info;
-      const body = content?.body;
       setFavorited(true);
       await mx
         .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-          gifs: [
-            ...favoritedContent.gifs,
-            {
-              title: body ?? '',
-              url: url,
-              width: info?.w,
-              height: info?.h,
-              size: info?.size,
-              mimetype: info?.mimetype,
-            },
-          ],
+          gifs: [...favoritedContent.gifs, favoriteGif],
         })
         .catch(() => setFavorited(false));
     } else {
       setFavorited(false);
       await mx
         .setAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS, {
-          gifs: favoritedContent.gifs.filter((v) => v.url != url),
+          gifs: favoritedContent.gifs.filter((v) => v.mediaUrl != url),
         })
         .catch(() => setFavorited(true));
     }

--- a/src/app/features/room/RoomInput.test.tsx
+++ b/src/app/features/room/RoomInput.test.tsx
@@ -247,10 +247,16 @@ vi.mock('$components/upload-card', () => ({
 }));
 vi.mock('./msgContent', async (importOriginal) => ({
   ...(await importOriginal<typeof MsgContentModule>()),
-  getGifMsgContent: async (_mx: unknown, gif: { title: string }, url: string) => ({
-    msgtype: 'm.image',
+  getGifMsgContent: (gif: { title: string }) => ({
+    msgtype: 'm.text',
     body: gif.title,
-    url,
+    'pet.plz.gif': {
+      v: 1,
+      provider: 'klipy',
+      media_url: 'https://static.klipy.com/ii/gif.gif',
+      w: 320,
+      h: 240,
+    },
   }),
 }));
 vi.mock('$components/attachment-sheet/AttachmentSheet', () => ({ AttachmentSheet: () => null }));
@@ -264,8 +270,10 @@ vi.mock('$components/emoji-board', () => ({
         type="button"
         onClick={() =>
           onGifSelect({
-            url: 'mxc://gif',
+            id: 'gif-id',
             title: 'gif',
+            shareUrl: 'https://klipy.com/gif/gif-id',
+            mediaUrl: 'https://static.klipy.com/ii/gif.gif',
             width: 320,
             height: 240,
             mimetype: 'image/gif',

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -187,6 +187,7 @@ import { AttachmentContent } from '$components/attachment-sheet/AttachmentConten
 import { MobileSwipeDownModal } from '$components/MobileSwipeDownModal';
 import { SchedulePickerDialog } from './schedule-send';
 import * as css from './schedule-send/SchedulePickerDialog.css';
+import { getKlipyGifBlurhash } from '$utils/klipy';
 import {
   getAudioMsgContent,
   getFileMsgContent,
@@ -196,7 +197,6 @@ import {
   buildGalleryContent,
   getGalleryItemContent,
 } from './msgContent';
-import { getSendableKlipyMxcUrl } from '$utils/klipy';
 import { CommandAutocomplete } from './CommandAutocomplete';
 import type {
   AudioMessageRecorderHandle,
@@ -205,7 +205,6 @@ import type {
 import { AudioMessageRecorder } from './AudioMessageRecorder';
 import * as prefix from '$unstable/prefixes';
 import { PollDialog } from './poll-modals';
-import { useClientConfig } from '$hooks/useClientConfig';
 import { PersonaPicker, type PersonaPickerTab } from './persona-picker/PersonaPicker.tsx';
 import { createComposerController, type ComposerController } from './composerController';
 import { buildEditReplacement, buildOutgoingMessage } from './composerMessage';
@@ -325,7 +324,6 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     // don't clobber the main room draft (and vice versa).
     const draftKey = threadRootId ?? roomId;
     const mx = useMatrixClient();
-    const clientConfig = useClientConfig();
     const useAuthentication = useMediaAuthentication();
     const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
     const [editorOldAddFile] = useSetting(settingsAtom, 'editorOldAddFile');
@@ -1887,10 +1885,8 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       const submission = takeSubmission({ clearEditor: false });
       return composerControllerRef.current?.enqueue(async (isLive) => {
         try {
-          const url = getSendableKlipyMxcUrl(gif.url, clientConfig.gifs?.proxyUrl);
-          if (!url) throw new Error('Unsendable GIF url');
-
-          const content = await getGifMsgContent(mx, gif, url, spoiler);
+          const blurhash = gif.blurhash ?? (await getKlipyGifBlurhash(gif));
+          const content = getGifMsgContent(blurhash ? { ...gif, blurhash } : gif, spoiler);
           if (!content) throw new Error('Unsendable GIF content');
 
           const sent = await handleSendContents({ contents: [content], submission, isLive });

--- a/src/app/features/room/buildReplacementContent.ts
+++ b/src/app/features/room/buildReplacementContent.ts
@@ -67,6 +67,7 @@ export function buildReplacementContent(
     'm.mentions': mMentions,
     'm.new_content': newContent,
   };
+  delete content['pet.plz.gif'];
 
   if (!customHtmlEqualsPlainText(adjustedCustomHtml, adjustedPlainText)) {
     newContent.format = 'org.matrix.custom.html';

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -33,6 +33,8 @@ import {
 import { canEditEvent, getEditedEvent } from '$utils/room/relations';
 import { getMemberAvatarMxc } from '$utils/room/display';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
+import { parseExternalGif } from '$utils/externalGif';
+import { parseLegacyKlipyGif } from '$utils/klipy';
 import type { MessageSpacing } from '$state/settings';
 import { getSettings, MessageLayout, settingsAtom } from '$state/settings';
 import { useMatrixClient } from '$hooks/useMatrixClient';
@@ -389,8 +391,12 @@ function MessageInternal(
 
   const isGif = useMemo(() => {
     const content = mEvent.getContent();
+    if (content.msgtype === MsgType.Text) return !!parseExternalGif(content);
     if (content.msgtype !== MsgType.Image) return false;
-    return checkIfGif(content?.info?.url ?? '', content?.info?.mimetype, content?.body);
+    return (
+      !!parseLegacyKlipyGif(content) ||
+      checkIfGif(content?.info?.url ?? '', content?.info?.mimetype, content?.body)
+    );
   }, [mEvent]);
 
   useEffect(() => {

--- a/src/app/features/room/message/MessageEditor.tsx
+++ b/src/app/features/room/message/MessageEditor.tsx
@@ -462,6 +462,7 @@ export const MessageEditor = as<'div', MessageEditorProps>(
               htmlReactParserOptions={htmlReactParserOptions}
               hideCaption
               linkifyOpts={linkifyOpts}
+              room={room}
             />
           )}
           <Box

--- a/src/app/features/room/msgContent.test.ts
+++ b/src/app/features/room/msgContent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { MsgType, type MatrixClient } from '$types/matrix-sdk';
 import type { TUploadItem } from '$state/room/roomInputDrafts';
 import { TGS_MIMETYPE } from '$utils/mimeTypes';
-import { getGalleryItemContent, getImageMsgContent } from './msgContent';
+import { getGalleryItemContent, getGifMsgContent, getImageMsgContent } from './msgContent';
 
 vi.mock('$utils/dom', () => ({
   getImageFileUrl: vi.fn<(file: File | Blob) => string>(() => 'blob:test'),
@@ -53,5 +53,57 @@ describe('TGS message content', () => {
     );
 
     expect(content.itemtype).toBe(MsgType.Image);
+  });
+});
+
+describe('KLIPY message content', () => {
+  it('sends a direct-link text event without fetching media', () => {
+    expect(
+      getGifMsgContent({
+        id: 'gif-id',
+        title: 'Reaction',
+        shareUrl: 'https://klipy.com/gif/gif-id',
+        mediaUrl: 'https://static.klipy.com/ii/reaction.gif',
+        width: 480,
+        height: 270,
+        mimetype: 'image/gif',
+      })
+    ).toEqual({
+      msgtype: MsgType.Text,
+      body: 'https://klipy.com/gif/gif-id',
+      'pet.plz.gif': {
+        v: 1,
+        provider: 'klipy',
+        media_url: 'https://static.klipy.com/ii/reaction.gif',
+        w: 480,
+        h: 270,
+        mimetype: 'image/gif',
+        id: 'gif-id',
+        title: 'Reaction',
+      },
+    });
+  });
+
+  it('keeps Matrix MXC favorites on the standard image path', () => {
+    expect(
+      getGifMsgContent({
+        id: 'matrix-gif',
+        title: 'Favorite',
+        shareUrl: 'mxc://matrix.example/media-id',
+        mediaUrl: 'mxc://matrix.example/media-id',
+        width: 320,
+        height: 240,
+        mimetype: 'image/gif',
+      })
+    ).toMatchObject({
+      msgtype: MsgType.Image,
+      body: 'Favorite',
+      url: 'mxc://matrix.example/media-id',
+      info: {
+        w: 320,
+        h: 240,
+        mimetype: 'image/gif',
+      },
+    });
   });
 });

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -16,16 +16,15 @@ import {
   getImageInfo,
   getThumbnailContent,
   getVideoInfo,
-  mxcUrlToHttp,
   uploadContentToServer,
 } from '$utils/matrix';
-import { isImageMimeType, mimeTypeToExt } from '$utils/mimeTypes';
+import { isImageMimeType } from '$utils/mimeTypes';
 import type { TUploadItem } from '$state/room/roomInputDrafts';
 import type { GifData } from '$components/emoji-board/types';
 import { encodeBlurHashAsync } from '$utils/blurHash';
 import { scaleYDimension } from '$utils/common';
 import { createLogger } from '$utils/debug';
-import { fetchMediaBlob } from '$utils/mediaTransport';
+import { getKlipyGifMetadata } from '$utils/klipy';
 import {
   MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME,
   MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME,
@@ -270,63 +269,30 @@ export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
   return content;
 };
 
-export const getGifMsgContent = async (
-  mx: MatrixClient,
-  gif: GifData,
-  mxcUrl: string,
-  spoiler?: boolean
-): Promise<IContent | undefined> => {
-  if (!mxcUrl.startsWith('mxc://')) return undefined;
-
-  const proxyUrl = mxcUrlToHttp(mx, mxcUrl, true);
-  let imgEl: HTMLImageElement | undefined;
-  try {
-    if (proxyUrl) {
-      const blob = await fetchMediaBlob(proxyUrl);
-      const objectUrl = URL.createObjectURL(blob);
-      imgEl = await loadImageElement(objectUrl);
-      URL.revokeObjectURL(objectUrl);
-    } else {
-      imgEl = await loadImageElement(gif.url, 'anonymous');
-    }
-  } catch (e) {
-    log.warn('Failed to load image element for blurhash, falling back to basic metadata:', e);
+export const getGifMsgContent = (gif: GifData, spoiler?: boolean): IContent | undefined => {
+  const metadata = getKlipyGifMetadata(gif);
+  if (!metadata) {
+    if (!gif.mediaUrl.startsWith('mxc://')) return undefined;
+    return {
+      msgtype: MsgType.Image,
+      body: gif.title,
+      url: gif.mediaUrl,
+      info: {
+        w: gif.width,
+        h: gif.height,
+        mimetype: gif.mimetype ?? 'image/gif',
+        ...(gif.size !== undefined ? { size: gif.size } : {}),
+      },
+      ...(spoiler ? { [MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME]: true } : {}),
+    };
   }
 
-  const mimetype = gif.mimetype ?? 'image/gif';
-  const ext = mimeTypeToExt(mimetype);
-
-  const content: IContent = {
-    msgtype: MsgType.Image,
-    body: gif.title.endsWith(`.${ext}`) ? gif.title : `${gif.title}.${ext}`,
-    url: mxcUrl,
-    info: {
-      w: gif.width,
-      h: gif.height,
-      mimetype,
-    },
+  return {
+    msgtype: MsgType.Text,
+    body: gif.shareUrl || metadata.media_url,
+    'pet.plz.gif': metadata,
+    ...(spoiler ? { [MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME]: true } : {}),
   };
-
-  if (gif.size) {
-    content.info.size = gif.size;
-  }
-
-  if (spoiler) {
-    content[MATRIX_UNSTABLE_SPOILER_PROPERTY_NAME] = true;
-  }
-
-  if (imgEl) {
-    const blurHash = await encodeBlurHashAsync(
-      imgEl,
-      512,
-      scaleYDimension(imgEl.width, 512, imgEl.height)
-    );
-    if (blurHash) {
-      content.info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] = blurHash;
-    }
-  }
-
-  return content;
 };
 
 const swapMsgTypeToItemType = (

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -1030,6 +1030,10 @@ function Embeds() {
     settingsAtom,
     'clientPreviewYoutube'
   );
+  const [externalGifAutoLoadEncrypted, setExternalGifAutoLoadEncrypted] = useSetting(
+    settingsAtom,
+    'externalGifAutoLoadEncrypted'
+  );
   const [enableGifPicker, setEnableGifPicker] = useSetting(settingsAtom, 'enableGifPicker');
   return (
     <Box direction="Column" gap="100">
@@ -1117,6 +1121,13 @@ function Embeds() {
         value={enableGifPicker}
         onChange={setEnableGifPicker}
         switchTitle={enableGifPicker ? 'Disable Gif Picker' : 'Enable Gif Picker'}
+      />
+      <SettingToggle
+        title="Automatically Load External GIFs in Encrypted Rooms"
+        focusId="external-gif-auto-load-encrypted"
+        description="Loading contacts the GIF provider directly and may reveal when you viewed a GIF."
+        value={externalGifAutoLoadEncrypted}
+        onChange={setExternalGifAutoLoadEncrypted}
       />
       <SettingToggle
         title="Show Interactive maps"

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -33,6 +33,7 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'enable-swiping',
     'encrypted-room-embeds',
     'encrypted-room-url-preview',
+    'external-gif-auto-load-encrypted',
     'enter-for-newline',
     'error-reporting',
     'export-diagnostics',

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -10,7 +10,6 @@ export type HashRouterConfig = {
 
 export type GifsConfig = {
   klipyApiKey?: string;
-  proxyUrl?: string;
 };
 
 export type ClientConfig = {

--- a/src/app/hooks/useFavoriteGifs.test.ts
+++ b/src/app/hooks/useFavoriteGifs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFavoriteGifs } from './useFavoriteGifs';
+
+describe('normalizeFavoriteGifs', () => {
+  it('migrates old MXC-backed KLIPY favorites to direct media URLs', () => {
+    const result = normalizeFavoriteGifs({
+      gifs: [
+        {
+          title: 'Reaction',
+          url: 'mxc://gifs.sable.moe/klipy_ZXhhbXBsZS5naWY',
+          shareUrl: 'mxc://gifs.sable.moe/klipy_ZXhhbXBsZS5naWY',
+          width: 480,
+          height: 270,
+        },
+      ],
+    });
+
+    expect(result[0]).toMatchObject({
+      title: 'Reaction',
+      shareUrl: 'https://static.klipy.com/ii/example.gif',
+      mediaUrl: 'https://static.klipy.com/ii/example.gif',
+    });
+  });
+
+  it('drops unsafe legacy favorites', () => {
+    expect(
+      normalizeFavoriteGifs({
+        gifs: [{ title: 'Tracking GIF', url: 'https://attacker.example/track.gif' }],
+      })
+    ).toEqual([]);
+  });
+});

--- a/src/app/hooks/useFavoriteGifs.ts
+++ b/src/app/hooks/useFavoriteGifs.ts
@@ -1,18 +1,80 @@
+import { useMemo } from 'react';
 import type { AccountDataEvents } from 'matrix-js-sdk';
+import type { GifData } from '$components/emoji-board/types';
+import { isAllowedKlipyMediaUrl } from '$utils/externalGif';
+import { decodeLegacyKlipyMxc } from '$utils/klipy';
 import { MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS } from '../../unstable/prefixes';
 import { useAccountData } from './useAccountData';
 
-const DEFAULT_FAVORITE_GIFS: AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] = {
-  gifs: [],
+type FavoriteGif = Omit<GifData, 'id'>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const isMatrixMediaUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'mxc:' &&
+      url.hostname !== '' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.pathname.length > 1 &&
+      url.search === '' &&
+      url.hash === ''
+    );
+  } catch {
+    return false;
+  }
+};
+
+const normalizeMediaUrl = (value: string): string | undefined => {
+  if (isAllowedKlipyMediaUrl(value)) return value;
+  return decodeLegacyKlipyMxc(value) ?? (isMatrixMediaUrl(value) ? value : undefined);
+};
+
+export const normalizeFavoriteGifs = (value: unknown): FavoriteGif[] => {
+  if (!isRecord(value) || !Array.isArray(value.gifs)) return [];
+
+  const gifs = value.gifs.flatMap((entry): FavoriteGif[] => {
+    if (!isRecord(entry)) return [];
+    const legacyUrl = typeof entry.url === 'string' ? entry.url : undefined;
+    const rawMediaUrl = typeof entry.mediaUrl === 'string' ? entry.mediaUrl : undefined;
+    const legacyMediaUrl =
+      (rawMediaUrl && decodeLegacyKlipyMxc(rawMediaUrl)) ??
+      (legacyUrl && decodeLegacyKlipyMxc(legacyUrl));
+    const mediaUrl = rawMediaUrl ? normalizeMediaUrl(rawMediaUrl) : undefined;
+    const migratedMediaUrl = mediaUrl ?? (legacyUrl ? normalizeMediaUrl(legacyUrl) : undefined);
+    if (!migratedMediaUrl) return [];
+    const shareUrl =
+      (typeof entry.shareUrl === 'string' && entry.shareUrl
+        ? (decodeLegacyKlipyMxc(entry.shareUrl) ?? entry.shareUrl)
+        : undefined) ?? migratedMediaUrl;
+
+    return [
+      {
+        title: typeof entry.title === 'string' ? entry.title : 'GIF',
+        shareUrl: legacyMediaUrl ?? shareUrl,
+        mediaUrl: migratedMediaUrl,
+        ...(typeof entry.width === 'number' ? { width: entry.width } : {}),
+        ...(typeof entry.height === 'number' ? { height: entry.height } : {}),
+        ...(typeof entry.size === 'number' ? { size: entry.size } : {}),
+        ...(typeof entry.mimetype === 'string' ? { mimetype: entry.mimetype } : {}),
+        ...(typeof entry.blurhash === 'string' ? { blurhash: entry.blurhash } : {}),
+      },
+    ];
+  });
+
+  return gifs;
 };
 
 export const useFavoriteGifs =
   (): AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS] => {
     const favoritedGifsData = useAccountData(MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS);
-    const favoritedContent =
-      favoritedGifsData?.getContent<
-        AccountDataEvents[typeof MATRIX_SABLE_UNSTABLE_FAVORITE_GIFS]
-      >() ?? DEFAULT_FAVORITE_GIFS;
+    const gifs = useMemo(
+      () => normalizeFavoriteGifs(favoritedGifsData?.getContent()),
+      [favoritedGifsData]
+    );
 
-    return favoritedContent;
+    return { gifs };
   };

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -153,6 +153,7 @@ export interface Settings {
   encUrlPreview: boolean;
   clientUrlPreview: boolean;
   encClientUrlPreview: boolean;
+  externalGifAutoLoadEncrypted: boolean;
   clientPreviewYoutube: boolean;
   enableGifPicker: boolean;
   showInteractiveMap: boolean;
@@ -329,6 +330,7 @@ export const defaultSettings: Settings = {
   encUrlPreview: false,
   clientUrlPreview: false,
   encClientUrlPreview: false,
+  externalGifAutoLoadEncrypted: false,
   clientPreviewYoutube: false,
   enableGifPicker: true,
   showInteractiveMap: true,

--- a/src/app/utils/externalGif.test.ts
+++ b/src/app/utils/externalGif.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { parseExternalGif } from './externalGif';
+
+const content = {
+  msgtype: 'm.text',
+  body: 'https://klipy.com/gif/id',
+  'pet.plz.gif': {
+    v: 1,
+    provider: 'klipy',
+    media_url: 'https://static.klipy.com/ii/example.gif',
+    w: 480,
+    h: 270,
+  },
+};
+
+describe('parseExternalGif', () => {
+  it('parses valid provider metadata', () => {
+    expect(parseExternalGif(content)).toMatchObject(content['pet.plz.gif']);
+  });
+
+  it('fails closed for unsupported versions, dimensions, and hosts', () => {
+    expect(
+      parseExternalGif({ ...content, 'pet.plz.gif': { ...content['pet.plz.gif'], v: 2 } })
+    ).toBe(undefined);
+    expect(
+      parseExternalGif({
+        ...content,
+        'pet.plz.gif': { ...content['pet.plz.gif'], w: 0 },
+      })
+    ).toBeUndefined();
+    expect(
+      parseExternalGif({
+        ...content,
+        'pet.plz.gif': {
+          ...content['pet.plz.gif'],
+          media_url: 'https://attacker.example/track.gif',
+        },
+      })
+    ).toBeUndefined();
+  });
+});

--- a/src/app/utils/externalGif.ts
+++ b/src/app/utils/externalGif.ts
@@ -1,0 +1,88 @@
+export type ExternalGifContent = {
+  v: 1;
+  provider: string;
+  media_url: string;
+  w: number;
+  h: number;
+  mimetype?: string;
+  size?: number;
+  blurhash?: string;
+  id?: string;
+  title?: string;
+};
+
+export type ExternalGif = ExternalGifContent;
+
+export type ExternalGifProvider = {
+  id: string;
+  isMediaUrlAllowed: (url: URL) => boolean;
+};
+
+const MAX_DIMENSION = 8192;
+const externalGifProviders: Record<string, ExternalGifProvider> = {
+  klipy: {
+    id: 'klipy',
+    isMediaUrlAllowed: (url) =>
+      url.protocol === 'https:' &&
+      url.hostname === 'static.klipy.com' &&
+      url.port === '' &&
+      url.username === '' &&
+      url.password === '' &&
+      /^\/ii\/.+/.test(url.pathname),
+  },
+};
+
+export function isAllowedKlipyMediaUrl(value: string | URL): boolean {
+  try {
+    const url = typeof value === 'string' ? new URL(value) : value;
+    return externalGifProviders.klipy?.isMediaUrlAllowed(url) === true;
+  } catch {
+    return false;
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+export const isValidExternalGifDimension = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value > 0 && value <= MAX_DIMENSION;
+
+export function parseExternalGif(content: unknown): ExternalGif | undefined {
+  if (!isRecord(content) || content.msgtype !== 'm.text') return undefined;
+  const raw = content['pet.plz.gif'];
+  if (!isRecord(raw) || raw.v !== 1 || typeof raw.provider !== 'string') return undefined;
+
+  const provider = Object.prototype.hasOwnProperty.call(externalGifProviders, raw.provider)
+    ? externalGifProviders[raw.provider]
+    : undefined;
+  if (
+    !provider ||
+    typeof raw.media_url !== 'string' ||
+    !isValidExternalGifDimension(raw.w) ||
+    !isValidExternalGifDimension(raw.h)
+  ) {
+    return undefined;
+  }
+  let mediaUrl: URL;
+  try {
+    mediaUrl = new URL(raw.media_url);
+  } catch {
+    return undefined;
+  }
+  if (!provider.isMediaUrlAllowed(mediaUrl)) return undefined;
+
+  return {
+    v: 1,
+    provider: provider.id,
+    media_url: raw.media_url,
+    w: raw.w,
+    h: raw.h,
+    ...(typeof raw.mimetype === 'string' ? { mimetype: raw.mimetype } : {}),
+    ...(typeof raw.size === 'number' && Number.isSafeInteger(raw.size) && raw.size >= 0
+      ? { size: raw.size }
+      : {}),
+    ...(typeof raw.blurhash === 'string' ? { blurhash: raw.blurhash } : {}),
+    ...(typeof raw.id === 'string' ? { id: raw.id } : {}),
+    ...(typeof raw.title === 'string' ? { title: raw.title } : {}),
+  };
+}

--- a/src/app/utils/favoriteGif.test.ts
+++ b/src/app/utils/favoriteGif.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { getFavoriteGifFromMessageContent } from './favoriteGif';
+
+describe('getFavoriteGifFromMessageContent', () => {
+  it('preserves external GIF metadata when favoriting a timeline message', () => {
+    expect(
+      getFavoriteGifFromMessageContent({
+        msgtype: 'm.text',
+        body: 'https://klipy.com/gif/reaction',
+        'pet.plz.gif': {
+          v: 1,
+          provider: 'klipy',
+          media_url: 'https://static.klipy.com/ii/reaction.gif',
+          w: 480,
+          h: 270,
+          mimetype: 'image/gif',
+          size: 1234,
+          title: 'Reaction',
+          blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+        },
+      })
+    ).toEqual({
+      title: 'Reaction',
+      shareUrl: 'https://klipy.com/gif/reaction',
+      mediaUrl: 'https://static.klipy.com/ii/reaction.gif',
+      width: 480,
+      height: 270,
+      size: 1234,
+      mimetype: 'image/gif',
+      blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    });
+  });
+
+  it('keeps standard MXC image favorites on the existing path', () => {
+    expect(
+      getFavoriteGifFromMessageContent({
+        msgtype: 'm.image',
+        body: 'Favorite',
+        url: 'mxc://example.org/media-id',
+        info: { w: 320, h: 240, mimetype: 'image/gif' },
+      })
+    ).toMatchObject({
+      title: 'Favorite',
+      shareUrl: 'mxc://example.org/media-id',
+      mediaUrl: 'mxc://example.org/media-id',
+      width: 320,
+      height: 240,
+      mimetype: 'image/gif',
+    });
+  });
+
+  it('uses the decoded media URL for historical Soliditas GIFs', () => {
+    expect(
+      getFavoriteGifFromMessageContent({
+        msgtype: 'm.image',
+        body: 'Reaction',
+        url: 'mxc://gifs.sable.moe/klipy_ZXhhbXBsZS5naWY',
+        info: { w: 480, h: 270, mimetype: 'image/gif' },
+      })
+    ).toMatchObject({
+      title: 'Reaction',
+      shareUrl: 'https://static.klipy.com/ii/example.gif',
+      mediaUrl: 'https://static.klipy.com/ii/example.gif',
+      width: 480,
+      height: 270,
+    });
+  });
+});

--- a/src/app/utils/favoriteGif.ts
+++ b/src/app/utils/favoriteGif.ts
@@ -1,0 +1,49 @@
+import type { GifData } from '$components/emoji-board/types';
+import type { IImageInfo } from '$types/matrix/common';
+import { MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME } from '$unstable/prefixes';
+import { parseExternalGif } from './externalGif';
+import { parseLegacyKlipyGif } from './klipy';
+
+const getIncomingMediaMxcUrl = (url: unknown): string | undefined =>
+  typeof url === 'string' && url.startsWith('mxc://') ? url : undefined;
+
+export const getFavoriteGifFromMessageContent = (
+  content: Record<string, unknown>
+): Omit<GifData, 'id'> | undefined => {
+  const externalGif = parseExternalGif(content);
+  const legacyGif = externalGif ? undefined : parseLegacyKlipyGif(content);
+  const gif = externalGif ?? legacyGif;
+  if (gif) {
+    return {
+      title: gif.title ?? '',
+      shareUrl: externalGif && typeof content.body === 'string' ? content.body : gif.media_url,
+      mediaUrl: gif.media_url,
+      width: gif.w,
+      height: gif.h,
+      ...(gif.size !== undefined ? { size: gif.size } : {}),
+      ...(gif.mimetype ? { mimetype: gif.mimetype } : {}),
+      ...(gif.blurhash ? { blurhash: gif.blurhash } : {}),
+    };
+  }
+
+  const file = content.file;
+  const fileUrl =
+    file && typeof file === 'object' && !Array.isArray(file)
+      ? (file as { url?: unknown }).url
+      : undefined;
+  const url = getIncomingMediaMxcUrl(fileUrl ?? content.url);
+  if (!url) return undefined;
+  const info = content.info as IImageInfo | undefined;
+  return {
+    title: typeof content.body === 'string' ? content.body : '',
+    shareUrl: url,
+    mediaUrl: url,
+    ...(info?.w !== undefined ? { width: info.w } : {}),
+    ...(info?.h !== undefined ? { height: info.h } : {}),
+    ...(info?.size !== undefined ? { size: info.size } : {}),
+    ...(info?.mimetype ? { mimetype: info.mimetype } : {}),
+    ...(info?.[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME]
+      ? { blurhash: info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] }
+      : {}),
+  };
+};

--- a/src/app/utils/klipy.test.ts
+++ b/src/app/utils/klipy.test.ts
@@ -1,25 +1,78 @@
 import { describe, expect, it } from 'vitest';
-import { getKlipyMxcUrl, getSendableKlipyMxcUrl } from './klipy';
+import { getKlipyGifMetadata, isAllowedKlipyMediaUrl, parseLegacyKlipyGif } from './klipy';
 
-describe('getKlipyMxcUrl', () => {
+describe('Klipy external GIF metadata', () => {
   const gifUrl = 'https://static.klipy.com/ii/example.gif';
 
-  it('does not create an MXC URL without a proxy', () => {
-    expect(getKlipyMxcUrl(gifUrl)).toBe(gifUrl);
-    expect(getSendableKlipyMxcUrl(gifUrl)).toBeUndefined();
-    expect(getSendableKlipyMxcUrl(gifUrl, '   ')).toBeUndefined();
+  it('accepts only approved media URLs', () => {
+    expect(isAllowedKlipyMediaUrl(gifUrl)).toBe(true);
+    expect(isAllowedKlipyMediaUrl('https://static.klipy.com.attacker.example/ii/a.gif')).toBe(
+      false
+    );
+    expect(isAllowedKlipyMediaUrl('https://static.klipy.com:8443/ii/a.gif')).toBe(false);
+    expect(isAllowedKlipyMediaUrl('https://user:pass@static.klipy.com/ii/a.gif')).toBe(false);
   });
 
-  it('allows an existing MXC favorite without a proxy', () => {
-    expect(getSendableKlipyMxcUrl('mxc://example.org/existing')).toBe('mxc://example.org/existing');
+  it('builds direct-link metadata without an MXC', () => {
+    expect(
+      getKlipyGifMetadata({
+        id: 'id',
+        title: 'Reaction',
+        mediaUrl: gifUrl,
+        shareUrl: 'https://klipy.com/gif/id',
+        width: 480,
+        height: 270,
+        mimetype: 'image/gif',
+      })
+    ).toMatchObject({
+      v: 1,
+      provider: 'klipy',
+      media_url: gifUrl,
+      w: 480,
+      h: 270,
+    });
   });
 
-  it('creates an MXC URL when a proxy is configured', () => {
-    expect(getKlipyMxcUrl(gifUrl, 'media.example.org')).toMatch(
-      /^mxc:\/\/media\.example\.org\/klipy_[A-Za-z0-9_-]+$/
-    );
-    expect(getSendableKlipyMxcUrl(gifUrl, 'media.example.org')).toMatch(
-      /^mxc:\/\/media\.example\.org\/klipy_[A-Za-z0-9_-]+$/
-    );
+  it('serializes large provider IDs as strings', () => {
+    const metadata = getKlipyGifMetadata({
+      id: 9188075299582436,
+      title: 'Reaction',
+      mediaUrl: gifUrl,
+      shareUrl: gifUrl,
+      width: 480,
+      height: 270,
+    } as unknown as Parameters<typeof getKlipyGifMetadata>[0]);
+
+    expect(metadata?.id).toBe('9188075299582436');
+  });
+
+  it('decodes historical Soliditas MXC events to external GIF metadata', () => {
+    expect(
+      parseLegacyKlipyGif({
+        msgtype: 'm.image',
+        body: 'Reaction',
+        url: 'mxc://gifs.sable.moe/klipy_ZXhhbXBsZS5naWY',
+        info: { w: 480, h: 270, mimetype: 'image/gif' },
+      })
+    ).toMatchObject({
+      provider: 'klipy',
+      media_url: gifUrl,
+      w: 480,
+      h: 270,
+      title: 'Reaction',
+    });
+  });
+
+  it('shares the inbound dimension limit on outgoing metadata', () => {
+    expect(
+      getKlipyGifMetadata({
+        id: 'id',
+        title: 'Too large',
+        mediaUrl: gifUrl,
+        shareUrl: gifUrl,
+        width: 8193,
+        height: 270,
+      })
+    ).toBeUndefined();
   });
 });

--- a/src/app/utils/klipy.ts
+++ b/src/app/utils/klipy.ts
@@ -1,32 +1,137 @@
-function toBase64Url(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  let binary = '';
+import type { GifData } from '$components/emoji-board/types';
+import type { ExternalGifContent } from './externalGif';
+import { isAllowedKlipyMediaUrl, isValidExternalGifDimension } from './externalGif';
+import { encodeBlurHashAsync } from './blurHash';
+import { loadImageElement } from './dom';
+import { MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME } from '$unstable/prefixes';
 
-  for (const byte of bytes) {
-    binary += String.fromCodePoint(byte);
+const LEGACY_MEDIA_PREFIX = 'klipy_';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+function decodeBase64Url(value: string): string | undefined {
+  try {
+    if (!/^[A-Za-z0-9_-]+$/.test(value)) return undefined;
+    const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    const binary = atob(padded);
+    return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)));
+  } catch {
+    return undefined;
+  }
+}
+
+export function decodeLegacyKlipyMxc(mxcUrl: string): string | undefined {
+  try {
+    const mxc = new URL(mxcUrl);
+    const encoded = mxc.pathname.slice(1);
+    if (
+      mxc.protocol !== 'mxc:' ||
+      mxc.hostname !== 'gifs.sable.moe' ||
+      mxc.port !== '' ||
+      mxc.username !== '' ||
+      mxc.password !== '' ||
+      mxc.search !== '' ||
+      mxc.hash !== '' ||
+      !encoded.startsWith(LEGACY_MEDIA_PREFIX)
+    ) {
+      return undefined;
+    }
+
+    const path = decodeBase64Url(encoded.slice(LEGACY_MEDIA_PREFIX.length));
+    const mediaUrl = path ? `https://static.klipy.com/ii/${path}` : undefined;
+    return mediaUrl && isAllowedKlipyMediaUrl(mediaUrl) ? mediaUrl : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseLegacyKlipyGif(content: unknown): ExternalGifContent | undefined {
+  if (!isRecord(content) || content.msgtype !== 'm.image') return undefined;
+
+  const file = content.file;
+  const mxcUrl =
+    typeof content.url === 'string'
+      ? content.url
+      : isRecord(file) && typeof file.url === 'string'
+        ? file.url
+        : undefined;
+  const mediaUrl = mxcUrl ? decodeLegacyKlipyMxc(mxcUrl) : undefined;
+  const info = isRecord(content.info) ? content.info : undefined;
+  const width = info?.w;
+  const height = info?.h;
+  if (!mediaUrl || !isValidExternalGifDimension(width) || !isValidExternalGifDimension(height)) {
+    return undefined;
   }
 
-  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll(/=+$/g, '');
+  return {
+    v: 1,
+    provider: 'klipy',
+    media_url: mediaUrl,
+    w: width,
+    h: height,
+    ...(typeof info?.mimetype === 'string' ? { mimetype: info.mimetype } : {}),
+    ...(typeof info?.size === 'number' && Number.isSafeInteger(info.size) && info.size >= 0
+      ? { size: info.size }
+      : {}),
+    ...(typeof info?.[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] === 'string'
+      ? { blurhash: info[MATRIX_UNSTABLE_BLUR_HASH_PROPERTY_NAME] }
+      : {}),
+    ...(typeof content.body === 'string' ? { title: content.body } : {}),
+  };
 }
 
-function toMatrixID(fname: string, urlPrefix: string): string {
-  const base64 = toBase64Url(fname);
-  return urlPrefix + base64;
-}
-
-export function getKlipyMxcUrl(url: string, proxyUrl?: string): string {
-  if (url.startsWith('mxc://')) return url;
-  if (!proxyUrl) return url;
-  if (url.startsWith('https://static.klipy.com/ii/')) {
-    const id = url.slice('https://static.klipy.com/ii/'.length);
-    return `mxc://${proxyUrl}/${toMatrixID(id, 'klipy_')}`;
+export async function getKlipyGifBlurhash(gif: GifData): Promise<string | undefined> {
+  const source =
+    gif.preview_url && isAllowedKlipyMediaUrl(gif.preview_url) ? gif.preview_url : gif.mediaUrl;
+  if (
+    !isAllowedKlipyMediaUrl(source) ||
+    !isValidExternalGifDimension(gif.width) ||
+    !isValidExternalGifDimension(gif.height)
+  ) {
+    return undefined;
   }
-  return url;
+
+  try {
+    const image = await loadImageElement(source, 'anonymous');
+    const width = 32;
+    const height = Math.max(1, Math.min(32, Math.round((width * gif.height) / gif.width)));
+    return await encodeBlurHashAsync(image, width, height);
+  } catch {
+    return undefined;
+  }
 }
 
-export function getSendableKlipyMxcUrl(url: string, proxyUrl?: string): string | undefined {
-  if (url.startsWith('mxc://')) return url;
-  if (!proxyUrl?.trim()) return undefined;
-  const mxcUrl = getKlipyMxcUrl(url, proxyUrl);
-  return mxcUrl.startsWith('mxc://') ? mxcUrl : undefined;
+export function getKlipyGifMetadata(gif: GifData): ExternalGifContent | undefined {
+  const mediaUrl = gif.mediaUrl;
+  const width = gif.width;
+  const height = gif.height;
+  const idValue: unknown = gif.id;
+  const id =
+    typeof idValue === 'string' || typeof idValue === 'number' ? String(idValue) : undefined;
+  if (
+    !isAllowedKlipyMediaUrl(mediaUrl) ||
+    !isValidExternalGifDimension(width) ||
+    !isValidExternalGifDimension(height)
+  ) {
+    return undefined;
+  }
+
+  return {
+    v: 1,
+    provider: 'klipy',
+    media_url: mediaUrl,
+    w: width,
+    h: height,
+    ...(gif.mimetype ? { mimetype: gif.mimetype } : {}),
+    ...(typeof gif.size === 'number' && Number.isSafeInteger(gif.size) && gif.size > 0
+      ? { size: gif.size }
+      : {}),
+    ...(id ? { id } : {}),
+    ...(gif.title ? { title: gif.title } : {}),
+    ...(gif.blurhash ? { blurhash: gif.blurhash } : {}),
+  };
 }
+
+export { isAllowedKlipyMediaUrl };


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

To appease the klipy overlords.

Removes all uses of the gif proxy. Previous favorites/sent gifs are still rendered and parsed fully client side, so everything should migrate cleanly. Gifs now go directly to klipy, no homeserver or gif proxy intermediary to fully comply with Klipy's integration requirements.

Obviously, this now means gifs will likely not appear on any clients other than Sable (it would just be a message with a raw link, so it would be dependent on homeserver fetching, sable attaches some metadata to the message to make it easier for us to render blurhash and sizes) and it means gifs are always going to be directly loaded by the client so there's a little bit of a privacy issue there, but I can't find any other way to satisfy Klipy.

Toggle for unencrypted rooms is baked into the disable media autoload. There's an explicit opt-in toggle for automatically loading external gifs for encrypted rooms.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
