### PR TITLE
fix(media): fall back to the original when a homeserver thumbnail drops EXIF orientation

### DIFF
--- a/src/app/components/message/content/ImageContent.test.tsx
+++ b/src/app/components/message/content/ImageContent.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ImageContent } from './ImageContent';
-import { downloadEncryptedMedia } from '$utils/matrix';
+import { downloadEncryptedMedia, mxcUrlToHttp } from '$utils/matrix';
 
 const screenMocks = vi.hoisted(() => ({ isMobile: true, tauri: false }));
 vi.mock('$hooks/useScreenSize', () => ({
@@ -21,7 +21,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 const SABLE_MEDIA_URL =
   'sable-media://https://hs.example/_matrix/client/v1/media/download/example.org/abc123?__sable_media_cache=3';
 vi.mock('$utils/matrix', () => ({
-  mxcUrlToHttp: () => SABLE_MEDIA_URL,
+  mxcUrlToHttp: vi.fn<(...args: unknown[]) => string>(() => SABLE_MEDIA_URL),
   rewriteAuthenticatedMediaUrl: (url: string | null) => url,
   downloadEncryptedMedia: vi.fn<() => Promise<ArrayBuffer>>(),
   decryptFile: vi.fn<() => Promise<ArrayBuffer>>(),
@@ -228,6 +228,41 @@ describe('ImageContent', () => {
     } finally {
       screenMocks.tauri = false;
     }
+  });
+
+  it('falls back to the original when the homeserver thumbnail is transposed', async () => {
+    vi.mocked(mxcUrlToHttp).mockClear();
+    render(
+      <ImageContent
+        url="mxc://example.org/abc123"
+        info={{ w: 1500, h: 2000, size: 4 * 1024 * 1024, mimetype: 'image/jpeg' }}
+        renderImage={(props) => <img alt="preview" src={props.src} onLoad={props.onLoad} />}
+        renderViewer={() => <div>viewer</div>}
+      />
+    );
+
+    touchTap(screen.getByRole('button', { name: 'View' }));
+    const img = await screen.findByAltText('preview');
+    expect(vi.mocked(mxcUrlToHttp).mock.calls.at(-1)).toEqual([
+      {},
+      'mxc://example.org/abc123',
+      false,
+      800,
+      600,
+      'scale',
+    ]);
+
+    Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    fireEvent.load(img);
+
+    await waitFor(() =>
+      expect(vi.mocked(mxcUrlToHttp).mock.calls.at(-1)).toEqual([
+        {},
+        'mxc://example.org/abc123',
+        false,
+      ])
+    );
   });
 
   it('still allows ordinary message touches to start long press', () => {

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactNode, SyntheticEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Badge,
@@ -95,6 +95,14 @@ function wantsThumbnail(info: IImageInfo | undefined, width: number, height: num
   return window.devicePixelRatio === 1 || info.size > THUMBNAIL_MIN_SOURCE_BYTES;
 }
 
+// `info.w`/`info.h` have the source EXIF orientation applied; homeservers that scale raw pixels
+// return a transposed thumbnail with no EXIF left for the browser to correct.
+function isTransposedThumbnail(info: IImageInfo | undefined, image: HTMLImageElement): boolean {
+  const { naturalWidth, naturalHeight } = image;
+  if (!info?.w || !info.h || !naturalWidth || !naturalHeight) return false;
+  return info.w > info.h !== naturalWidth > naturalHeight;
+}
+
 type RenderViewerProps = {
   src: string;
   alt: string;
@@ -108,7 +116,7 @@ type RenderImageProps = {
   title: string;
   src: string;
   info?: IImageInfo;
-  onLoad: () => void;
+  onLoad: (event?: SyntheticEvent<HTMLImageElement>) => void;
   onError: () => void;
   onLottieLoad: () => void;
   onLottieError: () => void;
@@ -255,7 +263,11 @@ export const ImageContent = as<'div', ImageContentProps>(
       };
     }, [viewer, usesThumbnail, url, mx, useAuthentication]);
 
-    const handleLoad = () => {
+    const handleLoad = (event?: SyntheticEvent<HTMLImageElement>) => {
+      if (usesThumbnail && event && isTransposedThumbnail(info, event.currentTarget)) {
+        setThumbnailFailed(true);
+        return;
+      }
       setLoad(true);
     };
     const handleError = () => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
