### PR TITLE
fix(sliding-sync): keep the head back-pagination token on overlapping limited responses

### DIFF
--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -428,6 +428,15 @@ export const prepareSlidingSyncTimelines = (
       continue;
     }
 
+    // The SDK writes prev_batch over the live timeline's BACKWARDS token on every
+    // limited response. When the window starts at an event we already have below
+    // our top, nothing is prepended and the top does not move, so that token would
+    // back-paginate from the wrong stream position and prepend newer events.
+    if (timelineData.limited === true && firstKnownResponseIndex === 0 && firstKnownLiveIndex > 0) {
+      const topToken = liveTimeline?.getPaginationToken(EventTimeline.BACKWARDS);
+      if (typeof topToken === 'string') timelineData.prev_batch = topToken;
+    }
+
     if (!shouldMarkLimited) {
       continue;
     }

--- a/src/client/slidingSyncTimelineReconciliation.test.ts
+++ b/src/client/slidingSyncTimelineReconciliation.test.ts
@@ -600,6 +600,37 @@ describe('timeline reconciliation in matrix-js-sdk', () => {
     expect(timelineIds(mx)).toEqual(['$e3', '$e4']);
   });
 
+  it('keeps the top-of-timeline token when a limited response overlaps mid-timeline', async () => {
+    const { mx, deliver } = makeSdk();
+    await deliver(roomId, {
+      initial: true,
+      required_state: [],
+      timeline: history,
+      limited: true,
+      prev_batch: 'top-token',
+    } as unknown as MSC3575RoomData);
+    const room = mx.getRoom(roomId)!;
+    expect(room.getLiveTimeline().getPaginationToken(EventTimeline.BACKWARDS)).toBe('top-token');
+
+    const roomData = {
+      required_state: [],
+      timeline: [newest, message('$e4', 400)],
+      limited: true,
+      prev_batch: 'mid-token',
+    } as unknown as MSC3575RoomData;
+    const resp = {
+      pos: 'p4',
+      rooms: { [roomId]: roomData },
+    } as unknown as MSC3575SlidingSyncResponse;
+    prepareSlidingSyncTimelines(resp, mx);
+    await deliver(roomId, roomData);
+
+    expect(timelineIds(mx)).toEqual(['$e1', '$e2', '$e3', '$e4']);
+    // 'mid-token' paginates back from $e3, so it would prepend above $e1 events
+    // that belong below it.
+    expect(room.getLiveTimeline().getPaginationToken(EventTimeline.BACKWARDS)).toBe('top-token');
+  });
+
   it('keeps a usable back-pagination token after reconciling', async () => {
     const { mx, deliver } = makeSdk();
     await deliver(roomId, initialRoomData(newest));


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
