### PR TITLE
fix(editor): restore composer focus after the autocomplete menu closes

### DIFF
--- a/src/app/components/editor/autocomplete/index.ts
+++ b/src/app/components/editor/autocomplete/index.ts
@@ -1,5 +1,6 @@
 export * from './AutocompleteMenu';
 export * from './autocompleteQuery';
+export * from './useAutocompleteQuery';
 export * from './RoomMentionAutocomplete';
 export * from './UserMentionAutocomplete';
 export * from './EmoticonAutocomplete';

--- a/src/app/components/editor/autocomplete/useAutocompleteQuery.test.tsx
+++ b/src/app/components/editor/autocomplete/useAutocompleteQuery.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type {
+  EditorAutocompleteQuery,
+  ProseMirrorEditorController,
+} from '../prosemirrorController';
+import { AutocompletePrefix } from './autocompleteQuery';
+import { useAutocompleteQuery } from './useAutocompleteQuery';
+
+const query: EditorAutocompleteQuery<AutocompletePrefix> = {
+  prefix: AutocompletePrefix.Emoticon,
+  text: 'smile',
+  from: 0,
+  to: 6,
+};
+
+const setup = () => {
+  const events: string[] = [];
+  const editor = {
+    focus: () => events.push('focus'),
+  } as unknown as ProseMirrorEditorController;
+
+  function Harness() {
+    const [autocompleteQuery, setAutocompleteQuery, closeAutocomplete] =
+      useAutocompleteQuery(editor);
+    return (
+      <>
+        <button type="button" onClick={() => setAutocompleteQuery(query)}>
+          open
+        </button>
+        <button type="button" onClick={closeAutocomplete}>
+          close
+        </button>
+        {autocompleteQuery && (
+          <div
+            ref={(node) => {
+              if (!node) events.push('menu-unmount');
+            }}
+          />
+        )}
+      </>
+    );
+  }
+
+  return { events, view: render(<Harness />) };
+};
+
+describe('useAutocompleteQuery', () => {
+  it('focuses the editor only once the menu is unmounted', () => {
+    const { events, view } = setup();
+
+    fireEvent.click(view.getByText('open'));
+    fireEvent.click(view.getByText('close'));
+
+    expect(events).toEqual(['menu-unmount', 'focus']);
+  });
+
+  it('does not focus the editor when no menu is open', () => {
+    const { events, view } = setup();
+
+    fireEvent.click(view.getByText('close'));
+
+    expect(events).toEqual([]);
+  });
+});

--- a/src/app/components/editor/autocomplete/useAutocompleteQuery.ts
+++ b/src/app/components/editor/autocomplete/useAutocompleteQuery.ts
@@ -1,0 +1,26 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+import type {
+  EditorAutocompleteQuery,
+  ProseMirrorEditorController,
+} from '../prosemirrorController';
+import type { AutocompletePrefix } from './autocompleteQuery';
+
+export function useAutocompleteQuery(editor: ProseMirrorEditorController) {
+  const [query, setQuery] = useState<EditorAutocompleteQuery<AutocompletePrefix>>();
+  const refocusEditor = useRef(false);
+
+  useLayoutEffect(() => {
+    if (query !== undefined || !refocusEditor.current) return;
+    refocusEditor.current = false;
+    editor.focus();
+  }, [query, editor]);
+
+  const close = useCallback(() => {
+    if (query === undefined) return;
+    refocusEditor.current = true;
+    setQuery(undefined);
+  }, [query]);
+
+  return [query, setQuery, close] as const;
+}

--- a/src/app/components/upload-card/UploadDescriptionEditor.tsx
+++ b/src/app/components/upload-card/UploadDescriptionEditor.tsx
@@ -1,14 +1,14 @@
 import type { KeyboardEventHandler } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { Room } from '$types/matrix-sdk';
 import type { RectCords } from 'folds';
 import { Box, Chip, IconButton, Spinner, Text, config } from 'folds';
 import { PopOut } from '$components/overlay-stack';
 import { Smiley, sizedIcon } from '$components/icons/phosphor';
 import { isKeyHotkey } from 'is-hotkey';
-import type { EditorAutocompleteQuery } from '$components/editor/prosemirrorController';
 import {
   AutocompletePrefix,
+  useAutocompleteQuery,
   EmoticonAutocomplete,
   MarkdownFormattingToolbarBottom,
   MarkdownFormattingToolbarToggle,
@@ -47,8 +47,8 @@ export function DescriptionEditor({
   const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
   const [shortcutOverrides] = useSetting(settingsAtom, 'shortcutOverrides');
 
-  const [autocompleteQuery, setAutocompleteQuery] =
-    useState<EditorAutocompleteQuery<AutocompletePrefix>>();
+  const [autocompleteQuery, setAutocompleteQuery, handleCloseAutocomplete] =
+    useAutocompleteQuery(editor);
 
   const prevValue = useRef(value);
   const initialized = useRef(false);
@@ -119,13 +119,8 @@ export function DescriptionEditor({
       }
       setAutocompleteQuery(editor.getAutocompleteQuery([AutocompletePrefix.Emoticon]));
     },
-    [editor, onCancel]
+    [editor, onCancel, setAutocompleteQuery]
   );
-
-  const handleCloseAutocomplete = useCallback(() => {
-    editor.focus();
-    setAutocompleteQuery(undefined);
-  }, [editor]);
 
   const handleEmoticonSelect = (key: string, shortcode: string) => {
     editor.insertInline(createEmoticonElement(key, shortcode));

--- a/src/app/features/room/RoomInput.test.tsx
+++ b/src/app/features/room/RoomInput.test.tsx
@@ -130,7 +130,9 @@ vi.mock('$state/upload', async () => {
   };
 });
 
-vi.mock('$components/editor', () => {
+vi.mock('$components/editor', async () => {
+  const { useAutocompleteQuery } =
+    await import('$components/editor/autocomplete/useAutocompleteQuery');
   const textOf = (nodes: any[]): string =>
     nodes
       .map((node) => (typeof node.text === 'string' ? node.text : textOf(node.children ?? [])))
@@ -204,6 +206,7 @@ vi.mock('$components/editor', () => {
     toPlainText: textOf,
     trimCommand: (_command: unknown, text: string) => text,
     trimCustomHtml: (html: string) => html,
+    useAutocompleteQuery,
   };
 });
 

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -50,12 +50,10 @@ import {
 import { Overlay, PopOut } from '$components/overlay-stack';
 
 import { useMatrixClient } from '$hooks/useMatrixClient';
-import type {
-  EditorAutocompleteQuery,
-  ProseMirrorEditorController,
-} from '$components/editor/prosemirrorController';
+import type { ProseMirrorEditorController } from '$components/editor/prosemirrorController';
 import {
   AutocompletePrefix,
+  useAutocompleteQuery,
   createEmoticonElement,
   CustomEditor,
   customHtmlEqualsPlainText,
@@ -458,8 +456,8 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       },
       []
     );
-    const [autocompleteQuery, setAutocompleteQuery] =
-      useState<EditorAutocompleteQuery<AutocompletePrefix>>();
+    const [autocompleteQuery, setAutocompleteQuery, handleCloseAutocomplete] =
+      useAutocompleteQuery(editor);
     const [isQuickTextReact, setQuickTextReact] = useState(false);
 
     const replyDraftBase = useMemo(
@@ -638,7 +636,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         editor.getAutocompleteQuery(ANYWHERE_AUTOCOMPLETE_PREFIXES);
 
       setAutocompleteQuery(query);
-    }, [editor]);
+    }, [editor, setAutocompleteQuery]);
 
     const handleEditorChange = useCallback(() => {
       setHasText(!editor.isEmpty());
@@ -1370,15 +1368,6 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       });
     };
 
-    const handleCloseAutocomplete = useCallback(() => {
-      setAutocompleteQuery((prev) => {
-        if (prev !== undefined) {
-          editor.focus();
-        }
-        return undefined;
-      });
-    }, [editor]);
-
     const handleQuickReact = useCallback(
       (key: string, shortcode?: string) => {
         if (key.length > 0) {
@@ -1772,6 +1761,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         setReplyDraft,
         enterForNewline,
         autocompleteQuery,
+        setAutocompleteQuery,
         isComposing,
         showAudioRecorder,
         editor,

--- a/src/app/features/room/message/MessageEditor.tsx
+++ b/src/app/features/room/message/MessageEditor.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAtomValue } from 'jotai';
 import type { RectCords } from 'folds';
 import { Box, Chip, IconButton, OverlayBackdrop, Spinner, Text, as, config } from 'folds';
@@ -16,9 +16,9 @@ import type {
 import { MsgType } from '$types/matrix-sdk';
 import { isKeyHotkey } from 'is-hotkey';
 import type { EditorDocument } from '$components/editor/model';
-import type { EditorAutocompleteQuery } from '$components/editor/prosemirrorController';
 import {
   AutocompletePrefix,
+  useAutocompleteQuery,
   CustomEditor,
   EmoticonAutocomplete,
   MarkdownFormattingToolbarBottom,
@@ -115,8 +115,8 @@ export const MessageEditor = as<'div', MessageEditorProps>(
     const [pmpNoFallback] = useSetting(settingsAtom, 'pmpNoFallback');
     const isComposing = useComposingCheck();
 
-    const [autocompleteQuery, setAutocompleteQuery] =
-      useState<EditorAutocompleteQuery<AutocompletePrefix>>();
+    const [autocompleteQuery, setAutocompleteQuery, handleCloseAutocomplete] =
+      useAutocompleteQuery(editor);
 
     const getPrevBodyAndFormattedBody = useCallback((): [
       string | undefined,
@@ -321,7 +321,7 @@ export const MessageEditor = as<'div', MessageEditorProps>(
 
     const detectAutocomplete = useCallback(() => {
       setAutocompleteQuery(editor.getAutocompleteQuery(ANYWHERE_AUTOCOMPLETE_PREFIXES));
-    }, [editor]);
+    }, [editor, setAutocompleteQuery]);
 
     const handleKeyUp: KeyboardEventHandler = useCallback(
       (evt) => {
@@ -334,15 +334,6 @@ export const MessageEditor = as<'div', MessageEditorProps>(
       },
       [detectAutocomplete]
     );
-
-    const handleCloseAutocomplete = useCallback(() => {
-      setAutocompleteQuery((prev) => {
-        if (prev !== undefined) {
-          editor.focus();
-        }
-        return undefined;
-      });
-    }, [editor]);
 
     const handleEmoticonSelect = (key: string, shortcode: string) => {
       editor.insertInline(createEmoticonElement(key, shortcode));

--- a/src/app/features/settings/account/BioEditor.tsx
+++ b/src/app/features/settings/account/BioEditor.tsx
@@ -6,9 +6,9 @@ import { Box, Chip, IconButton, Spinner, Text, config } from 'folds';
 import { PopOut } from '$components/overlay-stack';
 import { composerIcon, Smiley } from '$components/icons/phosphor';
 import { isKeyHotkey } from 'is-hotkey';
-import type { EditorAutocompleteQuery } from '$components/editor/prosemirrorController';
 import {
   AutocompletePrefix,
+  useAutocompleteQuery,
   EmoticonAutocomplete,
   MarkdownFormattingToolbarBottom,
   MarkdownFormattingToolbarToggle,
@@ -41,8 +41,8 @@ export function BioEditor({ value, isSaving, imagePackRooms, onSave }: BioEditor
   const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
   const [shortcutOverrides] = useSetting(settingsAtom, 'shortcutOverrides');
 
-  const [autocompleteQuery, setAutocompleteQuery] =
-    useState<EditorAutocompleteQuery<AutocompletePrefix>>();
+  const [autocompleteQuery, setAutocompleteQuery, handleCloseAutocomplete] =
+    useAutocompleteQuery(editor);
   const [hasChanged, setHasChanged] = useState(false);
 
   const prevValue = useRef(value);
@@ -116,13 +116,8 @@ export function BioEditor({ value, isSaving, imagePackRooms, onSave }: BioEditor
       }
       setAutocompleteQuery(editor.getAutocompleteQuery([AutocompletePrefix.Emoticon]));
     },
-    [editor]
+    [editor, setAutocompleteQuery]
   );
-
-  const handleCloseAutocomplete = useCallback(() => {
-    editor.focus();
-    setAutocompleteQuery(undefined);
-  }, [editor]);
 
   const handleEmoticonSelect = (key: string, shortcode: string) => {
     editor.insertInline(createEmoticonElement(key, shortcode));


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
