### PR TITLE
revert(editor): restore the always inline editor setting

### DIFF
--- a/src/app/components/editor/Editor.tsx
+++ b/src/app/components/editor/Editor.tsx
@@ -79,12 +79,14 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
     ref
   ) => {
     const [shortcutOverrides] = useSetting(settingsAtom, 'shortcutOverrides');
+    const [alwaysInlineEditor] = useSetting(settingsAtom, 'alwaysInlineEditor');
     const rootRef = useRef<HTMLDivElement | null>(null);
     const focusScrollTimerRef = useRef<number>();
 
     // Buttons stay inline however tall the composer grows; only the audio
     // recorder stacks, because its controls need a row of their own.
-    const showResponsiveAfterInFooter = Boolean(responsiveAfter) && forceMultilineLayout;
+    const layoutIsMultiline = !alwaysInlineEditor && forceMultilineLayout;
+    const showResponsiveAfterInFooter = Boolean(responsiveAfter) && layoutIsMultiline;
 
     useEffect(() => () => window.clearTimeout(focusScrollTimerRef.current), []);
     const handleKeyDown: KeyboardEventHandler = useCallback(
@@ -133,13 +135,13 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
       <div ref={setRootRef} className={`${css.Editor} ${className ?? ''}`}>
         {top}
         <Box
-          className={`${css.EditorRow} ${forceMultilineLayout ? css.EditorRowMultiline : ''} ${showResponsiveAfterInFooter ? css.EditorRowMultilineWithResponsiveAfter : ''}`}
+          className={`${css.EditorRow} ${layoutIsMultiline ? css.EditorRowMultiline : ''} ${showResponsiveAfterInFooter ? css.EditorRowMultilineWithResponsiveAfter : ''}`}
           alignItems="Start"
           style={{ display: after ? 'grid' : 'flex' }}
         >
           {before && (
             <Box
-              className={`${css.EditorOptions} ${forceMultilineLayout ? css.EditorOptionsMultiline : ''}`}
+              className={`${css.EditorOptions} ${layoutIsMultiline ? css.EditorOptionsMultiline : ''}`}
               alignItems="Center"
               gap="100"
               shrink="No"
@@ -148,7 +150,7 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
             </Box>
           )}
           <Scroll
-            className={`${css.EditorTextareaScroll} ${forceMultilineLayout ? css.EditorTextareaScrollMultiline : ''}`}
+            className={`${css.EditorTextareaScroll} ${layoutIsMultiline ? css.EditorTextareaScrollMultiline : ''}`}
             variant={variant}
             style={{ maxHeight: showResponsiveAfterInFooter ? undefined : maxHeight }}
             size="300"
@@ -187,7 +189,7 @@ export const CustomEditor = forwardRef<HTMLDivElement, CustomEditorProps>(
           </Scroll>
           {(after || (responsiveAfter && !showResponsiveAfterInFooter)) && (
             <Box
-              className={`${css.EditorOptions} ${forceMultilineLayout ? `${css.EditorOptionsMultiline} ${css.EditorOptionsAfterMultiline}` : ''}`}
+              className={`${css.EditorOptions} ${layoutIsMultiline ? `${css.EditorOptionsMultiline} ${css.EditorOptionsAfterMultiline}` : ''}`}
               alignItems="Center"
               gap="100"
               shrink="No"

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -445,6 +445,10 @@ function EditorButtonOrderRow({
 function Editor() {
   const [enterForNewline, setEnterForNewline] = useSetting(settingsAtom, 'enterForNewline');
   const [editorToolbar, setEditorToolbar] = useSetting(settingsAtom, 'editorToolbar');
+  const [alwaysInlineEditor, setAlwaysInlineEditor] = useSetting(
+    settingsAtom,
+    'alwaysInlineEditor'
+  );
   const [editorOldAddFile, setEditorOldAddFile] = useSetting(settingsAtom, 'editorOldAddFile');
   const [editorMicButton, setEditorMicButton] = useSetting(settingsAtom, 'editorMicButton');
   const [editorEmojiButton, setEditorEmojiButton] = useSetting(settingsAtom, 'editorEmojiButton');
@@ -534,6 +538,13 @@ function Editor() {
         description="Show the sticker button inline with the message composer."
         value={editorStickerButton}
         onChange={setEditorStickerButton}
+      />
+      <SettingToggle
+        title="Always Inline Editor"
+        focusId="always-inline-editor"
+        description="Always keep the last line of the text editor inline with UI buttons."
+        value={alwaysInlineEditor}
+        onChange={setAlwaysInlineEditor}
       />
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -76,6 +76,7 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'always-play-call-sound',
     'custom-call-ringtone',
     'custom-call-ringback',
+    'always-inline-editor',
     'composer-button-order',
     'show-emoji-button',
     'show-gif-button',

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -132,6 +132,7 @@ export interface Settings {
   editorStickerButton: boolean;
   editorButtonOrder: EditorButtonId[];
   composerToolbarOpen: boolean;
+  alwaysInlineEditor: boolean;
   messageLayout: MessageLayout;
   messageSpacing: MessageSpacing;
   hideMembershipEvents: boolean;
@@ -319,6 +320,7 @@ export const defaultSettings: Settings = {
   editorStickerButton: false,
   editorButtonOrder: [...EDITOR_BUTTON_ORDER_DEFAULT],
   composerToolbarOpen: false,
+  alwaysInlineEditor: false,
   messageLayout: 0,
   messageSpacing: '400',
   hideMembershipEvents: false,


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
