### PR TITLE
feat(mobile): allow swiping notifications away

### DIFF
--- a/.changeset/allow_swiping_away_in_app_notifications_on_mobile.md
+++ b/.changeset/allow_swiping_away_in_app_notifications_on_mobile.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Allow swiping away in-app notifications on mobile

--- a/.changeset/allow_swiping_away_in_app_notifications_on_mobile.md
+++ b/.changeset/allow_swiping_away_in_app_notifications_on_mobile.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-# Allow swiping away in-app notifications on mobile
+Allow swiping away in-app notifications on mobile

--- a/src/app/components/notification-banner/NotificationBanner.css.ts
+++ b/src/app/components/notification-banner/NotificationBanner.css.ts
@@ -79,19 +79,8 @@ export const BannerContainer = style({
   },
 });
 
-export const Banner = style({
-  position: 'relative',
-  overflow: 'hidden',
+export const BannerWrapper = style({
   pointerEvents: 'all',
-  display: 'flex',
-  alignItems: 'center',
-  gap: config.space.S300,
-  backgroundColor: color.Surface.Container,
-  color: color.Surface.OnContainer,
-  border: `${config.borderWidth.B300} solid ${color.Surface.ContainerLine}`,
-  borderRadius: toRem(16),
-  padding: `${config.space.S300} ${config.space.S400}`,
-  boxShadow: `0 ${toRem(8)} ${toRem(32)} rgba(0, 0, 0, 0.45), 0 ${toRem(2)} ${toRem(8)} rgba(0, 0, 0, 0.3)`,
   cursor: 'pointer',
   width: '100%',
   maxWidth: toRem(420),
@@ -104,9 +93,6 @@ export const Banner = style({
   transitionTimingFunction: 'ease-out',
 
   selectors: {
-    '&:hover': {
-      backgroundColor: color.Surface.ContainerHover,
-    },
     '&[data-dismissing=up], &[data-dismissing=left], &[data-dismissing=right]': {
       animationDuration: '200ms',
       animationTimingFunction: 'cubic-bezier(0.4, 0, 1, 1)',
@@ -124,6 +110,26 @@ export const Banner = style({
     },
     '&[data-swiping=true]': {
       transitionProperty: 'none',
+    },
+  },
+});
+
+export const Banner = style({
+  position: 'relative',
+  overflow: 'hidden',
+  display: 'flex',
+  alignItems: 'center',
+  gap: config.space.S300,
+  backgroundColor: color.Surface.Container,
+  color: color.Surface.OnContainer,
+  border: `${config.borderWidth.B300} solid ${color.Surface.ContainerLine}`,
+  borderRadius: toRem(16),
+  padding: `${config.space.S300} ${config.space.S400}`,
+  boxShadow: `0 ${toRem(8)} ${toRem(32)} rgba(0, 0, 0, 0.45), 0 ${toRem(2)} ${toRem(8)} rgba(0, 0, 0, 0.3)`,
+
+  selectors: {
+    ':hover > &': {
+      backgroundColor: color.Surface.ContainerHover,
     },
   },
 });

--- a/src/app/components/notification-banner/NotificationBanner.css.ts
+++ b/src/app/components/notification-banner/NotificationBanner.css.ts
@@ -13,14 +13,39 @@ const slideIn = keyframes({
   },
 });
 
-const slideOut = keyframes({
+const fadeOut = keyframes({
   from: {
     opacity: 1,
-    transform: 'translateY(0)',
   },
   to: {
     opacity: 0,
+  },
+});
+
+const slideOut = keyframes({
+  from: {
+    transform: 'translateY(0)',
+  },
+  to: {
     transform: 'translateY(-100%)',
+  },
+});
+
+const swipeOutLeft = keyframes({
+  from: {
+    transform: 'translateX(0)',
+  },
+  to: {
+    transform: 'translateX(-100%)',
+  },
+});
+
+const swipeOutRight = keyframes({
+  from: {
+    transform: 'translateX(0)',
+  },
+  to: {
+    transform: 'translateX(100%)',
   },
 });
 
@@ -73,17 +98,32 @@ export const Banner = style({
   animationName: slideIn,
   animationDuration: '260ms',
   animationTimingFunction: 'cubic-bezier(0.22, 0.8, 0.6, 1)',
-  animationFillMode: 'both',
+  animationFillMode: 'backwards',
+  transitionProperty: 'transform',
+  transitionDuration: '200ms',
+  transitionTimingFunction: 'ease-out',
 
   selectors: {
     '&:hover': {
       backgroundColor: color.Surface.ContainerHover,
     },
-    '&[data-dismissing=true]': {
-      animationName: slideOut,
+    '&[data-dismissing=up], &[data-dismissing=left], &[data-dismissing=right]': {
       animationDuration: '200ms',
       animationTimingFunction: 'cubic-bezier(0.4, 0, 1, 1)',
-      animationFillMode: 'both',
+      animationFillMode: 'forwards',
+      animationComposition: 'accumulate, replace',
+    },
+    '&[data-dismissing=up]': {
+      animationName: `${slideOut}, ${fadeOut}`,
+    },
+    '&[data-dismissing=left]': {
+      animationName: `${swipeOutLeft}, ${fadeOut}`,
+    },
+    '&[data-dismissing=right]': {
+      animationName: `${swipeOutRight}, ${fadeOut}`,
+    },
+    '&[data-swiping=true]': {
+      transitionProperty: 'none',
     },
   },
 });

--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -12,6 +12,7 @@ import * as css from './NotificationBanner.css';
 
 const log = createLogger('NotificationBanner');
 const BANNER_DURATION_MS = 5000;
+const DISMISS_SWIPE_DISTANCE = 150;
 
 // Renders body text capped at a max height with a gradient fade when it overflows.
 function BodyText({ text, hovered }: { text: string; hovered: boolean }) {
@@ -63,31 +64,37 @@ function BannerMessage({ notification }: { notification: InAppBannerNotification
   );
 }
 
+type DismissDirection = 'up' | 'left' | 'right';
+
 function BannerItem({ notification, onDismiss }: BannerItemProps) {
-  const [dismissing, setDismissing] = useState(false);
+  const [dismissing, setDismissing] = useState<DismissDirection | undefined>();
   const [paused, setPaused] = useState(false);
-  const dismissedRef = useRef(false);
   const dismissAnimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const elapsedRef = useRef(0);
 
+  const [gesture, setGesture] = useState<{ startX: number; startY: number } | undefined>();
+  const [swipeDistance, setSwipeDistance] = useState(0);
+
   // Use a ref to guard against double-dismiss without creating a new callback identity.
-  const dismiss = useCallback(() => {
-    if (dismissedRef.current) return;
-    dismissedRef.current = true;
-    setDismissing(true);
-    dismissAnimTimerRef.current = setTimeout(() => onDismiss(notification.id), 200);
-  }, [notification.id, onDismiss]);
+  const dismiss = useCallback(
+    (direction: DismissDirection) => {
+      if (dismissing) return;
+      setDismissing(direction);
+      dismissAnimTimerRef.current = setTimeout(() => onDismiss(notification.id), 200);
+    },
+    [notification.id, onDismiss, dismissing]
+  );
 
   // Auto-dismiss timer  Eonly runs when not paused.
   useEffect(() => {
     if (paused) return undefined;
     const remaining = BANNER_DURATION_MS - elapsedRef.current;
     if (remaining <= 0) {
-      dismiss();
+      dismiss('up');
       return undefined;
     }
     const startedAt = Date.now();
-    const t = setTimeout(dismiss, remaining);
+    const t = setTimeout(() => dismiss('up'), remaining);
     return () => {
       clearTimeout(t);
       // Accumulate time spent un-paused so we can resume from the right point.
@@ -104,26 +111,88 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
 
   const handleClick = () => {
     notification.onClick();
-    dismiss();
+    dismiss('up');
   };
 
   // When hovering, pause the auto-dismiss timer.
-  const handleMouseEnter = () => setPaused(true);
-  const handleMouseLeave = () => setPaused(false);
+  const handleMouseEnter = useCallback(() => setPaused(true), []);
+  const handleMouseLeave = useCallback(() => setPaused(false), []);
+
+  const release = useCallback(
+    (commit: boolean) => {
+      setPaused(false);
+
+      if (commit && Math.abs(swipeDistance) > DISMISS_SWIPE_DISTANCE) {
+        // Continue off the side of the screen
+        dismiss(swipeDistance > 0 ? 'right' : 'left');
+      } else {
+        // Spring back to center
+        setSwipeDistance(0);
+        setGesture(undefined);
+      }
+    },
+    [swipeDistance]
+  );
+
+  const handleTouchStart = useCallback(
+    (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch || event.touches.length !== 1) {
+        release(false);
+        return;
+      }
+
+      setPaused(true);
+
+      setGesture({
+        startX: touch.clientX,
+        startY: touch.clientY,
+      });
+    },
+    [release]
+  );
+  const handleTouchMove = useCallback(
+    (event: TouchEvent) => {
+      if (dismissing) return;
+      const touch = event.touches[0];
+      if (!gesture || !touch) return;
+
+      const swipeDistance = touch.clientX - gesture.startX;
+      setSwipeDistance(swipeDistance);
+    },
+    [dismissing, gesture]
+  );
+  const handleTouchEnd = useCallback(() => {
+    if (dismissing) return;
+    release(true);
+  }, [dismissing, release]);
+  const handleTouchCancel = useCallback(() => {
+    if (dismissing) return;
+    release(false);
+  }, [dismissing, release]);
 
   return (
     <div
       className={css.Banner}
       data-dismissing={dismissing}
+      data-swiping={gesture !== undefined}
       onClick={handleClick}
-      role="button"
+      // role="button" // TODO: This breaking everything >:(
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') handleClick();
-        if (e.key === 'Escape') dismiss();
+        if (e.key === 'Escape') dismiss('up');
       }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchCancel={handleTouchCancel}
+      onTouchEnd={handleTouchEnd}
+      style={{
+        transform: `translateX(${swipeDistance}px)`,
+        willChange: 'transform',
+      }}
     >
       {!notification.event && notification.icon && (
         <img
@@ -163,7 +232,7 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
           radii="300"
           onClick={(e) => {
             e.stopPropagation();
-            dismiss();
+            dismiss('up');
           }}
           aria-label="Dismiss notification"
         >
@@ -173,7 +242,7 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
       <div
         className={css.ProgressBar}
         data-paused={paused}
-        style={{ animationDuration: `${BANNER_DURATION_MS - elapsedRef.current}ms` }}
+        style={{ animationDuration: `${BANNER_DURATION_MS}ms` }}
       />
     </div>
   );

--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -1,5 +1,6 @@
 import { useAtom } from 'jotai';
-import { useCallback, useEffect, useRef, useState, TouchEvent } from 'react';
+import type { TouchEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, IconButton, Text } from 'folds';
 import { sizedIcon, X } from '$components/icons/phosphor';
 import { createLogger } from '$utils/debug';

--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -173,16 +173,9 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
 
   return (
     <div
-      className={css.Banner}
+      className={css.BannerWrapper}
       data-dismissing={dismissing}
       data-swiping={gesture !== undefined}
-      onClick={handleClick}
-      // role="button" // TODO: This breaking everything >:(
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') handleClick();
-        if (e.key === 'Escape') dismiss('up');
-      }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
@@ -194,56 +187,67 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
         willChange: 'transform',
       }}
     >
-      {!notification.event && notification.icon && (
-        <img
-          src={notification.icon}
-          alt=""
-          className={css.BannerIcon}
-          onError={(e) => {
-            (e.currentTarget as HTMLImageElement).style.display = 'none';
-          }}
-        />
-      )}
-      <div className={css.BannerContent}>
-        {notification.room && notification.event ? (
-          <BannerMessage notification={notification} />
-        ) : (
-          <>
-            <Text size="T300" truncate className={css.BannerTitle}>
-              {notification.senderName ?? notification.title}
-              {(notification.roomName || notification.serverName) && (
-                <span className={css.BannerSubtitle}>
-                  {' ('}
-                  {notification.roomName && `#${notification.roomName}`}
-                  {notification.roomName && notification.serverName && ', '}
-                  {notification.serverName})
-                </span>
-              )}
-            </Text>
-            {notification.body && <BodyText text={notification.body} hovered={paused} />}
-          </>
-        )}
-      </div>
-      <Box shrink="No">
-        <IconButton
-          size="300"
-          variant="Surface"
-          fill="None"
-          radii="300"
-          onClick={(e) => {
-            e.stopPropagation();
-            dismiss('up');
-          }}
-          aria-label="Dismiss notification"
-        >
-          {sizedIcon(X, '100')}
-        </IconButton>
-      </Box>
       <div
-        className={css.ProgressBar}
-        data-paused={paused}
-        style={{ animationDuration: `${BANNER_DURATION_MS}ms` }}
-      />
+        className={css.Banner}
+        onClick={handleClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') handleClick();
+          if (e.key === 'Escape') dismiss('up');
+        }}
+      >
+        {!notification.event && notification.icon && (
+          <img
+            src={notification.icon}
+            alt=""
+            className={css.BannerIcon}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.display = 'none';
+            }}
+          />
+        )}
+        <div className={css.BannerContent}>
+          {notification.room && notification.event ? (
+            <BannerMessage notification={notification} />
+          ) : (
+            <>
+              <Text size="T300" truncate className={css.BannerTitle}>
+                {notification.senderName ?? notification.title}
+                {(notification.roomName || notification.serverName) && (
+                  <span className={css.BannerSubtitle}>
+                    {' ('}
+                    {notification.roomName && `#${notification.roomName}`}
+                    {notification.roomName && notification.serverName && ', '}
+                    {notification.serverName})
+                  </span>
+                )}
+              </Text>
+              {notification.body && <BodyText text={notification.body} hovered={paused} />}
+            </>
+          )}
+        </div>
+        <Box shrink="No">
+          <IconButton
+            size="300"
+            variant="Surface"
+            fill="None"
+            radii="300"
+            onClick={(e) => {
+              e.stopPropagation();
+              dismiss('up');
+            }}
+            aria-label="Dismiss notification"
+          >
+            {sizedIcon(X, '100')}
+          </IconButton>
+        </Box>
+        <div
+          className={css.ProgressBar}
+          data-paused={paused}
+          style={{ animationDuration: `${BANNER_DURATION_MS}ms` }}
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, TouchEvent } from 'react';
 import { Box, IconButton, Text } from 'folds';
 import { sizedIcon, X } from '$components/icons/phosphor';
 import { createLogger } from '$utils/debug';
@@ -131,7 +131,7 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
         setGesture(undefined);
       }
     },
-    [swipeDistance]
+    [dismiss, swipeDistance]
   );
 
   const handleTouchStart = useCallback(
@@ -157,8 +157,7 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
       const touch = event.touches[0];
       if (!gesture || !touch) return;
 
-      const swipeDistance = touch.clientX - gesture.startX;
-      setSwipeDistance(swipeDistance);
+      setSwipeDistance(touch.clientX - gesture.startX);
     },
     [dismissing, gesture]
   );


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Allow swiping notifications away to either side on mobile.

[Screencast From 2026-08-18 22-52-06.webm](https://github.com/user-attachments/assets/fcc2db1d-d1da-4989-99aa-ecc1e07079f3)

Closes #1842

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
