### PR TITLE
fix(avatar): recover room and space avatars after iOS webview refreshes

### DIFF
--- a/src/app/components/editor/Editor.test.tsx
+++ b/src/app/components/editor/Editor.test.tsx
@@ -159,6 +159,13 @@ const pasteWith = (container: HTMLElement, clipboardData: Record<string, string>
   });
 };
 
+// prosemirror's capturePaste schedules a 50ms `view.focus()`; run it out before
+// teardown so it cannot fire against a destroyed document.
+const flushPasteTimer = () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  });
+
 describe('CustomEditor paste', () => {
   it('reads the native clipboard when the ios webview delivers an empty paste event', async () => {
     platformState.isIosApp = true;
@@ -168,6 +175,7 @@ describe('CustomEditor paste', () => {
     pasteWith(container, { 'text/plain': '' });
 
     await waitFor(() => expect(editor.getText()).toBe('from the native clipboard'));
+    await flushPasteTimer();
   });
 
   it('leaves an empty paste event alone outside the ios webview', async () => {
@@ -179,6 +187,7 @@ describe('CustomEditor paste', () => {
 
     await Promise.resolve();
     expect(editor.getText()).toBe('');
+    await flushPasteTimer();
   });
 
   it('does not read the native clipboard when the event already carries text', async () => {
@@ -190,6 +199,7 @@ describe('CustomEditor paste', () => {
 
     await Promise.resolve();
     expect(editor.getText()).not.toBe('from the native clipboard');
+    await flushPasteTimer();
   });
 
   it('lets a consumer handler pre-empt the native clipboard fallback', async () => {
@@ -203,6 +213,7 @@ describe('CustomEditor paste', () => {
 
     await Promise.resolve();
     expect(editor.getText()).toBe('');
+    await flushPasteTimer();
   });
 });
 

--- a/src/app/components/room-avatar/RoomAvatar.test.tsx
+++ b/src/app/components/room-avatar/RoomAvatar.test.tsx
@@ -2,22 +2,34 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const media = vi.hoisted(() => ({
-  useRenderableMediaSource: vi.fn<(url: string | undefined) => string | undefined>(),
+  useAvatarMediaSource: vi.fn<
+    (src: string | undefined) => {
+      mediaSrc: string | undefined;
+      error: boolean;
+      onError: () => void;
+    }
+  >(),
 }));
 
 vi.mock('$hooks/useRenderableMediaUrl', () => media);
 
+import { RoomAvatar } from './RoomAvatar';
+
 const RAW_SRC = 'https://example.org/_matrix/client/v1/media/thumbnail/example.org/avatar';
+
+const sourceResult = (mediaSrc: string | undefined, onError: () => void = () => {}) => ({
+  mediaSrc,
+  error: false,
+  onError,
+});
 
 describe('RoomAvatar', () => {
   beforeEach(() => {
-    vi.resetModules();
-    media.useRenderableMediaSource.mockReset();
+    media.useAvatarMediaSource.mockReset();
   });
 
-  it('waits for a renderable url instead of requesting the raw one', async () => {
-    media.useRenderableMediaSource.mockReturnValue(undefined);
-    const { RoomAvatar } = await import('./RoomAvatar');
+  it('waits for a renderable url instead of requesting the raw one', () => {
+    media.useAvatarMediaSource.mockReturnValue(sourceResult(undefined));
 
     const { rerender } = render(
       <RoomAvatar roomId="!room:example.org" src={RAW_SRC} renderFallback={() => 'RM'} />
@@ -25,26 +37,39 @@ describe('RoomAvatar', () => {
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
 
-    media.useRenderableMediaSource.mockReturnValue('blob:resolved-avatar');
+    media.useAvatarMediaSource.mockReturnValue(sourceResult('blob:resolved-avatar'));
     rerender(<RoomAvatar roomId="!room:example.org" src={RAW_SRC} renderFallback={() => 'RM'} />);
 
     expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:resolved-avatar');
   });
 
-  it('falls back until a new url arrives when the image fails to load', async () => {
-    media.useRenderableMediaSource.mockReturnValue('blob:resolved-avatar');
-    const { RoomAvatar } = await import('./RoomAvatar');
+  it('falls back while the source reports a load error', () => {
+    media.useAvatarMediaSource.mockReturnValue({
+      mediaSrc: 'blob:resolved-avatar',
+      error: true,
+      onError: () => {},
+    });
 
     const { rerender } = render(
       <RoomAvatar roomId="!room:example.org" src={RAW_SRC} renderFallback={() => 'RM'} />
     );
 
-    fireEvent.error(screen.getByRole('img'));
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
 
-    media.useRenderableMediaSource.mockReturnValue('blob:next-avatar');
+    media.useAvatarMediaSource.mockReturnValue(sourceResult('blob:next-avatar'));
     rerender(<RoomAvatar roomId="!room:example.org" src={RAW_SRC} renderFallback={() => 'RM'} />);
 
     expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:next-avatar');
+  });
+
+  it('reports image load failures through the source error handler', () => {
+    const onError = vi.fn<() => void>();
+    media.useAvatarMediaSource.mockReturnValue(sourceResult('blob:resolved-avatar', onError));
+
+    render(<RoomAvatar roomId="!room:example.org" src={RAW_SRC} renderFallback={() => 'RM'} />);
+
+    fireEvent.error(screen.getByRole('img'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/components/room-avatar/RoomAvatar.tsx
+++ b/src/app/components/room-avatar/RoomAvatar.tsx
@@ -1,7 +1,7 @@
 import type { JoinRule } from '$types/matrix-sdk';
 import { AvatarFallback, color } from 'folds';
 import type { ReactNode } from 'react';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef } from 'react';
 import type { IconProps } from '@phosphor-icons/react';
 import classNames from 'classnames';
 import { sizedIcon, type IconSizeToken } from '$components/icons/phosphor';
@@ -12,7 +12,7 @@ import {
   getRoomStandaloneIconComponent,
 } from '$components/icons/roomIcons';
 import colorMXID from '$utils/colorMXID';
-import { useRenderableMediaSource } from '$hooks/useRenderableMediaUrl';
+import { useAvatarMediaSource } from '$hooks/useRenderableMediaUrl';
 import * as css from './RoomAvatar.css';
 import { AvatarImage } from './AvatarImage';
 
@@ -25,12 +25,7 @@ type RoomAvatarProps = {
 };
 
 export function RoomAvatar({ roomId, src, alt, renderFallback, uniformIcons }: RoomAvatarProps) {
-  const [error, setError] = useState(false);
-  const mediaSrc = useRenderableMediaSource(src);
-
-  useEffect(() => {
-    setError(false);
-  }, [mediaSrc]);
+  const { mediaSrc, error, onError } = useAvatarMediaSource(src);
 
   if (!mediaSrc || error) {
     return (
@@ -43,14 +38,7 @@ export function RoomAvatar({ roomId, src, alt, renderFallback, uniformIcons }: R
     );
   }
 
-  return (
-    <AvatarImage
-      src={mediaSrc}
-      alt={alt}
-      uniformIcons={uniformIcons}
-      onError={() => setError(true)}
-    />
-  );
+  return <AvatarImage src={mediaSrc} alt={alt} uniformIcons={uniformIcons} onError={onError} />;
 }
 
 export const RoomIcon = forwardRef<

--- a/src/app/components/user-avatar/UserAvatar.test.tsx
+++ b/src/app/components/user-avatar/UserAvatar.test.tsx
@@ -2,22 +2,34 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const media = vi.hoisted(() => ({
-  useRenderableMediaSource: vi.fn<(url: string | undefined) => string | undefined>(),
+  useAvatarMediaSource: vi.fn<
+    (src: string | undefined) => {
+      mediaSrc: string | undefined;
+      error: boolean;
+      onError: () => void;
+    }
+  >(),
 }));
 
 vi.mock('$hooks/useRenderableMediaUrl', () => media);
 
+import { UserAvatar } from './UserAvatar';
+
 const RAW_SRC = 'https://example.org/_matrix/client/v1/media/thumbnail/example.org/avatar';
+
+const sourceResult = (mediaSrc: string | undefined, onError: () => void = () => {}) => ({
+  mediaSrc,
+  error: false,
+  onError,
+});
 
 describe('UserAvatar', () => {
   beforeEach(() => {
-    vi.resetModules();
-    media.useRenderableMediaSource.mockReset();
+    media.useAvatarMediaSource.mockReset();
   });
 
-  it('waits for a renderable url instead of requesting the raw one', async () => {
-    media.useRenderableMediaSource.mockReturnValue(undefined);
-    const { UserAvatar } = await import('./UserAvatar');
+  it('waits for a renderable url instead of requesting the raw one', () => {
+    media.useAvatarMediaSource.mockReturnValue(sourceResult(undefined));
 
     const { rerender } = render(
       <UserAvatar userId="@user:example.org" src={RAW_SRC} renderFallback={() => 'US'} />
@@ -25,26 +37,39 @@ describe('UserAvatar', () => {
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
 
-    media.useRenderableMediaSource.mockReturnValue('blob:resolved-avatar');
+    media.useAvatarMediaSource.mockReturnValue(sourceResult('blob:resolved-avatar'));
     rerender(<UserAvatar userId="@user:example.org" src={RAW_SRC} renderFallback={() => 'US'} />);
 
     expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:resolved-avatar');
   });
 
-  it('falls back until a new url arrives when the image fails to load', async () => {
-    media.useRenderableMediaSource.mockReturnValue('blob:resolved-avatar');
-    const { UserAvatar } = await import('./UserAvatar');
+  it('falls back while the source reports a load error', () => {
+    media.useAvatarMediaSource.mockReturnValue({
+      mediaSrc: 'blob:resolved-avatar',
+      error: true,
+      onError: () => {},
+    });
 
     const { rerender } = render(
       <UserAvatar userId="@user:example.org" src={RAW_SRC} renderFallback={() => 'US'} />
     );
 
-    fireEvent.error(screen.getByRole('img'));
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
 
-    media.useRenderableMediaSource.mockReturnValue('blob:next-avatar');
+    media.useAvatarMediaSource.mockReturnValue(sourceResult('blob:next-avatar'));
     rerender(<UserAvatar userId="@user:example.org" src={RAW_SRC} renderFallback={() => 'US'} />);
 
     expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:next-avatar');
+  });
+
+  it('reports image load failures through the source error handler', () => {
+    const onError = vi.fn<() => void>();
+    media.useAvatarMediaSource.mockReturnValue(sourceResult('blob:resolved-avatar', onError));
+
+    render(<UserAvatar userId="@user:example.org" src={RAW_SRC} renderFallback={() => 'US'} />);
+
+    fireEvent.error(screen.getByRole('img'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/components/user-avatar/UserAvatar.tsx
+++ b/src/app/components/user-avatar/UserAvatar.tsx
@@ -1,9 +1,8 @@
 import { AvatarFallback, AvatarImage, color } from 'folds';
 import type { ReactEventHandler, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import colorMXID from '$utils/colorMXID';
-import { useRenderableMediaSource } from '$hooks/useRenderableMediaUrl';
+import { useAvatarMediaSource } from '$hooks/useRenderableMediaUrl';
 import * as css from './UserAvatar.css';
 
 type UserAvatarProps = {
@@ -27,12 +26,7 @@ export function UserAvatar({
   fallbackColor,
   renderFallback,
 }: UserAvatarProps) {
-  const [error, setError] = useState(false);
-  const mediaSrc = useRenderableMediaSource(src);
-
-  useEffect(() => {
-    setError(false);
-  }, [mediaSrc]);
+  const { mediaSrc, error, onError } = useAvatarMediaSource(src);
 
   if (!mediaSrc || error) {
     return (
@@ -55,7 +49,7 @@ export function UserAvatar({
       alt={alt}
       loading="lazy"
       decoding="async"
-      onError={() => setError(true)}
+      onError={onError}
       onLoad={handleImageLoad}
       draggable={false}
     />

--- a/src/app/hooks/useRenderableMediaUrl.test.tsx
+++ b/src/app/hooks/useRenderableMediaUrl.test.tsx
@@ -333,4 +333,107 @@ describe('useRenderableMediaUrl', () => {
 
     expect(result.current).toBe('https://example.org/avatar.png');
   });
+
+  describe('useAvatarMediaSource', () => {
+    const RAW_URL =
+      'sable-media://https://matrix.example.org/_matrix/client/v1/media/thumbnail/example.org/abc123';
+
+    it('retries with a fresh revision after the image fails to load', async () => {
+      vi.useFakeTimers();
+      tauriApi.isTauri.mockReturnValue(true);
+      tauriApi.invoke
+        .mockResolvedValueOnce('http://127.0.0.1:45678/stale-capability')
+        .mockResolvedValueOnce('http://127.0.0.1:45678/fresh-capability');
+      const { useAvatarMediaSource } = await import('./useRenderableMediaUrl');
+
+      const { result } = renderHook(() => useAvatarMediaSource(RAW_URL));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.mediaSrc).toBe('http://127.0.0.1:45678/stale-capability');
+      expect(result.current.error).toBe(false);
+
+      act(() => {
+        result.current.onError();
+      });
+      expect(result.current.error).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(result.current.error).toBe(false);
+      expect(result.current.mediaSrc).toBe('http://127.0.0.1:45678/fresh-capability');
+      expect(tauriApi.invoke).toHaveBeenCalledTimes(2);
+      const retryUrl = tauriApi.invoke.mock.calls[1]?.[1].url ?? '';
+      expect(retryUrl).toContain('__sable_media_retry=1');
+      vi.useRealTimers();
+    });
+
+    it('stops retrying once the backoff schedule is exhausted', async () => {
+      vi.useFakeTimers();
+      tauriApi.isTauri.mockReturnValue(true);
+      tauriApi.invoke.mockImplementation(async (_cmd: string, args: { url: string }) => {
+        return `http://127.0.0.1:45678/capability-${args.url.length}`;
+      });
+      const { useAvatarMediaSource } = await import('./useRenderableMediaUrl');
+
+      const { result } = renderHook(() => useAvatarMediaSource(RAW_URL));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.mediaSrc).toBeDefined();
+
+      const failAndExhaustRetry = async (delay: number) => {
+        act(() => {
+          result.current.onError();
+        });
+        expect(result.current.error).toBe(true);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delay);
+        });
+        expect(result.current.error).toBe(false);
+      };
+      await failAndExhaustRetry(500);
+      await failAndExhaustRetry(1500);
+      await failAndExhaustRetry(4500);
+
+      act(() => {
+        result.current.onError();
+      });
+      expect(result.current.error).toBe(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(result.current.error).toBe(true);
+      vi.useRealTimers();
+    });
+
+    it('resets the retry budget when the source changes', async () => {
+      vi.useFakeTimers();
+      tauriApi.isTauri.mockReturnValue(true);
+      tauriApi.invoke.mockResolvedValue('http://127.0.0.1:45678/capability');
+      const { useAvatarMediaSource } = await import('./useRenderableMediaUrl');
+
+      const { result, rerender } = renderHook(
+        ({ url }: { url: string | undefined }) => useAvatarMediaSource(url),
+        { initialProps: { url: RAW_URL as string | undefined } }
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      act(() => {
+        result.current.onError();
+      });
+      expect(result.current.error).toBe(true);
+
+      rerender({ url: undefined });
+      expect(result.current.error).toBe(false);
+      expect(result.current.mediaSrc).toBeUndefined();
+      vi.useRealTimers();
+    });
+  });
 });

--- a/src/app/hooks/useRenderableMediaUrl.ts
+++ b/src/app/hooks/useRenderableMediaUrl.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { useAtomValue } from 'jotai';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { activeSessionIdAtom } from '$state/sessions';
@@ -13,6 +13,7 @@ import {
   subscribeSWMediaAuthSupport,
 } from '$utils/swMediaAuth';
 import { rewriteAuthenticatedMediaUrl } from '$utils/matrix';
+import { addTauriMediaRetryRevision } from '$utils/mediaUrl';
 
 type ObjectUrlEntry = {
   refs: number;
@@ -45,8 +46,9 @@ function pruneUnreferencedCache(): void {
   }
 }
 
-function getObjectUrlCacheKey(sessionScope: string, url: string): string {
-  return `${sessionScope}\x00${getStableMediaCacheKeyFragment(url)}`;
+function getObjectUrlCacheKey(sessionScope: string, url: string, retryRevision = 0): string {
+  const retryFragment = retryRevision > 0 ? `\x00retry=${retryRevision}` : '';
+  return `${sessionScope}\x00${getStableMediaCacheKeyFragment(url)}${retryFragment}`;
 }
 
 function normalizeRenderableMediaUrl(url: string | undefined): string | undefined {
@@ -186,14 +188,17 @@ export function getRenderableMediaUrlStats(): { cacheSize: number; inflightCount
   return { cacheSize: objectUrlCache.size, inflightCount: inflightRequests.size };
 }
 
-export function useRenderableMediaUrl(url: string | undefined): string | undefined {
+export function useRenderableMediaUrl(
+  url: string | undefined,
+  retryRevision = 0
+): string | undefined {
   const tauri = isTauri();
   const activeSessionId = useAtomValue(activeSessionIdAtom);
   const sessionScope = activeSessionId ?? getCurrentMediaSessionScope();
   const renderableUrl = normalizeRenderableMediaUrl(url);
   const objectUrlCacheKey =
     renderableUrl && !renderableUrl.startsWith('blob:')
-      ? getObjectUrlCacheKey(sessionScope, renderableUrl)
+      ? getObjectUrlCacheKey(sessionScope, renderableUrl, retryRevision)
       : undefined;
   // Media elements and bare URLs are only safe once the (current) service
   // worker has proven it intercepts authenticated media; until then media goes
@@ -325,8 +330,51 @@ export function useRenderableMediaUrl(url: string | undefined): string | undefin
 
 // Undefined while the url is still being prepared: on Tauri, rendering the raw source first
 // only means a second load once the loopback url lands, and an error on either latches.
-export function useRenderableMediaSource(url: string | undefined): string | undefined {
-  const resolvedUrl = useRenderableMediaUrl(url);
+export function useRenderableMediaSource(
+  url: string | undefined,
+  retryRevision = 0
+): string | undefined {
+  const retriedUrl =
+    url && retryRevision > 0 ? addTauriMediaRetryRevision(url, retryRevision) : url;
+  const resolvedUrl = useRenderableMediaUrl(retriedUrl, retryRevision);
   if (resolvedUrl) return resolvedUrl;
-  return isTauri() ? undefined : url;
+  return isTauri() ? undefined : retriedUrl;
+}
+
+const AVATAR_RETRY_DELAYS_MS = [500, 1500, 4500];
+
+type AvatarMediaSource = {
+  mediaSrc: string | undefined;
+  error: boolean;
+  onError: () => void;
+};
+
+export function useAvatarMediaSource(src: string | undefined): AvatarMediaSource {
+  const [error, setError] = useState(false);
+  const [retryRevision, setRetryRevision] = useState(0);
+  const mediaSrc = useRenderableMediaSource(src, retryRevision);
+
+  useEffect(() => {
+    setError(false);
+    setRetryRevision(0);
+  }, [src]);
+
+  useEffect(() => {
+    setError(false);
+  }, [mediaSrc]);
+
+  useEffect(() => {
+    if (!error) return undefined;
+    const delay = AVATAR_RETRY_DELAYS_MS[retryRevision];
+    if (delay === undefined) return undefined;
+    const timer = setTimeout(() => {
+      setError(false);
+      setRetryRevision((revision) => revision + 1);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [error, retryRevision]);
+
+  const onError = useCallback(() => setError(true), []);
+
+  return { mediaSrc, error, onError };
 }

--- a/src/app/utils/tauriMediaAuth.test.ts
+++ b/src/app/utils/tauriMediaAuth.test.ts
@@ -138,4 +138,20 @@ describe('Tauri media session coordinator', () => {
       scope: '@b:two.example',
     });
   });
+
+  it('does not wipe the native session when a sync reads no stored session', async () => {
+    mediaTransport.getActiveMediaSession.mockReturnValue(undefined);
+
+    await initTauriMediaSession();
+
+    window.dispatchEvent(new Event('sable-session-changed'));
+    window.dispatchEvent(new StorageEvent('storage', { key: 'matrixSessions' }));
+    await Promise.resolve();
+
+    expect(commands.clearMediaSession).not.toHaveBeenCalled();
+    expect(commands.setMediaSession).not.toHaveBeenCalled();
+
+    await updateTauriMediaSession();
+    expect(commands.clearMediaSession).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/utils/tauriMediaAuth.ts
+++ b/src/app/utils/tauriMediaAuth.ts
@@ -46,7 +46,8 @@ export const updateTauriMediaSession = (
 
 const syncTauriMediaSession = (): Promise<void> => {
   const session = getActiveMediaSession();
-  return updateTauriMediaSession(session?.baseUrl, session?.accessToken, session?.userId);
+  if (!session) return Promise.resolve();
+  return updateTauriMediaSession(session.baseUrl, session.accessToken, session.userId);
 };
 
 export const initTauriMediaSession = (): Promise<void> => {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
