### PR TITLE
fix(android): pad mobile sheet from injected safe-area inset

### DIFF
--- a/src/app/features/room/message/styles.css.ts
+++ b/src/app/features/room/message/styles.css.ts
@@ -125,7 +125,8 @@ export const MessageMobileOptionsContainer = style({
   borderTopLeftRadius: toRem(20),
   borderTopRightRadius: toRem(20),
   boxShadow: '0 -4px 24px rgba(0, 0, 0, 0.15)',
-  paddingBottom: 'var(--mobile-sheet-safe-bottom, env(safe-area-inset-bottom, 0px))',
+  paddingBottom:
+    'var(--mobile-sheet-safe-bottom, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))',
 });
 
 export const MessageMobileOptionsContainerContained = style({

--- a/src/app/styles/edgeToEdgeInsets.test.ts
+++ b/src/app/styles/edgeToEdgeInsets.test.ts
@@ -57,6 +57,17 @@ describe('android edge-to-edge inset contract', () => {
     expect(sheet.match(/zIndex,/g)).toHaveLength(2);
   });
 
+  it('falls back to the injected edge-to-edge inset before env() for the mobile sheet', () => {
+    const messageStyles = readWorkspaceFile('src/app/features/room/message/styles.css.ts');
+
+    expect(messageStyles).toContain(
+      "'var(--mobile-sheet-safe-bottom, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))'"
+    );
+    expect(messageStyles).not.toContain(
+      "'var(--mobile-sheet-safe-bottom, env(safe-area-inset-bottom, 0px))'"
+    );
+  });
+
   it('uses the App shell as the only safe-area owner', () => {
     const appShell = readWorkspaceFile('src/app/components/app-shell/AppShell.tsx');
     const systemBarShell = readWorkspaceFile('src/app/components/app-shell/SystemBarShell.tsx');


### PR DESCRIPTION
The sheet container fell back to env(safe-area-inset-bottom) directly, which Android WebView reports as 0px on devices with three-button navigation and certain WebView versions. Prefer the edge-to-edge plugin's injected --safe-area-inset-bottom (native insets) first, matching the rest of the app.

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).
<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
