### PR TITLE
fix(ci): make the nix flake check continue even after treefmt fails

### DIFF
--- a/.github/workflows/flake-lock-fix.yml
+++ b/.github/workflows/flake-lock-fix.yml
@@ -33,7 +33,7 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@61cbfe2efc2d4e7a8a6d56967c3c1058e846c858 # v3.21.9
 
       - id: check
-        run: nix flake check -L
+        run: nix flake check -L --keep-going
         continue-on-error: true
 
       - name: Fix hash mismatches


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Added `--keep-going` flag to `nix flake check` to make it produce a new hash even if treefmt fails, like in https://github.com/SableClient/Sable/actions/runs/32358846966/job/96393846156#step:5:415

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
