### PR TITLE
fix(call): load the call iframe after the widget transport is listening

### DIFF
--- a/src/app/plugins/call/CallEmbed.handshake.test.ts
+++ b/src/app/plugins/call/CallEmbed.handshake.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/debugLogger', () => ({
+  createDebugLogger: () => ({
+    info: vi.fn<(...args: unknown[]) => void>(),
+    warn: vi.fn<(...args: unknown[]) => void>(),
+    error: vi.fn<(...args: unknown[]) => void>(),
+    debug: vi.fn<(...args: unknown[]) => void>(),
+  }),
+}));
+
+import { CallEmbed } from './CallEmbed';
+
+describe('CallEmbed.getIframe', () => {
+  it('leaves src unset so the caller can load after the transport is listening', () => {
+    const iframe = CallEmbed.getIframe();
+
+    expect(iframe.getAttribute('src')).toBeNull();
+  });
+});

--- a/src/app/plugins/call/CallEmbed.ts
+++ b/src/app/plugins/call/CallEmbed.ts
@@ -194,7 +194,7 @@ export class CallEmbed {
     return widget;
   }
 
-  static getIframe(url: string): HTMLIFrameElement {
+  static getIframe(): HTMLIFrameElement {
     const iframe = document.createElement('iframe');
 
     iframe.title = 'Call Embed';
@@ -202,7 +202,6 @@ export class CallEmbed {
       'allow-forms allow-scripts allow-same-origin allow-popups allow-modals allow-downloads';
     iframe.allow =
       'microphone; camera; display-capture; autoplay; clipboard-write; local-network-access;';
-    iframe.src = url;
 
     iframe.style.width = '100%';
     iframe.style.height = '100%';
@@ -220,13 +219,14 @@ export class CallEmbed {
   ) {
     debugLog.info('call', 'Initializing call embed', { roomId: room.roomId });
 
-    const iframe = CallEmbed.getIframe(
-      widget.getCompleteUrl({ currentUserId: mx.getSafeUserId() })
-    );
+    const iframe = CallEmbed.getIframe();
     container.append(iframe);
 
     const callWidgetDriver: WidgetDriver = new CallWidgetDriver(mx, room.roomId);
     const call: ClientWidgetApi = new ClientWidgetApi(widget, iframe, callWidgetDriver);
+
+    // Load after the transport is listening, or a fast iframe's contentLoaded is missed.
+    iframe.src = widget.getCompleteUrl({ currentUserId: mx.getSafeUserId() });
 
     this.mx = mx;
     this.call = call;


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
