### PR TITLE
Add setting to show timestamps on every message

### DIFF
--- a/.changeset/show-all-timestamps.md
+++ b/.changeset/show-all-timestamps.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a setting to show all timestamps, including on grouped messages from the same sender

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -538,6 +538,7 @@ function MessageInternal(
   const [parsePronouns] = useSetting(settingsAtom, 'parsePronouns');
 
   const [useRightBubbles] = useSetting(settingsAtom, 'useRightBubbles');
+  const [showAllTimestamps] = useSetting(settingsAtom, 'showAllTimestamps');
   const { cleanedDisplayName, inlinePronoun } = useMemo(() => {
     const rawName = pmp?.displayname || resolvedSenderDisplayName || '';
     return getParsedPronouns(rawName, parsePronouns);
@@ -661,7 +662,32 @@ function MessageInternal(
           </Box>
         </Box>
       );
-    return <></>;
+    return showAllTimestamps ? (
+      <Box
+        gap="300"
+        direction={
+          messageLayout === MessageLayout.Compact ||
+          (messageLayout === MessageLayout.Bubble && useRightBubbles && senderId === mx.getUserId())
+            ? 'RowReverse'
+            : 'Row'
+        }
+        justifyContent="SpaceBetween"
+        alignItems="Baseline"
+        grow="Yes"
+      >
+        <Box grow="Yes" style={{ minWidth: 0 }} />
+        <Box shrink="No" gap="100">
+          <Time
+            ts={mEvent.getTs()}
+            compact={messageLayout === MessageLayout.Compact}
+            hour24Clock={hour24Clock}
+            dateFormatString={dateFormatString}
+          />
+        </Box>
+      </Box>
+    ) : (
+      <></>
+    );
   };
 
   const avatarJSX = (collapsed?: boolean) => {

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -819,6 +819,7 @@ function Messages() {
     settingsAtom,
     'hideMembershipInReadOnly'
   );
+  const [showAllTimestamps, setShowAllTimestamps] = useSetting(settingsAtom, 'showAllTimestamps');
 
   const [messageLayout] = useSetting(settingsAtom, 'messageLayout');
   const [rightBubbles, setRightBubbles] = useSetting(settingsAtom, 'useRightBubbles');
@@ -839,6 +840,13 @@ function Messages() {
           after={<SelectMessageSpacing />}
         />
       </SequenceCard>
+      <SettingToggle
+        title="Show All Timestamps"
+        focusId="show-all-timestamps"
+        description="Display a timestamp on every message, including consecutive messages from the same sender that are normally grouped."
+        value={showAllTimestamps}
+        onChange={setShowAllTimestamps}
+      />
       <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
         <SettingTile
           title="File description placement"

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -47,6 +47,7 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'markdown-formatting',
     'message-layout',
     'message-spacing',
+    'show-all-timestamps',
     'presence-status',
     'reply-notifications',
     'right-aligned-bubbles',

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -181,6 +181,7 @@ export interface Settings {
 
   hour24Clock: boolean;
   dateFormatString: string;
+  showAllTimestamps: boolean;
 
   developerTools: boolean;
   enableMSC4268CMD: boolean;
@@ -377,6 +378,7 @@ export const defaultSettings: Settings = {
 
   hour24Clock: false,
   dateFormatString: 'D MMM YYYY',
+  showAllTimestamps: false,
 
   developerTools: false,
   settingsSyncEnabled: false,


### PR DESCRIPTION
### Description

By default, Sable only shows a timestamp on the first message in a group of consecutive messages from the same sender. This adds a `showAllTimestamps` setting (default: off) that renders a timestamp on every message, even grouped/collapsed ones. The toggle is in Settings → General → Messages, below "Message Spacing".

When enabled, collapsed messages render a right-aligned timestamp in place of the empty header, without the username, avatar, or pronouns that appear on ungrouped messages. The layout direction respects the same Row/RowReverse logic as the full header (compact and right-aligned bubble layouts).

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### AI disclosure:

- [x] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The implementation was AI-assisted: adding the `showAllTimestamps` boolean to the `Settings` interface and defaults, reading it via `useSetting` in `Message.tsx` and conditionally rendering a timestamp-only header for collapsed messages, and adding the `SettingToggle` in `General.tsx`. I reviewed each change, verified the collapsed header layout matches the existing direction logic, and ran typecheck, lint, format, and tests in a containerized environment.