### PR TITLE
feat(message): add an option to hide the count on single-reaction chips

### DIFF
--- a/.changeset/hide-single-reaction-count.md
+++ b/.changeset/hide-single-reaction-count.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Adds an opt-in "Hide Single Reaction Counts" setting that removes the count numeral from reaction chips with only one participant. Useful when bot reactions clutter the timeline.

--- a/src/app/components/message/Reaction.css.ts
+++ b/src/app/components/message/Reaction.css.ts
@@ -53,6 +53,12 @@ export const Reaction = style([
   },
 ]);
 
+// Declared after Reaction so it wins the cascade tie and rebalances the
+// right-side padding that was sized for the trailing count numeral.
+export const ReactionNoCount = style({
+  padding: `${toRem(2)} ${config.space.S100} ${toRem(2)} ${config.space.S100}`,
+});
+
 export const ReactionText = style([
   DefaultReset,
   {

--- a/src/app/components/message/Reaction.test.tsx
+++ b/src/app/components/message/Reaction.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MatrixClient } from '$types/matrix-sdk';
+import { useSetting } from '$state/hooks/settings';
+import * as css from './Reaction.css';
+import { Reaction } from './Reaction';
+
+vi.mock(import('$state/settings'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  settingsAtom: {} as never,
+}));
+
+vi.mock('$state/hooks/settings', () => ({
+  useSetting: vi.fn<typeof useSetting>(),
+}));
+
+const defaultSettingValues: Record<string, unknown> = {
+  hideSingleReactionCount: false,
+};
+
+describe('Reaction', () => {
+  beforeEach(() => {
+    vi.mocked(useSetting).mockImplementation(((_atom: unknown, key: string) => {
+      return [defaultSettingValues[key], vi.fn<() => void>()] as never;
+    }) as never);
+  });
+
+  it('shows the count on single-reaction chips by default', () => {
+    render(<Reaction mx={{ roomId: '' } as unknown as MatrixClient} count={1} reaction="😀" />);
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveClass(css.Reaction);
+    expect(screen.getByRole('button')).not.toHaveClass(css.ReactionNoCount);
+  });
+
+  it('shows the count on multi-reaction chips by default', () => {
+    render(<Reaction mx={{ roomId: '' } as unknown as MatrixClient} count={3} reaction="😀" />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByRole('button')).not.toHaveClass(css.ReactionNoCount);
+  });
+
+  it('hides the count on single-reaction chips when the setting is enabled', () => {
+    vi.mocked(useSetting).mockImplementation(((_atom: unknown, key: string) => {
+      if (key === 'hideSingleReactionCount') {
+        return [true, vi.fn<() => void>()] as never;
+      }
+      return [defaultSettingValues[key], vi.fn<() => void>()] as never;
+    }) as never);
+
+    render(<Reaction mx={{ roomId: '' } as unknown as MatrixClient} count={1} reaction="😀" />);
+
+    expect(screen.getByText('😀')).toBeInTheDocument();
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveClass(css.ReactionNoCount);
+  });
+
+  it('keeps the count on multi-reaction chips when the setting is enabled', () => {
+    vi.mocked(useSetting).mockImplementation(((_atom: unknown, key: string) => {
+      if (key === 'hideSingleReactionCount') {
+        return [true, vi.fn<() => void>()] as never;
+      }
+      return [defaultSettingValues[key], vi.fn<() => void>()] as never;
+    }) as never);
+
+    render(<Reaction mx={{ roomId: '' } as unknown as MatrixClient} count={2} reaction="😀" />);
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByRole('button')).not.toHaveClass(css.ReactionNoCount);
+  });
+});

--- a/src/app/components/message/Reaction.tsx
+++ b/src/app/components/message/Reaction.tsx
@@ -10,6 +10,8 @@ import { useAtomValue } from 'jotai';
 import { Image as MediaImage } from '$components/media';
 import { useRenderableMediaUrl } from '$hooks/useRenderableMediaUrl';
 import { nicknamesAtom } from '$state/nicknames';
+import { settingsAtom } from '$state/settings';
+import { useSetting } from '$state/hooks/settings';
 import * as css from './Reaction.css';
 
 export const Reaction = as<
@@ -22,6 +24,8 @@ export const Reaction = as<
   }
 >(({ className, mx, count, reaction, useAuthentication, ...props }, ref) => {
   const [imgError, setImgError] = useState(false);
+  const [hideSingleReactionCount] = useSetting(settingsAtom, 'hideSingleReactionCount');
+  const showCount = !hideSingleReactionCount || count > 1;
   const rawReactionUrl = reaction.startsWith('mxc://')
     ? (mxcUrlToHttp(mx, reaction, useAuthentication) ?? undefined)
     : undefined;
@@ -30,7 +34,7 @@ export const Reaction = as<
   return (
     <Box
       as="button"
-      className={classNames(css.Reaction, className)}
+      className={classNames(css.Reaction, !showCount && css.ReactionNoCount, className)}
       alignItems="Center"
       shrink="No"
       gap="200"
@@ -64,9 +68,11 @@ export const Reaction = as<
           </Text>
         )}
       </Text>
-      <Text as="span" size="T300">
-        {count}
-      </Text>
+      {showCount && (
+        <Text as="span" size="T300">
+          {count}
+        </Text>
+      )}
     </Box>
   );
 });

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -819,6 +819,10 @@ function Messages() {
     settingsAtom,
     'hideMembershipInReadOnly'
   );
+  const [hideSingleReactionCount, setHideSingleReactionCount] = useSetting(
+    settingsAtom,
+    'hideSingleReactionCount'
+  );
 
   const [messageLayout] = useSetting(settingsAtom, 'messageLayout');
   const [rightBubbles, setRightBubbles] = useSetting(settingsAtom, 'useRightBubbles');
@@ -887,6 +891,13 @@ function Messages() {
         description="Hide membership changes, reactions, and reaction redactions in read-only rooms such as announcement channels."
         value={hideMembershipInReadOnly}
         onChange={setHideMembershipInReadOnly}
+      />
+      <SettingToggle
+        title="Hide Single Reaction Counts"
+        focusId="hide-single-reaction-count"
+        description="Hide the count numeral on reactions with only one participant."
+        value={hideSingleReactionCount}
+        onChange={setHideSingleReactionCount}
       />
       <SettingToggle
         title="Show Hidden Events"

--- a/src/app/features/settings/settingsLink.ts
+++ b/src/app/features/settings/settingsLink.ts
@@ -41,6 +41,7 @@ export const settingsLinkFocusIdsBySection: Record<SettingsSectionId, readonly s
     'hide-member-events-read-only-rooms',
     'hide-membership-change',
     'hide-profile-change',
+    'hide-single-reaction-count',
     'hide-read-receipts',
     'hide-typing-indicators',
     'large-room-call-button',

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -138,6 +138,7 @@ export interface Settings {
   alwaysInlineEditor: boolean;
   messageLayout: MessageLayout;
   messageSpacing: MessageSpacing;
+  hideSingleReactionCount: boolean;
   hideMembershipEvents: boolean;
   hideNickAvatarEvents: boolean;
   showHiddenEvents: boolean;
@@ -328,6 +329,7 @@ export const defaultSettings: Settings = {
   alwaysInlineEditor: false,
   messageLayout: 0,
   messageSpacing: '400',
+  hideSingleReactionCount: false,
   hideMembershipEvents: false,
   hideNickAvatarEvents: true,
   mediaAutoLoad: true,


### PR DESCRIPTION
### Description

Adds an opt-in setting, **Hide Single Reaction Counts** (Settings -> General -> Messages, default off), that hides the count numeral on reaction chips where only one user reacted - the single glyph already conveys who reacted, and single-digit aggregates mostly come from bots re-paginating. If requested, more precise functionality (only removing the number when a bot reacts to its own message) can be included instead.

When the count is hidden, the chip's padding is rebalanced (`ReactionNoCount` modifier) so no blank space remains where the numeral used to sit; chips with plural counts are pixel-identical to before.

Purely cosmetic, and off by default.

Tested on the desktop app, Ubuntu 24.04.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - `.changeset`
- [X] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [X] Fully AI generated (explain what all the generated code does in moderate detail).

I designed and directed the feature and tested it in the GUI; the code itself was AI-generated.

Conditionally unmounts the count `<Text>` when there is exactly one reaction (depending on the setting `hideSingleReactionCount`). `Reaction.css.ts` adds the padding modifier declared after the base style. The setting follows the standard boolean pattern in `settings.ts`, gets a `SettingToggle` in the Messages section of `General.tsx`, and is registered in `settingsLink.ts` focus-ID map. Tests cover both default states and the enabled state asserting the modifier class lands on the chip.