### PR TITLE
fix: improve legacy image pack compatibility

### DIFF
--- a/.changeset/merge-legacy-image-pack-rooms.md
+++ b/.changeset/merge-legacy-image-pack-rooms.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Merge image-pack updates from legacy clients and mirror edits or deletions to active legacy pack state keys.

--- a/src/app/components/image-pack-view/RoomImagePack.tsx
+++ b/src/app/components/image-pack-view/RoomImagePack.tsx
@@ -3,14 +3,13 @@ import type { Room } from '$types/matrix-sdk';
 import { usePowerLevels } from '$hooks/usePowerLevels';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import type { PackContent } from '$plugins/custom-emoji';
-import { ImagePack } from '$plugins/custom-emoji';
+import { getImagePackStateEventTypes, ImagePack } from '$plugins/custom-emoji';
 
 import { useRoomImagePack } from '$hooks/useImagePacks';
 import { randomStr } from '$utils/common';
 import { useRoomPermissions } from '$hooks/useRoomPermissions';
 import { useRoomCreators } from '$hooks/useRoomCreators';
 import { ImagePackContent } from './ImagePackContent';
-import { CustomStateEvent } from '$types/matrix/room';
 
 type RoomImagePackProps = {
   room: Room;
@@ -22,9 +21,6 @@ export function RoomImagePack({ room, stateKey }: RoomImagePackProps) {
   const userId = mx.getUserId()!;
   const powerLevels = usePowerLevels(room);
   const creators = useRoomCreators(room);
-
-  const permissions = useRoomPermissions(creators, powerLevels);
-  const canEditImagePack = permissions.stateEvent(CustomStateEvent.ImagePack, userId);
 
   const fallbackPack = useMemo(() => {
     const fakePackId = randomStr(4);
@@ -39,19 +35,23 @@ export function RoomImagePack({ room, stateKey }: RoomImagePackProps) {
   }, [room.roomId, stateKey]);
   const imagePack = useRoomImagePack(room, stateKey) ?? fallbackPack;
 
+  const permissions = useRoomPermissions(creators, powerLevels);
+  const canEditImagePack = getImagePackStateEventTypes(room, stateKey).every((eventType) =>
+    permissions.stateEvent(eventType, userId)
+  );
+
   const handleUpdate = useCallback(
     async (packContent: PackContent) => {
       const { address } = imagePack;
       if (!address) return;
 
-      await mx.sendStateEvent(
-        address.roomId,
-        CustomStateEvent.ImagePack,
-        packContent,
-        address.stateKey
+      await Promise.all(
+        getImagePackStateEventTypes(room, address.stateKey).map((eventType) =>
+          mx.sendStateEvent(address.roomId, eventType, packContent, address.stateKey)
+        )
       );
     },
-    [mx, imagePack]
+    [mx, imagePack, room]
   );
 
   return (

--- a/src/app/features/common-settings/emojis-stickers/RoomPacks.tsx
+++ b/src/app/features/common-settings/emojis-stickers/RoomPacks.tsx
@@ -17,7 +17,7 @@ import { composerIcon, menuIcon, Plus, Sticker, X } from '$components/icons/phos
 import type { MatrixError } from '$types/matrix-sdk';
 import { SequenceCard, SequenceCardStyle } from '$components/sequence-card';
 import type { ImagePack, PackAddress, PackContent } from '$plugins/custom-emoji';
-import { ImageUsage, packAddressEqual } from '$plugins/custom-emoji';
+import { getImagePackStateEventTypes, ImageUsage, packAddressEqual } from '$plugins/custom-emoji';
 import { useRoom } from '$hooks/useRoom';
 import { useRoomImagePacks } from '$hooks/useImagePacks';
 import { LineClamp2 } from '$styles/Text.css';
@@ -152,7 +152,7 @@ export function RoomPacks({ onViewPack }: Readonly<RoomPacksProps>) {
   const creators = useRoomCreators(room);
 
   const permissions = useRoomPermissions(creators, powerLevels);
-  const canEdit = permissions.stateEvent(CustomStateEvent.ImagePack, mx.getSafeUserId());
+  const canCreate = permissions.stateEvent(CustomStateEvent.ImagePack, mx.getSafeUserId());
 
   const unfilteredPacks = useRoomImagePacks(room);
   const packs = useMemo(() => unfilteredPacks.filter((pack) => !pack.deleted), [unfilteredPacks]);
@@ -162,12 +162,13 @@ export function RoomPacks({ onViewPack }: Readonly<RoomPacksProps>) {
 
   const [applyState, applyChanges] = useAsyncCallback(
     useCallback(async () => {
-      for (let i = 0; i < removedPacks.length; i += 1) {
-        const addr = removedPacks[i];
-        if (!addr) continue;
-        // oxlint-disable-next-line no-await-in-loop
-        await mx.sendStateEvent(room.roomId, CustomStateEvent.ImagePack, {}, addr.stateKey);
-      }
+      await Promise.all(
+        removedPacks.flatMap((addr) =>
+          getImagePackStateEventTypes(room, addr.stateKey).map((eventType) =>
+            mx.sendStateEvent(room.roomId, eventType, {}, addr.stateKey)
+          )
+        )
+      );
     }, [mx, room, removedPacks])
   );
   const applyingChanges = applyState.status === AsyncStatus.Loading;
@@ -195,6 +196,9 @@ export function RoomPacks({ onViewPack }: Readonly<RoomPacksProps>) {
     const avatarUrl = avatarMxc ? mxcUrlToHttp(mx, avatarMxc, useAuthentication) : undefined;
     const { address } = pack;
     if (!address) return null;
+    const canEdit = getImagePackStateEventTypes(room, address.stateKey).every((eventType) =>
+      permissions.stateEvent(eventType, mx.getSafeUserId())
+    );
     const removed = removedPacks.some((addr) => packAddressEqual(addr, address));
 
     return (
@@ -268,7 +272,7 @@ export function RoomPacks({ onViewPack }: Readonly<RoomPacksProps>) {
     <>
       <Box direction="Column" gap="100">
         <Text size="L400">Packs</Text>
-        {canEdit && <CreatePackTile roomId={room.roomId} packs={packs} />}
+        {canCreate && <CreatePackTile roomId={room.roomId} packs={packs} />}
         {packs.map(renderPack)}
         {packs.length === 0 && (
           <SequenceCard

--- a/src/app/plugins/custom-emoji/ImagePack.ts
+++ b/src/app/plugins/custom-emoji/ImagePack.ts
@@ -32,7 +32,7 @@ export class ImagePack {
     this.images = new PackImagesReader(content.images ?? {});
   }
 
-  static fromMatrixEvent(id: string, matrixEvent: MatrixEvent) {
+  static fromMatrixEvent(id: string, matrixEvent: MatrixEvent, legacyEvent?: MatrixEvent) {
     const roomId = matrixEvent.getRoomId();
     const stateKey = matrixEvent.getStateKey();
 
@@ -40,8 +40,16 @@ export class ImagePack {
       roomId && typeof stateKey === 'string' ? new PackAddress(roomId, stateKey) : undefined;
 
     const content = matrixEvent.getContent<PackContent>();
+    const legacyContent = legacyEvent?.getContent<PackContent>();
+    const mergedContent =
+      legacyContent && (content.pack !== undefined || content.images !== undefined)
+        ? {
+            pack: { ...legacyContent.pack, ...content.pack },
+            images: { ...legacyContent.images, ...content.images },
+          }
+        : content;
 
-    const imagePack: ImagePack = new ImagePack(id, content, address);
+    const imagePack: ImagePack = new ImagePack(id, mergedContent, address);
 
     return imagePack;
   }

--- a/src/app/plugins/custom-emoji/utils.test.ts
+++ b/src/app/plugins/custom-emoji/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MatrixEvent, Room } from '$types/matrix-sdk';
+import { CustomStateEvent } from '$types/matrix/room';
+import { getImagePackStateEventTypes, getRoomImagePacks } from './utils';
+
+type TestRoom = Room & { packEvents: Record<string, MatrixEvent[]> };
+
+vi.mock('$utils/room/hierarchy', () => ({
+  getAccountData: vi.fn<() => undefined>(),
+  getStateEvent: (room: TestRoom, type: string, stateKey: string) =>
+    room.packEvents[type]?.find((event) => event.getStateKey() === stateKey),
+  getStateEvents: (room: TestRoom, type: string) => room.packEvents[type] ?? [],
+}));
+
+const packEvent = (id: string, content: object): MatrixEvent =>
+  ({
+    getId: () => id,
+    getRoomId: () => '!packs:example.org',
+    getStateKey: () => 'pack',
+    getContent: () => content,
+  }) as MatrixEvent;
+
+describe('legacy image pack compatibility', () => {
+  it('merges legacy additions and keeps the legacy key updated', () => {
+    const room = {
+      roomId: '!packs:example.org',
+      packEvents: {
+        [CustomStateEvent.ImagePack]: [
+          packEvent('$stable', {
+            pack: { display_name: 'Stable name' },
+            images: { stable: { url: 'mxc://example.org/stable' } },
+          }),
+        ],
+        [CustomStateEvent.PoniesRoomEmotes]: [
+          packEvent('$legacy', {
+            images: { addedByLegacyClient: { url: 'mxc://example.org/legacy' } },
+          }),
+        ],
+      },
+    } as unknown as TestRoom;
+
+    const [pack] = getRoomImagePacks(room);
+    expect(Array.from(pack?.images.collection.keys() ?? [])).toEqual([
+      'addedByLegacyClient',
+      'stable',
+    ]);
+    expect(getImagePackStateEventTypes(room, 'pack')).toEqual([
+      CustomStateEvent.ImagePack,
+      CustomStateEvent.PoniesRoomEmotes,
+    ]);
+  });
+});

--- a/src/app/plugins/custom-emoji/utils.ts
+++ b/src/app/plugins/custom-emoji/utils.ts
@@ -3,7 +3,7 @@ import type { MatrixClient, MatrixEvent, Room } from '$types/matrix-sdk';
 import { getAccountData, getStateEvent, getStateEvents } from '$utils/room/hierarchy';
 
 import type { IImageInfo } from '$types/matrix/common';
-import type { ImageUsage } from './types';
+import type { ImageUsage, PackContent } from './types';
 import { ImagePack } from './ImagePack';
 import type { PackMetaReader } from './PackMetaReader';
 import type { PackAddress } from './PackAddress';
@@ -14,6 +14,20 @@ export function packAddressEqual(a1?: PackAddress, a2?: PackAddress): boolean {
   if (!a1 && !a2) return true;
   if (!a1 || !a2) return false;
   return a1.roomId === a2.roomId && a1.stateKey === a2.stateKey;
+}
+
+export function getImagePackStateEventTypes(
+  room: Room,
+  stateKey: string
+): Array<typeof CustomStateEvent.ImagePack | typeof CustomStateEvent.PoniesRoomEmotes> {
+  const legacyContent = getStateEvent(
+    room,
+    CustomStateEvent.PoniesRoomEmotes,
+    stateKey
+  )?.getContent<PackContent>();
+  return legacyContent && (legacyContent.pack !== undefined || legacyContent.images !== undefined)
+    ? [CustomStateEvent.ImagePack, CustomStateEvent.PoniesRoomEmotes]
+    : [CustomStateEvent.ImagePack];
 }
 
 export function imageUsageEqual(u1: ImageUsage[], u2: ImageUsage[]) {
@@ -29,40 +43,39 @@ export function packMetaEqual(a: PackMetaReader, b: PackMetaReader): boolean {
   );
 }
 
-function makeImagePacks(packEvents: MatrixEvent[]): ImagePack[] {
-  return packEvents.reduce<ImagePack[]>((imagePacks, packEvent) => {
-    const packId = packEvent.getId();
-    if (!packId) return imagePacks;
-    imagePacks.push(ImagePack.fromMatrixEvent(packId, packEvent));
-    return imagePacks;
-  }, []);
+function makeImagePacks(
+  stableEvents: MatrixEvent[],
+  legacyEvents: MatrixEvent[],
+  includeStateKey: (stateKey: string) => boolean = () => true
+): ImagePack[] {
+  const legacyByKey = new Map<string, MatrixEvent>();
+  const eventByKey = new Map<string, MatrixEvent>();
+  legacyEvents.concat(stableEvents).forEach((event) => {
+    const key = event.getStateKey();
+    if (typeof key !== 'string' || !includeStateKey(key)) return;
+    eventByKey.set(key, event);
+    if (legacyEvents.includes(event)) legacyByKey.set(key, event);
+  });
+
+  return Array.from(eventByKey, ([key, event]) => {
+    const id = event.getId();
+    if (!id) return undefined;
+    const legacyEvent = legacyByKey.get(key);
+    return ImagePack.fromMatrixEvent(id, event, legacyEvent === event ? undefined : legacyEvent);
+  }).filter((pack): pack is ImagePack => pack !== undefined);
 }
 
 export function getRoomImagePack(room: Room, stateKey: string): ImagePack | undefined {
-  const packEvent =
-    getStateEvent(room, CustomStateEvent.ImagePack, stateKey) ||
-    getStateEvent(room, CustomStateEvent.PoniesRoomEmotes, stateKey);
-  if (!packEvent) return undefined;
-  const packId = packEvent.getId();
-  if (!packId) return undefined;
-  return ImagePack.fromMatrixEvent(packId, packEvent);
+  const stable = getStateEvent(room, CustomStateEvent.ImagePack, stateKey);
+  const legacy = getStateEvent(room, CustomStateEvent.PoniesRoomEmotes, stateKey);
+  return makeImagePacks(stable ? [stable] : [], legacy ? [legacy] : [])[0];
 }
 
 export function getRoomImagePacks(room: Room): ImagePack[] {
-  const packEventsStable = getStateEvents(room, CustomStateEvent.ImagePack);
-  const packEventsUnstable = getStateEvents(room, CustomStateEvent.PoniesRoomEmotes);
-
-  const uniquePackEvents = new Map<string, MatrixEvent>();
-  packEventsUnstable.forEach((ev) => {
-    const key = ev.getStateKey();
-    if (typeof key === 'string') uniquePackEvents.set(key, ev);
-  });
-  packEventsStable.forEach((ev) => {
-    const key = ev.getStateKey();
-    if (typeof key === 'string') uniquePackEvents.set(key, ev);
-  });
-
-  return makeImagePacks(Array.from(uniquePackEvents.values()));
+  return makeImagePacks(
+    getStateEvents(room, CustomStateEvent.ImagePack),
+    getStateEvents(room, CustomStateEvent.PoniesRoomEmotes)
+  );
 }
 
 export function getGlobalImagePacks(mx: MatrixClient): ImagePack[] {
@@ -83,24 +96,11 @@ export function getGlobalImagePacks(mx: MatrixClient): ImagePack[] {
     if (!room) return [];
     const packStateKeyToUnknown = roomIdToPackInfo[roomId];
 
-    const packEventsStable = getStateEvents(room, CustomStateEvent.ImagePack);
-    const packEventsUnstable = getStateEvents(room, CustomStateEvent.PoniesRoomEmotes);
-
-    const uniquePackEvents = new Map<string, MatrixEvent>();
-    packEventsUnstable.forEach((ev) => {
-      const key = ev.getStateKey();
-      if (typeof key === 'string' && !!packStateKeyToUnknown[key]) {
-        uniquePackEvents.set(key, ev);
-      }
-    });
-    packEventsStable.forEach((ev) => {
-      const key = ev.getStateKey();
-      if (typeof key === 'string' && !!packStateKeyToUnknown[key]) {
-        uniquePackEvents.set(key, ev);
-      }
-    });
-
-    return makeImagePacks(Array.from(uniquePackEvents.values()));
+    return makeImagePacks(
+      getStateEvents(room, CustomStateEvent.ImagePack),
+      getStateEvents(room, CustomStateEvent.PoniesRoomEmotes),
+      (stateKey) => !!packStateKeyToUnknown[stateKey]
+    );
   });
 
   return packs;


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When modifying image packs created with the legacy unstable keys, ensures they are still updated and continually reads legacy keys for updates from other clients.

New packs should use the stable key only and are unaffected.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
