### PR TITLE
fix(flatpak): restore refs/remotes dropped by zip artifacts

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1008,6 +1008,9 @@ jobs:
             repos=(arch-repos/*/)
           fi
           for src in "${repos[@]}"; do
+            # Zip artifacts drop empty directories; ostree needs refs/remotes
+            # to exist when listing the source repo's refs.
+            mkdir -p "$src/refs/remotes"
             echo "Pulling $src"
             ostree --repo=site/repo pull-local "$src"
           done


### PR DESCRIPTION
Follow-up to #1983. The nightly Flatpak publish now fails one step later:

```
Pulling arch-repos/
error: Listing refs: opendir(refs/remotes): No such file or directory
```

**Cause:** workflow artifacts are zip-based and drop empty directories. The repo exported by `flatpak-builder` has an empty `refs/remotes/`, which vanishes in the upload/download round-trip. `ostree pull-local` lists the source repo's refs from both `refs/heads` and `refs/remotes`, so it fails on the pruned directory.

**Fix:** `mkdir -p "$src/refs/remotes"` before each `pull-local`.

**Verified locally** against the actual `flatpak-nightly-repo-x86_64` artifact from run 33168925183: reproduced the exact error, then confirmed the pull succeeds with the directory restored (380 metadata + 324 content objects imported; all three refs present in the assembled repo).