### PR TITLE
feat(cef): add env var to enable experimental cef views runtime

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime-cef"
 version = "0.1.0"
-source = "git+https://github.com/SableClient/tauri-runtime-cef?rev=69a6b8cac865f48bfaf324c21369a2bd101c1e94#69a6b8cac865f48bfaf324c21369a2bd101c1e94"
+source = "git+https://github.com/SableClient/tauri-runtime-cef?rev=eace83edf055acc17e811b2bc75d4b6eadf39670#eace83edf055acc17e811b2bc75d4b6eadf39670"
 dependencies = [
  "base64 0.22.1",
  "cef",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -132,7 +132,7 @@ webkit2gtk = { version = "2.0", optional = true, features = ["v2_34"] }
 # Fork of tauri's unreleased feat/cef branch, ported onto published crates.
 # https://github.com/SableClient/tauri-runtime-cef
 [target.'cfg(target_os = "linux")'.dependencies]
-tauri-runtime-cef = { git = "https://github.com/SableClient/tauri-runtime-cef", rev = "69a6b8cac865f48bfaf324c21369a2bd101c1e94", optional = true }
+tauri-runtime-cef = { git = "https://github.com/SableClient/tauri-runtime-cef", rev = "eace83edf055acc17e811b2bc75d4b6eadf39670", optional = true }
 cef = { version = "=150.2.1", optional = true }
 libloading = "0.9"
 zbus = "5"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,6 +33,14 @@ fn prompt_cef_permission(message: String, tx: std::sync::mpsc::Sender<bool>) {
     });
 }
 
+#[cfg(target_os = "linux")]
+fn is_cef_views() -> bool {
+    cfg!(feature = "cef")
+        && std::env::var_os("SABLE_CEF_VIEWS").is_some()
+        // Only supported on Wayland for now
+        && std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
 fn main() {
     // CEF (Chromium) runtime, Linux only. Must run before anything else — CEF
     // re-execs this binary for its subprocesses.
@@ -95,6 +103,11 @@ fn main() {
                     }
                 }
                 args
+            },
+            linux_windowing: if is_cef_views() {
+                tauri_runtime_cef::LinuxWindowing::Wayland
+            } else {
+                tauri_runtime_cef::LinuxWindowing::X11
             },
             ..Default::default()
         });
@@ -220,7 +233,10 @@ fn main() {
         // https://github.com/tauri-apps/tao/issues/1046
         // https://github.com/tauri-apps/tauri/issues/11856
         // https://github.com/tauri-apps/tauri/issues/14251
-        std::env::set_var("GDK_BACKEND", "x11");
+        // Dont' force X11 if explictly opted into CEF Views runtime
+        if !is_cef_views() {
+            std::env::set_var("GDK_BACKEND", "x11");
+        }
 
         // NVIDIA explicit sync is another upstream WebKitGTK/Wayland failure mode. Prefer this lower-cost workaround over WEBKIT_DISABLE_DMABUF_RENDERER=1, but don't stomp an explicit user override.
         // https://github.com/tauri-apps/tauri/issues/10702


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add env var to enable experimental support for wayland by using a CEF Browser View.
While not enabled, behavior under cef does not change.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
