### PR TITLE
fix: version shell url to prevent stale webview

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,10 @@ use tauri::Wry as BrowserEngine;
 
 pub const MAIN_WINDOW_LABEL: &str = "main";
 
+fn versioned_shell_url(version: impl std::fmt::Display) -> tauri::WebviewUrl {
+    tauri::WebviewUrl::App(format!("index.html?build={version}").into())
+}
+
 #[cfg(target_os = "android")]
 fn is_internal_navigation(url: &tauri::Url, dev: bool) -> bool {
     url.scheme() == "tauri"
@@ -147,11 +151,12 @@ pub fn show_or_create_main_window(app: &AppHandle<crate::BrowserEngine>) -> taur
     #[cfg(desktop)]
     let desktop_settings = desktop::tray::load_desktop_settings(app)?;
 
-    let builder =
-        tauri::WebviewWindowBuilder::new(app, MAIN_WINDOW_LABEL, tauri::WebviewUrl::default())
-            .disable_drag_drop_handler()
-            .use_https_scheme(true)
-            .background_color(tauri::window::Color(0x1A, 0x1C, 0x28, 0xFF));
+    // Version the shell URL so WebView cannot reuse an index.html from an older install.
+    let shell_url = versioned_shell_url(&app.package_info().version);
+    let builder = tauri::WebviewWindowBuilder::new(app, MAIN_WINDOW_LABEL, shell_url)
+        .disable_drag_drop_handler()
+        .use_https_scheme(true)
+        .background_color(tauri::window::Color(0x1A, 0x1C, 0x28, 0xFF));
 
     // Only android: intercept navigation to external URLs and open them in the system browser
     // Other platforms: might need other URI schemes, and on_navigation might get called on iframe urls
@@ -543,6 +548,18 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn shell_cache_key_uses_native_version() {
+        assert_eq!(
+            crate::versioned_shell_url("1.21.1-nightly.260829"),
+            tauri::WebviewUrl::App("index.html?build=1.21.1-nightly.260829".into())
+        );
+        assert_ne!(
+            crate::versioned_shell_url("1.20.1"),
+            crate::versioned_shell_url("1.21.1")
+        );
+    }
+
     #[cfg(target_os = "android")]
     #[test]
     fn javascript_navigation_stays_in_webview() {


### PR DESCRIPTION
<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

At some point in a recent update my webview was persistently using some old cached index.html for some reason, clearing the actual app cache is an easy fix but this should hopefully evade the problem for non-technical users. Ideally we also detect stale caches and evict them but too lazy for that atm

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!-- Write any explanation required here, but do not generate the explanation using AI!! You must prove you understand what the code in this PR does. -->
