### PR TITLE
fix(timeline): guard per-message-profile emote stripping against missing bodies

### DIFF
--- a/src/app/components/RenderMessageContent.test.tsx
+++ b/src/app/components/RenderMessageContent.test.tsx
@@ -222,4 +222,14 @@ describe('RenderMessageContent', () => {
 
     expect(screen.getByTestId('poll-event')).toBeInTheDocument();
   });
+
+  it('renders a per-message profile emote without a formatted body', () => {
+    renderMessageWithContent({
+      msgtype: MsgType.Emote,
+      body: 'Bob: waves',
+      'com.beeper.per_message_profile': { id: 'bob', displayname: 'Bob' },
+    });
+
+    expect(screen.getByText('waves')).toBeInTheDocument();
+  });
 });

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -449,8 +449,12 @@ function RenderMessageContentInternal({
     const strippedContent = pmp
       ? {
           ...content,
-          formatted_body: stripPerMessageProfileFormattedBody(content['formatted_body'] as string),
-          body: stripPerMessageProfilePlainBody(content['body'] as string),
+          ...(typeof content['formatted_body'] === 'string'
+            ? { formatted_body: stripPerMessageProfileFormattedBody(content['formatted_body']) }
+            : {}),
+          ...(typeof content['body'] === 'string'
+            ? { body: stripPerMessageProfilePlainBody(content['body']) }
+            : {}),
         }
       : content;
 

--- a/src/app/persona/projection.ts
+++ b/src/app/persona/projection.ts
@@ -123,6 +123,8 @@ export function stripPerMessageProfilePlainBody(formatted_body: string, profile?
   return formatted_body.replace(/^.*?: /, '');
 }
 
-export function stripPerMessageProfileFormattedBody(formatted_body: string): string {
-  return formatted_body.replace(/^<strong\s+data-mx-profile-fallback[^>]*>.*?<\/strong>/, '');
+export function stripPerMessageProfileFormattedBody(
+  formatted_body: string | undefined
+): string | undefined {
+  return formatted_body?.replace(/^<strong\s+data-mx-profile-fallback[^>]*>.*?<\/strong>/, '');
 }


### PR DESCRIPTION
Fixes SABLE-1T0

<!-- Please read https://github.com/SableClient/Sable/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### AI disclosure:

- [ ] Created without the usage of AI
- [ ] Partially AI assisted (clarify which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

<!--
Write any explanation required here, but do not generate the explanation using AI!! You MUST prove you understand what the code in this PR does.
You MUST explain what modifications you have made in order to ensure that the result is compatible with THE LICENSE
By deleting this section or comment, in code or in body, the PR should be rejected and closed.
-->
